### PR TITLE
Fix OpenAI strict tool schema for optional read arguments

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/AetherAgent.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AetherAgent.kt
@@ -1540,43 +1540,38 @@ class AetherAgent(
                 )
                 put(
                     "parameters",
-                    JSONObject().apply {
-                        put("type", "object")
-                        put(
-                            "properties",
-                            JSONObject().apply {
-                                put(
-                                    "command",
-                                    JSONObject().apply {
-                                        put("type", "string")
-                                        put("description", "The bash command or script to execute.")
-                                    }
-                                )
-                                put(
-                                    "working_directory",
-                                    JSONObject().apply {
-                                        put("type", "string")
-                                        put(
-                                            "description",
-                                            "Optional working directory inside Termux, for example ~/.aether/workspaces/<session-id>."
-                                        )
-                                    }
-                                )
-                                put(
-                                    "workingDirectory",
-                                    JSONObject().apply {
-                                        put("type", "string")
-                                        put(
-                                            "description",
-                                            "Alias of working_directory."
-                                        )
-                                    }
-                                )
-                            }
-                        )
-                        put("required", JSONArray().put("command"))
-                        put("additionalProperties", false)
-                    }
+                    buildStrictToolParameters(
+                        properties = JSONObject().apply {
+                            put(
+                                "command",
+                                JSONObject().apply {
+                                    put("type", "string")
+                                    put("description", "The bash command or script to execute.")
+                                }
+                            )
+                            put(
+                                "working_directory",
+                                JSONObject().apply {
+                                    put("type", "string")
+                                    put(
+                                        "description",
+                                        "Optional working directory inside Termux, for example ~/.aether/workspaces/<session-id>."
+                                    )
+                                }
+                            )
+                            put(
+                                "workingDirectory",
+                                JSONObject().apply {
+                                    put("type", "string")
+                                    put(
+                                        "description",
+                                        "Alias of working_directory."
+                                    )
+                                }
+                            )
+                        },
+                        required = listOf("command"),
+                    )
                 )
                 put("strict", true)
             }
@@ -1837,15 +1832,10 @@ class AetherAgent(
                 put("description", description)
                 put(
                     "parameters",
-                    JSONObject().apply {
-                        put("type", "object")
-                        put("properties", properties)
-                        put(
-                            "required",
-                            JSONArray().apply { required.forEach(::put) },
-                        )
-                        put("additionalProperties", false)
-                    }
+                    buildStrictToolParameters(
+                        properties = properties,
+                        required = required,
+                    )
                 )
                 put("strict", true)
             }
@@ -1929,6 +1919,62 @@ internal fun shouldReconnectLlmRequest(throwable: Throwable): Boolean {
     }
     return false
 }
+
+internal fun buildStrictToolParameters(
+    properties: JSONObject,
+    required: List<String>,
+): JSONObject {
+    val requiredSet = required.toSet()
+    val normalizedProperties = JSONObject()
+    val normalizedRequired = JSONArray()
+    val iterator = properties.keys()
+
+    while (iterator.hasNext()) {
+        val propertyName = iterator.next()
+        normalizedRequired.put(propertyName)
+        val propertySchema = JSONObject(properties.getJSONObject(propertyName).toString())
+        normalizedProperties.put(
+            propertyName,
+            if (propertyName in requiredSet) {
+                propertySchema
+            } else {
+                makeSchemaNullable(propertySchema)
+            },
+        )
+    }
+
+    return JSONObject().apply {
+        put("type", "object")
+        put("properties", normalizedProperties)
+        put("required", normalizedRequired)
+        put("additionalProperties", false)
+    }
+}
+
+private fun makeSchemaNullable(schema: JSONObject): JSONObject =
+    JSONObject(schema.toString()).apply {
+        when (val typeValue = opt("type")) {
+            is String -> {
+                if (typeValue != "null") {
+                    put("type", JSONArray().put(typeValue).put("null"))
+                }
+            }
+
+            is JSONArray -> {
+                var hasNull = false
+                for (index in 0 until typeValue.length()) {
+                    if (typeValue.optString(index) == "null") {
+                        hasNull = true
+                        break
+                    }
+                }
+                if (!hasNull) {
+                    typeValue.put("null")
+                }
+                put("type", typeValue)
+            }
+        }
+    }
 
 private fun resolveReconnectDelayMillis(
     throwable: Throwable,

--- a/app/src/test/java/com/zhousl/aether/data/ToolSchemaNormalizationTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ToolSchemaNormalizationTest.kt
@@ -1,0 +1,78 @@
+package com.zhousl.aether.data
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToolSchemaNormalizationTest {
+    @Test
+    fun strictToolParametersMakeOptionalFieldsRequiredAndNullable() {
+        val schema = buildStrictToolParameters(
+            properties = JSONObject().apply {
+                put("path", JSONObject().apply { put("type", "string") })
+                put("offset", JSONObject().apply { put("type", "integer") })
+                put("limit", JSONObject().apply { put("type", "integer") })
+            },
+            required = listOf("path"),
+        )
+
+        val requiredNames = schema.getJSONArray("required").toStringSet()
+        val properties = schema.getJSONObject("properties")
+
+        assertEquals(setOf("path", "offset", "limit"), requiredNames)
+        assertEquals("string", properties.getJSONObject("path").getString("type"))
+        assertEquals(setOf("integer", "null"), properties.getJSONObject("offset").getJSONArray("type").toStringSet())
+        assertEquals(setOf("integer", "null"), properties.getJSONObject("limit").getJSONArray("type").toStringSet())
+        assertFalse(schema.getBoolean("additionalProperties"))
+    }
+
+    @Test
+    fun strictToolParametersPreserveNestedSchemasWhenNullable() {
+        val itemSchema = JSONObject().apply {
+            put("type", "object")
+            put(
+                "properties",
+                JSONObject().apply {
+                    put("oldText", JSONObject().apply { put("type", "string") })
+                    put("newText", JSONObject().apply { put("type", "string") })
+                },
+            )
+            put("required", JSONArray().put("oldText").put("newText"))
+            put("additionalProperties", false)
+        }
+
+        val schema = buildStrictToolParameters(
+            properties = JSONObject().apply {
+                put(
+                    "edits",
+                    JSONObject().apply {
+                        put("type", "array")
+                        put("items", itemSchema)
+                    },
+                )
+            },
+            required = emptyList(),
+        )
+
+        val editsSchema = schema.getJSONObject("properties").getJSONObject("edits")
+
+        assertEquals(setOf("array", "null"), editsSchema.getJSONArray("type").toStringSet())
+        assertEquals(
+            setOf("oldText", "newText"),
+            editsSchema.getJSONObject("items").getJSONArray("required").toStringSet(),
+        )
+        assertTrue(
+            editsSchema.getJSONObject("items").getJSONObject("properties").has("oldText"),
+        )
+    }
+
+    private fun JSONArray.toStringSet(): Set<String> =
+        buildSet {
+            for (index in 0 until length()) {
+                add(getString(index))
+            }
+        }
+}


### PR DESCRIPTION
## Summary
- Normalize strict function schemas so every declared property is included in `required` for OpenAI format
- Mark optional fields as nullable instead of omitting them, which avoids the schema validation failure on `read.offset`
- Apply the same normalization to the bash tool schema and add unit coverage for strict schema generation

## Testing
- Added unit tests covering optional fields becoming required + nullable and nested array item schemas
- `testDebugUnitTest` passed locally
- `assembleDebug` passed locally