### PR TITLE
Add i18n support and refresh app theme

### DIFF
--- a/app/src/main/java/com/zhousl/aether/MainActivity.kt
+++ b/app/src/main/java/com/zhousl/aether/MainActivity.kt
@@ -8,13 +8,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
 import com.zhousl.aether.ui.AetherApp
-import com.zhousl.aether.ui.theme.AetherTheme
 
 class MainActivity : ComponentActivity() {
     private val notificationPermissionLauncher = registerForActivityResult(
@@ -26,14 +21,7 @@ class MainActivity : ComponentActivity() {
         maybeRequestNotificationPermission()
         enableEdgeToEdge()
         setContent {
-            AetherTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    AetherApp()
-                }
-            }
+            AetherApp()
         }
     }
 

--- a/app/src/main/java/com/zhousl/aether/data/AppSettings.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AppSettings.kt
@@ -2,6 +2,7 @@ package com.zhousl.aether.data
 
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.Locale
 import java.util.UUID
 
 enum class LlmProvider(
@@ -51,6 +52,39 @@ enum class AgentModeAuthorizationMethod(
     }
 }
 
+enum class AppLanguage(
+    val storageValue: String,
+    val languageTag: String,
+) {
+    English(
+        storageValue = "en",
+        languageTag = "en",
+    ),
+    SimplifiedChinese(
+        storageValue = "zh-CN",
+        languageTag = "zh-CN",
+    );
+
+    companion object {
+        fun fromStorage(
+            value: String?,
+            defaultValue: AppLanguage = defaultAppLanguage(),
+        ): AppLanguage = entries.firstOrNull { it.storageValue == value } ?: defaultValue
+    }
+}
+
+enum class AppThemeMode(
+    val storageValue: String,
+) {
+    Light("light"),
+    Dark("dark");
+
+    companion object {
+        fun fromStorage(value: String?): AppThemeMode =
+            entries.firstOrNull { it.storageValue == value } ?: Light
+    }
+}
+
 data class AppSettings(
     val provider: LlmProvider = LlmProvider.OpenAiCompatible,
     val apiKey: String = "",
@@ -63,6 +97,8 @@ data class AppSettings(
     val notifyOnTaskCompletion: Boolean = true,
     val agentModeAuthorizationEnabled: Boolean = false,
     val agentModeAuthorizationMethod: AgentModeAuthorizationMethod = AgentModeAuthorizationMethod.Shizuku,
+    val language: AppLanguage = defaultAppLanguage(),
+    val themeMode: AppThemeMode = AppThemeMode.Light,
     val onboardingSeenVersion: Int = 0,
     val onboardingCompletedVersion: Int = 0,
 )
@@ -72,6 +108,14 @@ const val DefaultLlmInactivityReconnectTimeoutSeconds = 360
 private const val MinLlmInactivityReconnectTimeoutSeconds = 30
 private const val MaxLlmInactivityReconnectTimeoutSeconds = 3600
 const val OnboardingStarterPrompt = "Hi"
+
+fun defaultAppLanguage(
+    locale: Locale = Locale.getDefault(),
+): AppLanguage = if (locale.language.equals("zh", ignoreCase = true)) {
+    AppLanguage.SimplifiedChinese
+} else {
+    AppLanguage.English
+}
 
 fun normalizeLlmInactivityReconnectTimeoutSeconds(
     value: Int?,

--- a/app/src/main/java/com/zhousl/aether/data/SettingsRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SettingsRepository.kt
@@ -32,6 +32,8 @@ class SettingsRepository(
                 preferences[AGENT_MODE_AUTHORIZATION_METHOD],
                 defaultValue = defaultAgentModeAuthorizationMethod(context),
             ),
+            language = AppLanguage.fromStorage(preferences[LANGUAGE]),
+            themeMode = AppThemeMode.fromStorage(preferences[THEME_MODE]),
             onboardingSeenVersion = preferences[ONBOARDING_SEEN_VERSION] ?: 0,
             onboardingCompletedVersion = preferences[ONBOARDING_COMPLETED_VERSION] ?: 0,
         )
@@ -116,6 +118,8 @@ class SettingsRepository(
             it[NOTIFY_ON_TASK_COMPLETION] = settings.notifyOnTaskCompletion
             it[AGENT_MODE_AUTHORIZATION_ENABLED] = settings.agentModeAuthorizationEnabled
             it[AGENT_MODE_AUTHORIZATION_METHOD] = settings.agentModeAuthorizationMethod.storageValue
+            it[LANGUAGE] = settings.language.storageValue
+            it[THEME_MODE] = settings.themeMode.storageValue
             it[ONBOARDING_SEEN_VERSION] = settings.onboardingSeenVersion
             it[ONBOARDING_COMPLETED_VERSION] = settings.onboardingCompletedVersion
             it[PROVIDER_CONFIGS] = serializeProviderConfigs(providerConfigs)
@@ -142,6 +146,14 @@ class SettingsRepository(
         context.dataStore.edit { it[TAVILY_API_KEY] = value }
     }
 
+    suspend fun updateLanguage(language: AppLanguage) {
+        context.dataStore.edit { it[LANGUAGE] = language.storageValue }
+    }
+
+    suspend fun updateThemeMode(themeMode: AppThemeMode) {
+        context.dataStore.edit { it[THEME_MODE] = themeMode.storageValue }
+    }
+
     suspend fun updateSettings(settings: AppSettings) {
         context.dataStore.edit {
             it[PROVIDER] = settings.provider.storageValue
@@ -158,6 +170,8 @@ class SettingsRepository(
             it[NOTIFY_ON_TASK_COMPLETION] = settings.notifyOnTaskCompletion
             it[AGENT_MODE_AUTHORIZATION_ENABLED] = settings.agentModeAuthorizationEnabled
             it[AGENT_MODE_AUTHORIZATION_METHOD] = settings.agentModeAuthorizationMethod.storageValue
+            it[LANGUAGE] = settings.language.storageValue
+            it[THEME_MODE] = settings.themeMode.storageValue
         }
     }
 
@@ -190,6 +204,8 @@ class SettingsRepository(
             booleanPreferencesKey("agent_mode_authorization_enabled")
         val AGENT_MODE_AUTHORIZATION_METHOD =
             stringPreferencesKey("agent_mode_authorization_method")
+        val LANGUAGE = stringPreferencesKey("language")
+        val THEME_MODE = stringPreferencesKey("theme_mode")
         val PROVIDER_CONFIGS = stringPreferencesKey("provider_configs")
         val ONBOARDING_SEEN_VERSION = intPreferencesKey("onboarding_seen_version")
         val ONBOARDING_COMPLETED_VERSION = intPreferencesKey("onboarding_completed_version")

--- a/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
@@ -66,6 +66,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
@@ -120,6 +121,7 @@ import java.io.File
 private data class SuggestionAction(
     val icon: ImageVector,
     val label: String,
+    val tint: Color,
 )
 
 private sealed interface PendingSaveTarget {
@@ -142,13 +144,37 @@ private fun AppScreen.depth(): Int = when (this) {
 fun AetherApp(
     viewModel: AetherViewModel = viewModel(),
 ) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val strings = remember(uiState.settings.language) { aetherStringsFor(uiState.settings.language) }
+
+    AetherLocalization(uiState.settings.language) {
+        AetherTheme(themeMode = uiState.settings.themeMode) {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background,
+            ) {
+                AetherAppContent(
+                    viewModel = viewModel,
+                    uiState = uiState,
+                    strings = strings,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AetherAppContent(
+    viewModel: AetherViewModel,
+    uiState: AetherUiState,
+    strings: AetherStrings,
+) {
     val drawerState = rememberDrawerState(initialValue = androidx.compose.material3.DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val clipboardManager = LocalClipboardManager.current
     val workspaceFileBridge = remember(context) { WorkspaceFileBridge(context) }
-    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val activeSession = uiState.sessions.firstOrNull { it.id == uiState.currentSessionId }
     val activeProviderConfig = uiState.providerConfigs.firstOrNull { it.isActive }
     val currentSessionExecution = uiState.sessionExecutionStates[uiState.currentSessionId]
@@ -251,7 +277,7 @@ fun AetherApp(
                 }
                 Toast.makeText(
                     context,
-                    if (didSave) "File saved" else "Couldn't save file",
+                    if (didSave) strings.fileSaved else strings.couldNotSaveFile,
                     Toast.LENGTH_SHORT,
                 ).show()
             }
@@ -295,7 +321,7 @@ fun AetherApp(
             viewModel.refreshTermuxSetup()
             Toast.makeText(
                 context,
-                if (granted) "Termux access granted" else "Termux access not granted",
+                if (granted) strings.termuxAccessGranted else strings.termuxAccessNotGranted,
                 Toast.LENGTH_SHORT,
             ).show()
         },
@@ -481,7 +507,7 @@ fun AetherApp(
                     },
                     onCopyMessage = { message ->
                         clipboardManager.setText(AnnotatedString(message.text))
-                        Toast.makeText(context, "Reply copied", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, strings.replyCopied, Toast.LENGTH_SHORT).show()
                     },
                     onRequestTermuxPermission = {
                         termuxPermissionLauncher.launch(TermuxContract.RunCommandPermission)
@@ -509,6 +535,8 @@ fun AetherApp(
                     notifyOnTaskCompletion = uiState.settings.notifyOnTaskCompletion,
                     agentModeAuthorizationEnabled = uiState.settings.agentModeAuthorizationEnabled,
                     agentModeAuthorizationMethod = uiState.settings.agentModeAuthorizationMethod,
+                    language = uiState.settings.language,
+                    themeMode = uiState.settings.themeMode,
                     agentModeDisplayState = uiState.agentModeDisplayState,
                     providerConfigs = uiState.providerConfigs,
                     termuxSetupState = uiState.termuxSetupState,
@@ -516,6 +544,8 @@ fun AetherApp(
                     mcpServers = uiState.mcpServers,
                     isFetchingModels = uiState.isFetchingModels,
                     onSave = viewModel::saveSettings,
+                    onUpdateLanguage = viewModel::updateAppLanguage,
+                    onUpdateThemeMode = viewModel::updateAppThemeMode,
                     onUpsertProviderConfig = viewModel::upsertProviderConfig,
                     onRemoveProviderConfig = viewModel::removeProviderConfig,
                     onSetActiveProvider = viewModel::setActiveProvider,
@@ -822,6 +852,7 @@ private fun ChatTopBar(
     onMenu: () -> Unit,
     onNewChat: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -830,21 +861,22 @@ private fun ChatTopBar(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        SurfaceIconButton(Icons.Rounded.Menu, "Menu", onMenu)
+        SurfaceIconButton(Icons.Rounded.Menu, strings.menu, onMenu)
         Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            SurfaceIconButton(Icons.Rounded.Create, "New chat", onNewChat)
-            SurfaceIconButton(Icons.Rounded.MoreHoriz, "More", {})
+            SurfaceIconButton(Icons.Rounded.Create, strings.newChat, onNewChat)
+            SurfaceIconButton(Icons.Rounded.MoreHoriz, strings.more, {})
         }
     }
 }
 
 @Composable
 private fun EmptyChatState() {
+    val strings = rememberAetherStrings()
     val actions = listOf(
-        SuggestionAction(Icons.Rounded.Image, "Create image"),
-        SuggestionAction(Icons.Rounded.Lightbulb, "Brainstorm"),
-        SuggestionAction(Icons.Rounded.Visibility, "Analyze images"),
-        SuggestionAction(Icons.Rounded.AutoAwesome, "More"),
+        SuggestionAction(Icons.Rounded.Image, strings.createImage, Color(0xFF22C55E)),
+        SuggestionAction(Icons.Rounded.Lightbulb, strings.brainstorm, Color(0xFFFACC15)),
+        SuggestionAction(Icons.Rounded.Visibility, strings.analyzeImages, AetherPrimary),
+        SuggestionAction(Icons.Rounded.AutoAwesome, strings.more, AetherPrimary),
     )
 
     Column(
@@ -855,7 +887,7 @@ private fun EmptyChatState() {
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = "What can I help with?",
+            text = strings.whatCanIHelpWith,
             style = MaterialTheme.typography.headlineMedium,
             color = AetherOnSurface,
         )
@@ -866,12 +898,12 @@ private fun EmptyChatState() {
         ) {
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 actions.take(2).forEach { action ->
-                    SuggestionChip(Modifier.weight(1f), action.icon, action.label)
+                    SuggestionChip(Modifier.weight(1f), action)
                 }
             }
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 actions.drop(2).forEach { action ->
-                    SuggestionChip(Modifier.weight(1f), action.icon, action.label)
+                    SuggestionChip(Modifier.weight(1f), action)
                 }
             }
         }
@@ -881,8 +913,7 @@ private fun EmptyChatState() {
 @Composable
 private fun SuggestionChip(
     modifier: Modifier = Modifier,
-    icon: ImageVector,
-    label: String,
+    action: SuggestionAction,
 ) {
     Row(
         modifier = modifier
@@ -893,16 +924,12 @@ private fun SuggestionChip(
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Icon(
-            imageVector = icon,
+            imageVector = action.icon,
             contentDescription = null,
-            tint = when (label) {
-                "Create image" -> Color(0xFF22C55E)
-                "Brainstorm" -> Color(0xFFFACC15)
-                else -> AetherPrimary
-            },
+            tint = action.tint,
         )
         Text(
-            text = label,
+            text = action.label,
             style = MaterialTheme.typography.labelLarge,
             color = AetherOnSurface,
         )
@@ -950,6 +977,7 @@ private fun MessageBubble(message: ChatMessage) {
 
 @Composable
 private fun TypingIndicator() {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -961,7 +989,7 @@ private fun TypingIndicator() {
             strokeWidth = 2.dp,
         )
         Text(
-            text = "Aether is thinking...",
+            text = strings.aetherIsThinking,
             style = MaterialTheme.typography.bodyMedium,
             color = AetherOnSurfaceVariant,
         )
@@ -976,6 +1004,7 @@ private fun ComposerBar(
     hasMessages: Boolean,
     isSending: Boolean,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -995,7 +1024,7 @@ private fun ComposerBar(
         ) {
             if (value.isEmpty()) {
                 Text(
-                    text = if (hasMessages) "Reply to Aether" else "Ask Aether",
+                    text = if (hasMessages) strings.replyToAether else strings.askAether,
                     color = AetherOnSurfaceVariant,
                     style = MaterialTheme.typography.bodyLarge,
                 )
@@ -1013,7 +1042,7 @@ private fun ComposerBar(
         IconButton(onClick = {}, enabled = !isSending) {
             Icon(
                 imageVector = Icons.Rounded.KeyboardVoice,
-                contentDescription = "Voice",
+                contentDescription = strings.voice,
                 tint = AetherOnSurfaceVariant,
             )
         }
@@ -1035,6 +1064,7 @@ private fun AppDrawer(
     onSessionSelected: (String) -> Unit,
     onSettingsSelected: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     ModalDrawerSheet(
         modifier = Modifier.width(312.dp),
         drawerContainerColor = AetherSurface,
@@ -1053,18 +1083,18 @@ private fun AppDrawer(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 SearchBarStub(modifier = Modifier.weight(1f))
-                SurfaceIconButton(Icons.Rounded.Create, "New chat", onNewChat)
+                SurfaceIconButton(Icons.Rounded.Create, strings.newChat, onNewChat)
             }
 
             Spacer(modifier = Modifier.height(14.dp))
-            DrawerPrimaryAction(Icons.Rounded.Create, "New chat", onNewChat)
-            DrawerPrimaryAction(Icons.Rounded.Image, "Images", {})
-            DrawerPrimaryAction(Icons.Rounded.GridView, "Apps", {})
-            DrawerPrimaryAction(Icons.Rounded.AutoAwesome, "GPTs", {})
+            DrawerPrimaryAction(Icons.Rounded.Create, strings.newChat, onNewChat)
+            DrawerPrimaryAction(Icons.Rounded.Image, strings.images, {})
+            DrawerPrimaryAction(Icons.Rounded.GridView, strings.apps, {})
+            DrawerPrimaryAction(Icons.Rounded.AutoAwesome, strings.gpts, {})
 
             Spacer(modifier = Modifier.height(18.dp))
             Text(
-                text = "Recent",
+                text = strings.recent,
                 style = MaterialTheme.typography.labelLarge,
                 color = AetherOnSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 8.dp),
@@ -1072,7 +1102,7 @@ private fun AppDrawer(
             Spacer(modifier = Modifier.height(10.dp))
             if (sessions.isEmpty()) {
                 Text(
-                    text = "No conversations yet.",
+                    text = strings.noConversationsYet,
                     style = MaterialTheme.typography.bodyMedium,
                     color = AetherOnSurfaceVariant,
                     modifier = Modifier
@@ -1096,7 +1126,7 @@ private fun AppDrawer(
 
             Spacer(modifier = Modifier.height(4.dp))
             Spacer(modifier = Modifier.height(12.dp))
-            DrawerPrimaryAction(Icons.Rounded.Settings, "Settings", onSettingsSelected)
+            DrawerPrimaryAction(Icons.Rounded.Settings, strings.settings, onSettingsSelected)
             Spacer(modifier = Modifier.height(8.dp))
         }
     }
@@ -1104,6 +1134,7 @@ private fun AppDrawer(
 
 @Composable
 private fun SearchBarStub(modifier: Modifier = Modifier) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(22.dp))
@@ -1118,7 +1149,7 @@ private fun SearchBarStub(modifier: Modifier = Modifier) {
             tint = AetherOnSurfaceVariant,
         )
         Text(
-            text = "Search",
+            text = strings.search,
             style = MaterialTheme.typography.bodyMedium,
             color = AetherOnSurfaceVariant,
         )
@@ -1155,6 +1186,7 @@ private fun SessionRow(
     selected: Boolean,
     onClick: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -1172,7 +1204,7 @@ private fun SessionRow(
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = session.preview.ifBlank { "Empty draft" },
+            text = session.preview.ifBlank { strings.emptyDraft },
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             maxLines = 1,
@@ -1194,7 +1226,7 @@ private fun SurfaceIconButton(
             .size(44.dp)
             .shadow(12.dp, CircleShape, ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(CircleShape)
-            .background(Color.White.copy(alpha = 0.88f))
+            .background(AetherSurface.copy(alpha = 0.88f))
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
@@ -1233,16 +1265,18 @@ private fun CircleAction(
 @Preview(showBackground = true, backgroundColor = 0xFF000000)
 @Composable
 private fun AetherAppPreview() {
-    AetherTheme {
-        ChatScreen(
-            messages = defaultPreviewMessages(),
-            inputValue = "",
-            onInputChanged = {},
-            onSend = {},
-            onMenu = {},
-            onNewChat = {},
-            isSending = false,
-        )
+    AetherLocalization(language = com.zhousl.aether.data.AppLanguage.English) {
+        AetherTheme {
+            ChatScreen(
+                messages = defaultPreviewMessages(),
+                inputValue = "",
+                onInputChanged = {},
+                onSend = {},
+                onMenu = {},
+                onNewChat = {},
+                isSending = false,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/zhousl/aether/ui/AetherStrings.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherStrings.kt
@@ -1,0 +1,665 @@
+package com.zhousl.aether.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.zhousl.aether.data.AppLanguage
+import com.zhousl.aether.data.AppThemeMode
+import org.json.JSONObject
+
+@Stable
+data class AetherStrings(
+    val appLanguage: AppLanguage,
+    val menu: String,
+    val newChat: String,
+    val more: String,
+    val whatCanIHelpWith: String,
+    val createImage: String,
+    val brainstorm: String,
+    val analyzeImages: String,
+    val aetherIsThinking: String,
+    val replyToAether: String,
+    val askAether: String,
+    val voice: String,
+    val images: String,
+    val apps: String,
+    val gpts: String,
+    val recent: String,
+    val noConversationsYet: String,
+    val settings: String,
+    val search: String,
+    val emptyDraft: String,
+    val fileSaved: String,
+    val couldNotSaveFile: String,
+    val replyCopied: String,
+    val termuxAccessGranted: String,
+    val termuxAccessNotGranted: String,
+    val generalSettings: String,
+    val language: String,
+    val languageDescription: String,
+    val theme: String,
+    val themeDescription: String,
+    val modelProviders: String,
+    val personalization: String,
+    val webTools: String,
+    val reliability: String,
+    val agentSkills: String,
+    val mcpServers: String,
+    val termux: String,
+    val agentMode: String,
+    val developerSettings: String,
+    val about: String,
+    val getStartedTour: String,
+    val generalSettingsHubHint: String,
+    val customInstructions: String,
+    val tavilyConfigured: String,
+    val tavilyNotConfigured: String,
+    val backgroundRunsOn: String,
+    val backgroundRunsOff: String,
+    val connected: String,
+    val setupRequired: String,
+    val agentModeSubtitle: String,
+    val getStartedTourSubtitle: String,
+    val developerSettingsSubtitle: String,
+    val lightThemeSubtitle: String,
+    val darkThemeSubtitle: String,
+    val close: String,
+    val skip: String,
+    val back: String,
+    val continueLabel: String,
+    val done: String,
+    val cancel: String,
+    val next: String,
+    val install: String,
+    val refresh: String,
+    val openSettings: String,
+    val openTermux: String,
+    val grantAccess: String,
+    val loadModels: String,
+    val startChat: String,
+    val send: String,
+    val sendFollowUp: String,
+    val hide: String,
+    val chat: String,
+    val rename: String,
+    val export: String,
+    val delete: String,
+    val copy: String,
+    val selectText: String,
+    val editMessage: String,
+    val retry: String,
+    val copyReply: String,
+    val redoReply: String,
+    val deleteReply: String,
+    val save: String,
+    val searchChats: String,
+    val noChatsMatch: String,
+    val newChatFallback: String,
+    val addAttachmentOrTool: String,
+    val photos: String,
+    val files: String,
+    val agentModeLabel: String,
+    val virtualDisplayPreview: String,
+    val displayLabel: String,
+    val standby: String,
+    val analyzeImageChip: String,
+    val codeChip: String,
+    val helpMeWriteChip: String,
+    val summarizeFileChip: String,
+    val finishSetupTitle: String,
+    val finishSetupSubtitle: String,
+    val resumeSetup: String,
+    val thinking: String,
+    val firstPromptReadyTitle: String,
+    val firstPromptReadySubtitle: String,
+    val editingEarlierMessageTitle: String,
+    val editingEarlierMessageSubtitle: String,
+    val steerCurrentRun: String,
+    val queueNextTurn: String,
+    val noOutput: String,
+    val contentTruncated: String,
+)
+
+private val LocalAetherStrings = staticCompositionLocalOf {
+    aetherStringsFor(AppLanguage.English)
+}
+
+@Composable
+fun AetherLocalization(
+    language: AppLanguage,
+    content: @Composable () -> Unit,
+) {
+    val strings = remember(language) { aetherStringsFor(language) }
+    CompositionLocalProvider(LocalAetherStrings provides strings, content = content)
+}
+
+@Composable
+fun rememberAetherStrings(): AetherStrings = LocalAetherStrings.current
+
+fun aetherStringsFor(language: AppLanguage): AetherStrings = when (language) {
+    AppLanguage.English -> AetherStrings(
+        appLanguage = AppLanguage.English,
+        menu = "Menu",
+        newChat = "New chat",
+        more = "More",
+        whatCanIHelpWith = "What can I help with?",
+        createImage = "Create image",
+        brainstorm = "Brainstorm",
+        analyzeImages = "Analyze images",
+        aetherIsThinking = "Aether is thinking...",
+        replyToAether = "Reply to Aether",
+        askAether = "Ask Aether",
+        voice = "Voice",
+        images = "Images",
+        apps = "Apps",
+        gpts = "GPTs",
+        recent = "Recent",
+        noConversationsYet = "No conversations yet.",
+        settings = "Settings",
+        search = "Search",
+        emptyDraft = "Empty draft",
+        fileSaved = "File saved",
+        couldNotSaveFile = "Couldn't save file",
+        replyCopied = "Reply copied",
+        termuxAccessGranted = "Termux access granted",
+        termuxAccessNotGranted = "Termux access not granted",
+        generalSettings = "General Settings",
+        language = "Language",
+        languageDescription = "Choose the app language.",
+        theme = "Theme",
+        themeDescription = "Choose the app appearance.",
+        modelProviders = "Model Providers",
+        personalization = "Personalization",
+        webTools = "Web Tools",
+        reliability = "Reliability",
+        agentSkills = "Agent Skills",
+        mcpServers = "MCP Servers",
+        termux = "Termux",
+        agentMode = "Agent Mode",
+        developerSettings = "Developer Settings",
+        about = "About",
+        getStartedTour = "Get Started Tour",
+        generalSettingsHubHint = "App language and appearance",
+        customInstructions = "Custom instructions",
+        tavilyConfigured = "Tavily search configured",
+        tavilyNotConfigured = "URL fetch ready, Tavily not configured",
+        backgroundRunsOn = "Background runs on",
+        backgroundRunsOff = "Background runs off",
+        connected = "Connected",
+        setupRequired = "Setup required",
+        agentModeSubtitle = "Authorization and virtual display",
+        getStartedTourSubtitle = "Replay the first-run landing and setup flow",
+        developerSettingsSubtitle = "Replay the follow-up onboarding flow",
+        lightThemeSubtitle = "Keep the current bright appearance.",
+        darkThemeSubtitle = "Use a darker interface across the app.",
+        close = "Close",
+        skip = "Skip",
+        back = "Back",
+        continueLabel = "Continue",
+        done = "Done",
+        cancel = "Cancel",
+        next = "Next",
+        install = "Install",
+        refresh = "Refresh",
+        openSettings = "Open settings",
+        openTermux = "Open Termux",
+        grantAccess = "Grant access",
+        loadModels = "Load models",
+        startChat = "Start chat",
+        send = "Send",
+        sendFollowUp = "Send follow-up",
+        hide = "Hide",
+        chat = "Chat",
+        rename = "Rename",
+        export = "Export",
+        delete = "Delete",
+        copy = "Copy",
+        selectText = "Select text",
+        editMessage = "Edit message",
+        retry = "Retry",
+        copyReply = "Copy reply",
+        redoReply = "Redo reply",
+        deleteReply = "Delete reply",
+        save = "Save",
+        searchChats = "Search chats",
+        noChatsMatch = "No chats match",
+        newChatFallback = "New chat",
+        addAttachmentOrTool = "Add attachment or tool",
+        photos = "Photos",
+        files = "Files",
+        agentModeLabel = "Agent Mode",
+        virtualDisplayPreview = "Virtual display preview will appear after the agent starts.",
+        displayLabel = "display",
+        standby = "standby",
+        analyzeImageChip = "Analyze image",
+        codeChip = "Code",
+        helpMeWriteChip = "Help me write",
+        summarizeFileChip = "Summarize file",
+        finishSetupTitle = "Finish setup",
+        finishSetupSubtitle = "Connect a model, then come back to chat.",
+        resumeSetup = "Resume setup",
+        thinking = "Thinking",
+        firstPromptReadyTitle = "First prompt ready",
+        firstPromptReadySubtitle = "Tap send to test Aether.",
+        editingEarlierMessageTitle = "Editing earlier message",
+        editingEarlierMessageSubtitle = "Sending will replace the replies that came after it.",
+        steerCurrentRun = "Steer current run",
+        queueNextTurn = "Queue next turn",
+        noOutput = "No output",
+        contentTruncated = "Content truncated for readability.",
+    )
+
+    AppLanguage.SimplifiedChinese -> AetherStrings(
+        appLanguage = AppLanguage.SimplifiedChinese,
+        menu = "菜单",
+        newChat = "新建对话",
+        more = "更多",
+        whatCanIHelpWith = "想让我帮你做什么？",
+        createImage = "生成图片",
+        brainstorm = "头脑风暴",
+        analyzeImages = "分析图片",
+        aetherIsThinking = "Aether 正在思考...",
+        replyToAether = "回复 Aether",
+        askAether = "询问 Aether",
+        voice = "语音",
+        images = "图片",
+        apps = "应用",
+        gpts = "GPTs",
+        recent = "最近",
+        noConversationsYet = "还没有对话。",
+        settings = "设置",
+        search = "搜索",
+        emptyDraft = "空白草稿",
+        fileSaved = "文件已保存",
+        couldNotSaveFile = "无法保存文件",
+        replyCopied = "回复已复制",
+        termuxAccessGranted = "已授予 Termux 访问权限",
+        termuxAccessNotGranted = "未授予 Termux 访问权限",
+        generalSettings = "通用设置",
+        language = "语言",
+        languageDescription = "选择应用界面语言。",
+        theme = "主题",
+        themeDescription = "选择应用界面外观。",
+        modelProviders = "模型提供方",
+        personalization = "个性化",
+        webTools = "网页工具",
+        reliability = "可靠性",
+        agentSkills = "Agent 技能",
+        mcpServers = "MCP 服务器",
+        termux = "Termux",
+        agentMode = "Agent 模式",
+        developerSettings = "开发者设置",
+        about = "关于",
+        getStartedTour = "新手引导",
+        generalSettingsHubHint = "应用语言与外观",
+        customInstructions = "自定义指令",
+        tavilyConfigured = "已配置 Tavily 搜索",
+        tavilyNotConfigured = "URL 抓取可用，Tavily 未配置",
+        backgroundRunsOn = "后台运行已开启",
+        backgroundRunsOff = "后台运行已关闭",
+        connected = "已连接",
+        setupRequired = "需要设置",
+        agentModeSubtitle = "授权与虚拟显示",
+        getStartedTourSubtitle = "重新播放首次启动和设置流程",
+        developerSettingsSubtitle = "重新播放后续引导流程",
+        lightThemeSubtitle = "保持当前明亮外观。",
+        darkThemeSubtitle = "在整个应用中使用深色界面。",
+        close = "关闭",
+        skip = "跳过",
+        back = "返回",
+        continueLabel = "继续",
+        done = "完成",
+        cancel = "取消",
+        next = "下一步",
+        install = "安装",
+        refresh = "刷新",
+        openSettings = "打开设置",
+        openTermux = "打开 Termux",
+        grantAccess = "授予权限",
+        loadModels = "加载模型",
+        startChat = "开始聊天",
+        send = "发送",
+        sendFollowUp = "发送跟进",
+        hide = "隐藏",
+        chat = "聊天",
+        rename = "重命名",
+        export = "导出",
+        delete = "删除",
+        copy = "复制",
+        selectText = "选择文本",
+        editMessage = "编辑消息",
+        retry = "重试",
+        copyReply = "复制回复",
+        redoReply = "重新执行回复",
+        deleteReply = "删除回复",
+        save = "保存",
+        searchChats = "搜索对话",
+        noChatsMatch = "没有匹配的对话",
+        newChatFallback = "新建对话",
+        addAttachmentOrTool = "添加附件或工具",
+        photos = "照片",
+        files = "文件",
+        agentModeLabel = "Agent 模式",
+        virtualDisplayPreview = "代理启动后会显示虚拟屏幕预览。",
+        displayLabel = "显示",
+        standby = "待机",
+        analyzeImageChip = "分析图片",
+        codeChip = "代码",
+        helpMeWriteChip = "帮我写",
+        summarizeFileChip = "总结文件",
+        finishSetupTitle = "完成设置",
+        finishSetupSubtitle = "连接模型后再回到聊天。",
+        resumeSetup = "继续设置",
+        thinking = "思考中",
+        firstPromptReadyTitle = "首条消息已就绪",
+        firstPromptReadySubtitle = "点击发送来测试 Aether。",
+        editingEarlierMessageTitle = "正在编辑较早的消息",
+        editingEarlierMessageSubtitle = "发送后会替换它之后的回复。",
+        steerCurrentRun = "引导当前运行",
+        queueNextTurn = "排队下一轮",
+        noOutput = "无输出",
+        contentTruncated = "内容已截断，便于阅读。",
+    )
+}
+
+private val AetherStrings.isChinese: Boolean
+    get() = appLanguage == AppLanguage.SimplifiedChinese
+
+fun AetherStrings.languageDisplayName(language: AppLanguage): String = when (language) {
+    AppLanguage.English -> "English"
+    AppLanguage.SimplifiedChinese -> "简体中文"
+}
+
+fun AetherStrings.themeDisplayName(themeMode: AppThemeMode): String = when (themeMode) {
+    AppThemeMode.Light -> if (isChinese) "浅色" else "Light"
+    AppThemeMode.Dark -> if (isChinese) "深色" else "Dark"
+}
+
+fun AetherStrings.generalSettingsSummary(
+    language: AppLanguage,
+    themeMode: AppThemeMode,
+): String = "${languageDisplayName(language)} / ${themeDisplayName(themeMode)}"
+
+fun AetherStrings.reliabilitySummary(
+    reconnectAfterSeconds: Int,
+    keepTasksRunningInBackground: Boolean,
+): String {
+    val status = if (keepTasksRunningInBackground) backgroundRunsOn else backgroundRunsOff
+    return if (isChinese) {
+        "${reconnectAfterSeconds} 秒后重连 / $status"
+    } else {
+        "Reconnect after ${reconnectAfterSeconds}s / $status"
+    }
+}
+
+fun AetherStrings.skillCountSummary(skillCount: Int): String = when {
+    isChinese && skillCount == 0 -> "未安装技能"
+    isChinese -> "已安装 $skillCount 个"
+    skillCount == 0 -> "No skills installed"
+    else -> "$skillCount installed"
+}
+
+fun AetherStrings.serverCountSummary(serverCount: Int): String = when {
+    isChinese && serverCount == 0 -> "没有服务器"
+    isChinese -> "已配置 $serverCount 个"
+    serverCount == 0 -> "No servers"
+    else -> "$serverCount configured"
+}
+
+fun AetherStrings.noChatsMatchSummary(query: String): String = if (isChinese) {
+    "没有匹配的对话：“$query”"
+} else {
+    "No chats match \"$query\"."
+}
+
+fun AetherStrings.attachmentTypeLabel(isImage: Boolean): String = when {
+    isChinese && isImage -> "照片"
+    isChinese -> "文件"
+    isImage -> "Photo"
+    else -> "File"
+}
+
+fun AetherStrings.attachmentCountLabel(count: Int): String = when {
+    isChinese -> "$count 个附件"
+    count == 1 -> "1 attachment"
+    else -> "$count attachments"
+}
+
+fun AetherStrings.pendingInputModeLabel(isQueue: Boolean): String = when {
+    isChinese && isQueue -> "已排队"
+    isChinese -> "正在引导"
+    isQueue -> "Queued"
+    else -> "Steering"
+}
+
+fun AetherStrings.toolInvocationGroupTitle(count: Int, isRunning: Boolean): String = when {
+    isChinese && isRunning -> "正在执行 $count 个工具"
+    isChinese -> "已执行 $count 个工具"
+    isRunning -> "Executing $count tools"
+    else -> "Executed $count tools"
+}
+
+fun AetherStrings.toolInvocationTitleLabel(
+    toolName: String,
+    isRunning: Boolean,
+    arguments: JSONObject? = null,
+): String = when (toolName.lowercase()) {
+    "bash" -> statusLabel(isRunning, "Executing bash command", "Executed bash command", "正在执行 bash 命令", "已执行 bash 命令")
+    "fetch_bash_output" -> statusLabel(isRunning, "Fetching bash output", "Fetched bash output", "正在获取 bash 输出", "已获取 bash 输出")
+    "kill_bash" -> statusLabel(isRunning, "Stopping bash command", "Stopped bash command", "正在停止 bash 命令", "已停止 bash 命令")
+    "sleep" -> statusLabel(isRunning, "Waiting", "Waited", "正在等待", "已等待")
+    "read" -> statusLabel(isRunning, "Reading file", "Read file", "正在读取文件", "已读取文件")
+    "edit" -> statusLabel(isRunning, "Editing file", "Edited file", "正在编辑文件", "已编辑文件")
+    "write" -> statusLabel(isRunning, "Writing file", "Wrote file", "正在写入文件", "已写入文件")
+    "grep" -> statusLabel(isRunning, "Searching files", "Searched files", "正在搜索文件", "已搜索文件")
+    "find" -> statusLabel(isRunning, "Finding files", "Found files", "正在查找文件", "已找到文件")
+    "ls" -> statusLabel(isRunning, "Listing files", "Listed files", "正在列出文件", "已列出文件")
+    "analyze_image" -> statusLabel(isRunning, "Analyzing image", "Analyzed image", "正在分析图片", "已分析图片")
+    "tavily_search" -> formatArgumentDrivenTitle(
+        isRunning = isRunning,
+        progressiveVerb = if (isChinese) "正在搜索" else "Searching",
+        completedVerb = if (isChinese) "已搜索" else "Searched",
+        subject = arguments?.optString("query").orEmpty(),
+        fallback = if (isChinese) "Tavily 搜索" else "Tavily search",
+    )
+    "fetch_web_url" -> formatArgumentDrivenTitle(
+        isRunning = isRunning,
+        progressiveVerb = if (isChinese) "正在抓取" else "Fetching",
+        completedVerb = if (isChinese) "已抓取" else "Fetched",
+        subject = arguments?.optString("url").orEmpty(),
+        fallback = if (isChinese) "网页" else "web page",
+    )
+    "agent_display" -> formatAgentDisplayTitle(isRunning, arguments)
+    else -> if (isChinese) {
+        if (isRunning) "正在使用 $toolName" else "已使用 $toolName"
+    } else {
+        if (isRunning) "Using $toolName" else "Used $toolName"
+    }
+}
+
+fun AetherStrings.toolInvocationCommandLabel(toolName: String, arguments: JSONObject?): String {
+    if (arguments == null) return toolName
+    return when (toolName.lowercase()) {
+        "bash" -> arguments.optString("command").trim()
+        "fetch_bash_output" -> buildRunIdCommand("fetch", "获取", arguments)
+        "kill_bash" -> buildRunIdCommand("kill", "终止", arguments)
+        "sleep" -> {
+            val duration = arguments.optString("duration_ms").ifBlank { arguments.optString("durationMs") }.trim()
+            if (isChinese) "等待 ${duration}ms" else "sleep ${duration}ms"
+        }
+        "read" -> buildReadCommand(arguments)
+        "edit" -> buildEditCommand(arguments)
+        "write" -> buildPathCommand(arguments, "path", "write", "写入")
+        "grep" -> buildPatternCommand(arguments, "grep", "搜索")
+        "find" -> buildPatternCommand(arguments, "find", "查找")
+        "ls" -> buildPathCommand(arguments, "path", "ls", "列出")
+        "analyze_image" -> buildAnalyzeImageCommand(arguments)
+        "tavily_search" -> if (isChinese) {
+            "搜索 ${arguments.optString("query").trim()}".trim()
+        } else {
+            "search ${arguments.optString("query").trim()}".trim()
+        }
+        "fetch_web_url" -> if (isChinese) {
+            "抓取 ${arguments.optString("url").trim()}".trim()
+        } else {
+            "fetch ${arguments.optString("url").trim()}".trim()
+        }
+        "agent_display" -> summarizeAgentDisplayCommand(arguments)
+        else -> toolName
+    }.trim()
+}
+
+fun AetherStrings.formatArgumentDrivenTitle(
+    isRunning: Boolean,
+    progressiveVerb: String,
+    completedVerb: String,
+    subject: String,
+    fallback: String,
+): String {
+    val normalizedSubject = subject.trim()
+    val action = if (isRunning) progressiveVerb else completedVerb
+    if (normalizedSubject.isBlank()) return "$action $fallback"
+    val clipped = normalizedSubject.take(72)
+    return if (normalizedSubject.length > 72) "$action $clipped..." else "$action $clipped"
+}
+
+fun AetherStrings.formatAgentDisplayTitle(
+    isRunning: Boolean,
+    arguments: JSONObject?,
+): String {
+    return when (arguments?.optString("action").orEmpty().lowercase()) {
+        "start" -> statusLabel(isRunning, "Starting Agent Mode display", "Started Agent Mode display", "正在启动 Agent 模式显示", "已启动 Agent 模式显示")
+        "status" -> statusLabel(isRunning, "Checking Agent Mode display", "Checked Agent Mode display", "正在检查 Agent 模式显示", "已检查 Agent 模式显示")
+        "launch" -> formatArgumentDrivenTitle(
+            isRunning = isRunning,
+            progressiveVerb = if (isChinese) "正在打开" else "Launching",
+            completedVerb = if (isChinese) "已打开" else "Launched",
+            subject = arguments?.optString("target").orEmpty(),
+            fallback = if (isChinese) "Agent 模式中的应用" else "app in Agent Mode",
+        )
+        "tap" -> statusLabel(isRunning, "Tapping Agent Mode display", "Tapped Agent Mode display", "正在点击 Agent 模式屏幕", "已点击 Agent 模式屏幕")
+        "swipe" -> statusLabel(isRunning, "Swiping Agent Mode display", "Swiped Agent Mode display", "正在滑动 Agent 模式屏幕", "已滑动 Agent 模式屏幕")
+        "key" -> formatArgumentDrivenTitle(
+            isRunning = isRunning,
+            progressiveVerb = if (isChinese) "正在按下" else "Pressing",
+            completedVerb = if (isChinese) "已按下" else "Pressed",
+            subject = arguments?.optString("key").orEmpty(),
+            fallback = if (isChinese) "按键" else "key in Agent Mode",
+        )
+        "text" -> statusLabel(isRunning, "Typing in Agent Mode", "Typed in Agent Mode", "正在输入文本", "已输入文本")
+        "screenshot" -> statusLabel(isRunning, "Capturing Agent Mode display", "Captured Agent Mode display", "正在截取 Agent 模式显示", "已截取 Agent 模式显示")
+        "stop" -> statusLabel(isRunning, "Stopping Agent Mode display", "Stopped Agent Mode display", "正在停止 Agent 模式显示", "已停止 Agent 模式显示")
+        else -> statusLabel(isRunning, "Using Agent Mode display", "Used Agent Mode display", "正在使用 Agent 模式显示", "已使用 Agent 模式显示")
+    }
+}
+
+private fun AetherStrings.statusLabel(
+    isRunning: Boolean,
+    enProgress: String,
+    enDone: String,
+    zhProgress: String,
+    zhDone: String,
+): String = if (isChinese) {
+    if (isRunning) zhProgress else zhDone
+} else {
+    if (isRunning) enProgress else enDone
+}
+
+private fun AetherStrings.buildRunIdCommand(
+    enPrefix: String,
+    zhPrefix: String,
+    arguments: JSONObject,
+): String {
+    val runId = arguments.optString("run_id").ifBlank { arguments.optString("runId") }.trim()
+    return if (isChinese) "$zhPrefix $runId".trim() else "$enPrefix $runId".trim()
+}
+
+private fun AetherStrings.buildPathCommand(
+    arguments: JSONObject,
+    pathKey: String,
+    enPrefix: String,
+    zhPrefix: String,
+): String {
+    val path = arguments.optString(pathKey).trim()
+    return if (isChinese) "$zhPrefix $path".trim() else "$enPrefix $path".trim()
+}
+
+private fun AetherStrings.buildPatternCommand(
+    arguments: JSONObject,
+    enPrefix: String,
+    zhPrefix: String,
+): String {
+    val pattern = arguments.optString("pattern").trim()
+    val path = arguments.optString("path").trim()
+    return if (isChinese) {
+        "$zhPrefix $path 中的 $pattern".trim()
+    } else {
+        "$enPrefix $pattern in $path".trim()
+    }
+}
+
+private fun AetherStrings.buildReadCommand(arguments: JSONObject): String {
+    val path = arguments.optString("path").trim()
+    val offset = if (arguments.has("offset")) arguments.optInt("offset") else 0
+    val limit = if (arguments.has("limit")) arguments.optInt("limit") else null
+    return buildString {
+        append(if (isChinese) "读取 " else "read ")
+        append(path)
+        if (offset > 0 || limit != null) {
+            append(if (isChinese) " (" else " (")
+            if (isChinese) {
+                append("偏移=")
+            } else {
+                append("offset=")
+            }
+            append(offset)
+            if (limit != null) {
+                append(if (isChinese) ", 限制=" else ", limit=")
+                append(limit)
+            }
+            append(")")
+        }
+    }.trim()
+}
+
+private fun AetherStrings.buildEditCommand(arguments: JSONObject): String {
+    val path = arguments.optString("path").trim()
+    val editCount = arguments.optJSONArray("edits")?.length()
+        ?: if (arguments.has("oldText") || arguments.has("newText")) 1 else 0
+    return if (isChinese) {
+        if (editCount > 0) "编辑 $path（$editCount 处）" else "编辑 $path"
+    } else {
+        if (editCount > 0) "edit $path ($editCount edit${if (editCount == 1) "" else "s"})" else "edit $path"
+    }
+}
+
+private fun AetherStrings.buildAnalyzeImageCommand(arguments: JSONObject): String {
+    val path = arguments.optString("path").trim()
+    val prompt = arguments.optString("prompt").trim()
+    return buildString {
+        append(if (isChinese) "分析图片 " else "analyze_image ")
+        append(path)
+        if (prompt.isNotBlank()) {
+            append(if (isChinese) "（" else " (")
+            append(prompt.take(48))
+            if (prompt.length > 48) append("...")
+            append(if (isChinese) "）" else ")")
+        }
+    }.trim()
+}
+
+private fun AetherStrings.summarizeAgentDisplayCommand(arguments: JSONObject?): String {
+    if (arguments == null) return "agent_display"
+    val action = arguments.optString("action").trim().ifBlank { "unknown" }
+    val target = arguments.optString("target").trim()
+    return buildString {
+        append(if (isChinese) "agent_display " else "agent_display ")
+        append(action)
+        if (target.isNotBlank()) {
+            append(" ")
+            append(target)
+        }
+    }.trim()
+}

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -12,7 +12,9 @@ import com.zhousl.aether.data.AgentModeDisplayState
 import com.zhousl.aether.data.AgentModeAuthorizationMethod
 import com.zhousl.aether.data.AgentExtensionsRepository
 import com.zhousl.aether.data.AgentSkillManager
+import com.zhousl.aether.data.AppLanguage
 import com.zhousl.aether.data.AppSettings
+import com.zhousl.aether.data.AppThemeMode
 import com.zhousl.aether.data.AetherAgent
 import com.zhousl.aether.data.CurrentOnboardingVersion
 import com.zhousl.aether.data.InstalledSkill
@@ -1043,6 +1045,8 @@ class AetherViewModel(
         notifyOnTaskCompletion: Boolean,
         agentModeAuthorizationEnabled: Boolean,
         agentModeAuthorizationMethod: AgentModeAuthorizationMethod,
+        language: AppLanguage,
+        themeMode: AppThemeMode,
     ) {
         viewModelScope.launch {
             settingsRepository.updateSettings(
@@ -1061,12 +1065,26 @@ class AetherViewModel(
                     notifyOnTaskCompletion = notifyOnTaskCompletion,
                     agentModeAuthorizationEnabled = agentModeAuthorizationEnabled,
                     agentModeAuthorizationMethod = agentModeAuthorizationMethod,
+                    language = language,
+                    themeMode = themeMode,
                 )
             )
         }
     }
 
     // ── Multi-Provider methods ───────────────────────────────────────────────
+
+    fun updateAppLanguage(language: AppLanguage) {
+        viewModelScope.launch {
+            settingsRepository.updateLanguage(language)
+        }
+    }
+
+    fun updateAppThemeMode(themeMode: AppThemeMode) {
+        viewModelScope.launch {
+            settingsRepository.updateThemeMode(themeMode)
+        }
+    }
 
     fun upsertProviderConfig(config: LlmProviderConfig) {
         viewModelScope.launch {
@@ -2583,6 +2601,8 @@ class AetherViewModel(
         put("notifyOnTaskCompletion", notifyOnTaskCompletion)
         put("agentModeAuthorizationEnabled", agentModeAuthorizationEnabled)
         put("agentModeAuthorizationMethod", agentModeAuthorizationMethod.storageValue)
+        put("language", language.storageValue)
+        put("themeMode", themeMode.storageValue)
         put("onboardingSeenVersion", onboardingSeenVersion)
         put("onboardingCompletedVersion", onboardingCompletedVersion)
     }
@@ -2619,6 +2639,11 @@ class AetherViewModel(
                 json.optString("agentModeAuthorizationMethod"),
                 defaults.agentModeAuthorizationMethod,
             ),
+            language = AppLanguage.fromStorage(
+                json.optString("language"),
+                defaults.language,
+            ),
+            themeMode = AppThemeMode.fromStorage(json.optString("themeMode")),
             onboardingSeenVersion = json.optInt("onboardingSeenVersion", defaults.onboardingSeenVersion),
             onboardingCompletedVersion = json.optInt(
                 "onboardingCompletedVersion",

--- a/app/src/main/java/com/zhousl/aether/ui/ConversationMessages.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/ConversationMessages.kt
@@ -119,6 +119,7 @@ import com.zhousl.aether.ui.theme.AetherSecondary
 import com.zhousl.aether.ui.theme.AetherSurface
 import com.zhousl.aether.ui.theme.AetherSurfaceHigh
 import com.zhousl.aether.ui.theme.AetherTertiary
+import com.zhousl.aether.data.AppLanguage
 import com.zhousl.aether.termux.TermuxSetupIssue
 import com.zhousl.aether.termux.TermuxSetupState
 import kotlinx.coroutines.Dispatchers
@@ -194,7 +195,7 @@ fun SurfaceNotice(
             .fillMaxWidth()
             .shadow(12.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White.copy(alpha = 0.96f))
+            .background(AetherSurface.copy(alpha = 0.96f))
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -222,29 +223,32 @@ fun TermuxSetupNotice(
     onRefresh: () -> Unit,
 ) {
     if (setupState.isReady) return
+    val strings = rememberAetherStrings()
 
     val title: String
     val subtitle: String
 
     when (setupState.issue) {
         TermuxSetupIssue.NotInstalled -> {
-            title = "Install Termux to enable bash"
-            subtitle = "Aether uses Termux to run shell commands on-device."
+            title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "安装 Termux 以启用 bash" else "Install Termux to enable bash"
+            subtitle = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Aether 使用 Termux 在设备上运行 shell 命令。" else "Aether uses Termux to run shell commands on-device."
         }
 
         TermuxSetupIssue.PermissionMissing -> {
-            title = "Grant Termux command access"
-            subtitle = "Aether needs the \"Run commands in Termux environment\" permission."
+            title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "授予 Termux 命令访问权限" else "Grant Termux command access"
+            subtitle = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Aether 需要“在 Termux 环境中运行命令”的权限。" else "Aether needs the \"Run commands in Termux environment\" permission."
         }
 
         TermuxSetupIssue.ExternalAppsDisabled -> {
-            title = "Enable external apps in Termux"
-            subtitle = "Open Termux settings, or add allow-external-apps=true to ~/.termux/termux.properties."
+            title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "在 Termux 中启用外部应用" else "Enable external apps in Termux"
+            subtitle = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "打开 Termux 设置，或者在 ~/.termux/termux.properties 中添加 allow-external-apps=true。" else "Open Termux settings, or add allow-external-apps=true to ~/.termux/termux.properties."
         }
 
         TermuxSetupIssue.DispatchFailed -> {
-            title = "Finish Termux setup"
-            subtitle = setupState.detail.ifBlank { "Open Termux once and verify its integration settings." }
+            title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "完成 Termux 设置" else "Finish Termux setup"
+            subtitle = setupState.detail.ifBlank {
+                if (strings.appLanguage == AppLanguage.SimplifiedChinese) "打开一次 Termux，并确认其集成设置。" else "Open Termux once and verify its integration settings."
+            }
         }
 
         TermuxSetupIssue.Ready -> return
@@ -255,7 +259,7 @@ fun TermuxSetupNotice(
             .fillMaxWidth()
             .shadow(12.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White.copy(alpha = 0.96f))
+            .background(AetherSurface.copy(alpha = 0.96f))
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -277,13 +281,13 @@ fun TermuxSetupNotice(
                 TermuxSetupIssue.NotInstalled -> {
                     ActionIconLabel(
                         icon = Icons.AutoMirrored.Rounded.OpenInNew,
-                        label = "Install Termux",
+                        label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "安装 Termux" else "Install Termux",
                         enabled = true,
                         onClick = onInstallTermux,
                     )
                     ActionIconLabel(
                         icon = Icons.Rounded.Refresh,
-                        label = "Refresh",
+                        label = strings.refresh,
                         enabled = true,
                         onClick = onRefresh,
                     )
@@ -292,13 +296,13 @@ fun TermuxSetupNotice(
                 TermuxSetupIssue.PermissionMissing -> {
                     ActionIconLabel(
                         icon = Icons.Rounded.Settings,
-                        label = "Grant access",
+                        label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "授予访问权限" else "Grant access",
                         enabled = true,
                         onClick = onRequestPermission,
                     )
                     ActionIconLabel(
                         icon = Icons.AutoMirrored.Rounded.OpenInNew,
-                        label = "App settings",
+                        label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "应用设置" else "App settings",
                         enabled = true,
                         onClick = onOpenAppPermissions,
                     )
@@ -307,19 +311,19 @@ fun TermuxSetupNotice(
                 TermuxSetupIssue.ExternalAppsDisabled -> {
                     ActionIconLabel(
                         icon = Icons.Rounded.Settings,
-                        label = "Termux settings",
+                        label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Termux 设置" else "Termux settings",
                         enabled = true,
                         onClick = onOpenTermuxSettings,
                     )
                     ActionIconLabel(
                         icon = Icons.AutoMirrored.Rounded.OpenInNew,
-                        label = "Open Termux",
+                        label = strings.openTermux,
                         enabled = true,
                         onClick = onOpenTermux,
                     )
                     ActionIconLabel(
                         icon = Icons.Rounded.Refresh,
-                        label = "Refresh",
+                        label = strings.refresh,
                         enabled = true,
                         onClick = onRefresh,
                     )
@@ -328,19 +332,19 @@ fun TermuxSetupNotice(
                 TermuxSetupIssue.DispatchFailed -> {
                     ActionIconLabel(
                         icon = Icons.AutoMirrored.Rounded.OpenInNew,
-                        label = "Open Termux",
+                        label = strings.openTermux,
                         enabled = true,
                         onClick = onOpenTermux,
                     )
                     ActionIconLabel(
                         icon = Icons.Rounded.Settings,
-                        label = "Termux settings",
+                        label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Termux 设置" else "Termux settings",
                         enabled = true,
                         onClick = onOpenTermuxSettings,
                     )
                     ActionIconLabel(
                         icon = Icons.Rounded.Refresh,
-                        label = "Refresh",
+                        label = strings.refresh,
                         enabled = true,
                         onClick = onRefresh,
                     )
@@ -357,12 +361,13 @@ fun ComposerAttachmentTray(
     attachments: List<ChatAttachment>,
     onRemoveAttachment: (String) -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(10.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White.copy(alpha = 0.96f))
+            .background(AetherSurface.copy(alpha = 0.96f))
             .padding(10.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
@@ -456,6 +461,7 @@ private fun UserMessageActionDialog(
     onEdit: () -> Unit,
     onRetry: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     val menuVisibility = remember { MutableTransitionState(false) }
     menuVisibility.targetState = expanded
     if (!menuVisibility.currentState && !menuVisibility.targetState) return
@@ -513,22 +519,22 @@ private fun UserMessageActionDialog(
                 }
                 UserMessageActionRow(
                     icon = Icons.Rounded.ContentCopy,
-                    label = "Copy",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "复制" else "Copy",
                     onClick = onCopy,
                 )
                 UserMessageActionRow(
                     icon = Icons.Rounded.Description,
-                    label = "Select Text",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "选择文本" else "Select Text",
                     onClick = onSelectText,
                 )
                 UserMessageActionRow(
                     icon = Icons.Rounded.Edit,
-                    label = "Edit Message",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "编辑消息" else "Edit Message",
                     onClick = onEdit,
                 )
                 UserMessageActionRow(
                     icon = Icons.Rounded.Refresh,
-                    label = "Retry",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "重试" else "Retry",
                     onClick = onRetry,
                 )
             }
@@ -623,6 +629,7 @@ private fun SelectUserMessageTextDialog(
     text: String,
     onDismissRequest: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     if (!expanded) return
 
     Dialog(
@@ -640,7 +647,7 @@ private fun SelectUserMessageTextDialog(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = "Select Text",
+                text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "选择文本" else "Select Text",
                 style = MaterialTheme.typography.titleMedium,
                 color = AetherOnSurface,
             )
@@ -705,6 +712,7 @@ private fun AssistantMessageBlock(
     onRedo: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -714,7 +722,11 @@ private fun AssistantMessageBlock(
         }
         message.thoughtDurationMillis?.let { duration ->
             Text(
-                text = "Thought for ${formatThoughtDuration(duration)}",
+                text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) {
+                    "思考了 ${formatThoughtDuration(duration)}"
+                } else {
+                    "Thought for ${formatThoughtDuration(duration)}"
+                },
                 style = MaterialTheme.typography.bodySmall,
                 color = AetherOnSurfaceVariant,
             )
@@ -744,18 +756,18 @@ private fun AssistantMessageBlock(
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             AssistantMessageAction(
                 icon = LucideIcons.Copy,
-                contentDescription = "Copy reply",
+                contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "复制回复" else "Copy reply",
                 onClick = onCopy,
             )
             AssistantMessageAction(
                 icon = LucideIcons.RotateCcw,
-                contentDescription = "Redo reply",
+                contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "重新执行回复" else "Redo reply",
                 enabled = actionsEnabled,
                 onClick = onRedo,
             )
             AssistantMessageAction(
                 icon = LucideIcons.Trash2,
-                contentDescription = "Delete reply",
+                contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "删除回复" else "Delete reply",
                 enabled = actionsEnabled,
                 onClick = onDelete,
             )
@@ -768,6 +780,7 @@ private fun AgentModeReplayPanel(
     frames: List<AgentModeReplayFrame>,
     stateKey: String,
 ) {
+    val strings = rememberAetherStrings()
     var selectedIndex by rememberSaveable(stateKey, frames.size) {
         mutableStateOf((frames.size - 1).coerceAtLeast(0))
     }
@@ -786,7 +799,7 @@ private fun AgentModeReplayPanel(
             .fillMaxWidth()
             .shadow(12.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White)
+            .background(AetherSurface)
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
@@ -802,7 +815,7 @@ private fun AgentModeReplayPanel(
             if (bitmap != null) {
                 Image(
                     bitmap = bitmap.asImageBitmap(),
-                    contentDescription = "Agent Mode replay frame",
+                    contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Agent 模式回放帧" else "Agent Mode replay frame",
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(10.dp)
@@ -811,7 +824,7 @@ private fun AgentModeReplayPanel(
                 )
             } else {
                 Text(
-                    text = "Preview unavailable",
+                    text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "预览不可用" else "Preview unavailable",
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                 )
@@ -852,7 +865,7 @@ private fun AgentModeReplayToolStatus(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFFF6F7FB))
+            .background(AetherSurfaceHigh)
             .padding(horizontal = 14.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -884,7 +897,7 @@ private fun ReplayStepButton(
         modifier = Modifier
             .size(32.dp)
             .clip(CircleShape)
-            .background(if (enabled) Color(0xFFF0F3FA) else Color.Transparent)
+            .background(if (enabled) AetherSurfaceHigh else Color.Transparent)
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
@@ -905,6 +918,7 @@ fun ToolInvocationList(
     stateKey: String,
     autoExpand: Boolean = false,
 ) {
+    val strings = rememberAetherStrings()
     if (toolInvocations.isEmpty()) return
 
     if (toolInvocations.size < ToolInvocationCollapseThreshold) {
@@ -974,14 +988,14 @@ fun ToolInvocationList(
             ) {
                 if (isRunning) {
                     ShimmerStatusText(
-                        text = formatToolInvocationGroupTitle(toolInvocations.size, isRunning = true),
+                        text = strings.toolInvocationGroupTitle(toolInvocations.size, isRunning = true),
                         modifier = Modifier.weight(1f),
                         travelDurationMillis = 2600,
                         pauseDurationMillis = 1000,
                     )
                 } else {
                     Text(
-                        text = formatToolInvocationGroupTitle(toolInvocations.size, isRunning = false),
+                        text = strings.toolInvocationGroupTitle(toolInvocations.size, isRunning = false),
                         modifier = Modifier.weight(1f),
                         style = MaterialTheme.typography.bodyMedium,
                         color = AetherOnSurfaceVariant,
@@ -989,7 +1003,11 @@ fun ToolInvocationList(
                 }
                 Icon(
                     imageVector = Icons.AutoMirrored.Rounded.ArrowForwardIos,
-                    contentDescription = if (expanded) "Collapse tools" else "Expand tools",
+                    contentDescription = if (expanded) {
+                        if (strings.appLanguage == AppLanguage.SimplifiedChinese) "折叠工具" else "Collapse tools"
+                    } else {
+                        if (strings.appLanguage == AppLanguage.SimplifiedChinese) "展开工具" else "Expand tools"
+                    },
                     tint = AetherOnSurfaceVariant,
                     modifier = Modifier
                         .size(14.dp)
@@ -1296,7 +1314,8 @@ fun ToolInvocationCard(
     toolInvocation: ChatToolInvocation,
     topPadding: Dp = 6.dp,
 ) {
-    val detail = remember(toolInvocation) { formatToolInvocationDetail(toolInvocation) }
+    val strings = rememberAetherStrings()
+    val detail = remember(toolInvocation, strings.appLanguage) { formatToolInvocationDetail(strings, toolInvocation) }
     var expanded by rememberSaveable(toolInvocation.id) { mutableStateOf(false) }
     LaunchedEffect(
         toolInvocation.id,
@@ -1332,13 +1351,13 @@ fun ToolInvocationCard(
     ) {
         if (toolInvocation.isRunning) {
             ShimmerStatusText(
-                text = formatToolInvocationTitleLabel(toolInvocation),
+                text = strings.toolInvocationTitleLabel(toolInvocation.toolName, true, parseJsonObject(toolInvocation.argumentsJson)),
                 travelDurationMillis = 3200,
                 pauseDurationMillis = 1000,
             )
         } else {
             Text(
-                text = formatToolInvocationTitleLabel(toolInvocation),
+                text = strings.toolInvocationTitleLabel(toolInvocation.toolName, false, parseJsonObject(toolInvocation.argumentsJson)),
                 style = MaterialTheme.typography.bodyMedium,
                 color = AetherOnSurfaceVariant,
             )
@@ -1365,12 +1384,12 @@ fun ToolInvocationCard(
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 SyntaxHighlightedCodeBlock(
-                    label = "Command",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "命令" else "Command",
                     content = remember(detail.command) { highlightBashCommand(detail.command) },
                 )
                 detail.result?.let { result ->
                     SyntaxHighlightedCodeBlock(
-                        label = "Result",
+                        label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "结果" else "Result",
                         content = remember(result) { highlightToolResult(result) },
                     )
                 }
@@ -1441,6 +1460,7 @@ fun AttachmentPreviewDialog(
     onDismiss: () -> Unit,
     onSave: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -1451,7 +1471,7 @@ fun AttachmentPreviewDialog(
                 .padding(horizontal = 18.dp, vertical = 24.dp)
                 .shadow(24.dp, RoundedCornerShape(30.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
                 .clip(RoundedCornerShape(30.dp))
-                .background(Color.White.copy(alpha = 0.98f))
+            .background(AetherSurface.copy(alpha = 0.98f))
                 .padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
@@ -1482,14 +1502,14 @@ fun AttachmentPreviewDialog(
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
-                        text = formatAttachmentMetaLabel(attachment),
+                    text = formatAttachmentMetaLabel(strings, attachment),
                         style = MaterialTheme.typography.bodySmall,
                         color = AetherOnSurfaceVariant,
                     )
                 }
                 IconOnlyAction(
                     icon = Icons.Rounded.Close,
-                    contentDescription = "Close preview",
+                    contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "关闭预览" else "Close preview",
                     onClick = onDismiss,
                 )
             }
@@ -1502,7 +1522,7 @@ fun AttachmentPreviewDialog(
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 ActionIconLabel(
                     icon = Icons.Rounded.Download,
-                    label = "Save",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "保存" else "Save",
                     enabled = true,
                     onClick = onSave,
                 )
@@ -1546,6 +1566,7 @@ private fun AttachmentImagePreview(
 private fun AttachmentFilePreview(
     attachment: ChatAttachment,
 ) {
+    val strings = rememberAetherStrings()
     val preview = rememberAttachmentTextPreview(attachment)
 
     Column(
@@ -1558,7 +1579,7 @@ private fun AttachmentFilePreview(
     ) {
         if (preview == null) {
             Text(
-                text = "Preview unavailable for this file type.",
+                text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "此文件类型无法预览。" else "Preview unavailable for this file type.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = AetherOnSurfaceVariant,
             )
@@ -1579,7 +1600,7 @@ private fun AttachmentFilePreview(
             }
             if (preview.isTruncated) {
                 Text(
-                    text = "Preview truncated for readability.",
+                    text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "为了便于阅读，预览内容已截断。" else "Preview truncated for readability.",
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                 )
@@ -1599,7 +1620,7 @@ private fun UserImageAttachmentCard(
             .widthIn(max = 300.dp)
             .shadow(10.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White)
+            .background(AetherSurface)
             .clickable(onClick = onClick)
     ) {
         if (bitmap != null) {
@@ -1634,12 +1655,13 @@ private fun UserFileAttachmentCard(
     attachment: ChatAttachment,
     onClick: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier
             .widthIn(max = 300.dp)
             .shadow(10.dp, RoundedCornerShape(22.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(22.dp))
-            .background(Color.White)
+            .background(AetherSurface)
             .clickable(onClick = onClick)
             .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -1663,7 +1685,7 @@ private fun UserFileAttachmentCard(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = formatAttachmentMetaLabel(attachment),
+                    text = formatAttachmentMetaLabel(strings, attachment),
                 style = MaterialTheme.typography.bodySmall,
                 color = AetherOnSurfaceVariant,
                 maxLines = 1,
@@ -1684,6 +1706,7 @@ private fun ComposerImageAttachmentCard(
     attachment: ChatAttachment,
     onRemove: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     val bitmap = rememberAttachmentBitmap(attachment.uri, maxSize = 600)
     Row(
         modifier = Modifier
@@ -1698,7 +1721,7 @@ private fun ComposerImageAttachmentCard(
             modifier = Modifier
                 .size(62.dp)
                 .clip(RoundedCornerShape(16.dp))
-                .background(Color.White),
+            .background(AetherSurface),
             contentAlignment = Alignment.Center,
         ) {
             if (bitmap != null) {
@@ -1721,7 +1744,7 @@ private fun ComposerImageAttachmentCard(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = formatComposerAttachmentMetaLabel(attachment),
+                    text = formatComposerAttachmentMetaLabel(strings, attachment),
                 style = MaterialTheme.typography.bodySmall,
                 color = AetherOnSurfaceVariant,
             )
@@ -1739,6 +1762,7 @@ private fun ComposerFileAttachmentCard(
     attachment: ChatAttachment,
     onRemove: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -1752,7 +1776,7 @@ private fun ComposerFileAttachmentCard(
             modifier = Modifier
                 .size(38.dp)
                 .clip(CircleShape)
-                .background(Color.White),
+            .background(AetherSurface),
             contentAlignment = Alignment.Center,
         ) {
             Icon(Icons.Rounded.AttachFile, contentDescription = null, tint = AetherOnSurface)
@@ -1766,7 +1790,7 @@ private fun ComposerFileAttachmentCard(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = formatComposerAttachmentMetaLabel(attachment),
+                    text = formatComposerAttachmentMetaLabel(strings, attachment),
                 style = MaterialTheme.typography.bodySmall,
                 color = AetherOnSurfaceVariant,
             )
@@ -1811,7 +1835,9 @@ private fun IconOnlyAction(
         modifier = Modifier
             .size(28.dp)
             .clip(CircleShape)
-            .background(if (enabled) Color.White.copy(alpha = 0.72f) else Color.White.copy(alpha = 0.35f))
+            .background(
+                if (enabled) AetherSurface.copy(alpha = 0.72f) else AetherSurface.copy(alpha = 0.35f)
+            )
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
@@ -2025,20 +2051,20 @@ private fun formatThoughtDuration(durationMillis: Long): String {
     }
 }
 
-private fun formatAttachmentMetaLabel(attachment: ChatAttachment): String {
-    val typeLabel = if (attachment.kind == AttachmentKind.Image) "Photo" else "File"
+private fun formatAttachmentMetaLabel(strings: AetherStrings, attachment: ChatAttachment): String {
+    val typeLabel = strings.attachmentTypeLabel(attachment.kind == AttachmentKind.Image)
     val sizeLabel = attachment.sizeBytes?.let(::formatAttachmentSize)
     return listOfNotNull(typeLabel, sizeLabel).joinToString(" | ")
 }
 
-private fun formatComposerAttachmentMetaLabel(attachment: ChatAttachment): String {
+private fun formatComposerAttachmentMetaLabel(strings: AetherStrings, attachment: ChatAttachment): String {
     val statusLabel = when (attachment.workspaceState) {
-        AttachmentWorkspaceState.Pending -> "Copying to workspace"
-        AttachmentWorkspaceState.Failed -> "Workspace copy failed"
+        AttachmentWorkspaceState.Pending -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "正在复制到工作区" else "Copying to workspace"
+        AttachmentWorkspaceState.Failed -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "工作区复制失败" else "Workspace copy failed"
         AttachmentWorkspaceState.Ready -> null
     }
     return listOfNotNull(
-        formatAttachmentMetaLabel(attachment).ifBlank { null },
+        formatAttachmentMetaLabel(strings, attachment).ifBlank { null },
         statusLabel,
     ).joinToString(" | ")
 }
@@ -2156,13 +2182,13 @@ private fun formatToolInvocationGroupTitle(
     "Executed $count tools"
 }
 
-private fun formatToolInvocationDetail(toolInvocation: ChatToolInvocation): ToolInvocationDetail {
+private fun formatToolInvocationDetail(strings: AetherStrings, toolInvocation: ChatToolInvocation): ToolInvocationDetail {
     val arguments = parseJsonObject(toolInvocation.argumentsJson)
     val output = parseJsonObject(toolInvocation.outputJson)
     val command = output?.optString("command")
         .orEmpty()
         .trim()
-        .ifBlank { summarizeToolInvocationCommandLabel(toolInvocation.toolName, arguments) }
+        .ifBlank { strings.toolInvocationCommandLabel(toolInvocation.toolName, arguments) }
         .ifBlank { toolInvocation.toolName }
 
     if (toolInvocation.isRunning) {
@@ -2173,9 +2199,9 @@ private fun formatToolInvocationDetail(toolInvocation: ChatToolInvocation): Tool
     }
 
     val result = when {
-        output == null -> toolInvocation.outputJson.trim().ifBlank { "No output" }
+        output == null -> toolInvocation.outputJson.trim().ifBlank { strings.noOutput }
         toolInvocation.toolName.equals("fetch_web_url", ignoreCase = true) -> {
-            formatFetchWebUrlResult(output)
+            formatFetchWebUrlResult(strings, output)
         }
         output.optString("stdout").trim().isNotBlank() &&
             output.optString("stderr").trim().isNotBlank() -> {
@@ -2190,8 +2216,8 @@ private fun formatToolInvocationDetail(toolInvocation: ChatToolInvocation): Tool
         output.optString("stderr").trim().isNotBlank() -> output.optString("stderr").trim()
         output.optString("errmsg").trim().isNotBlank() -> output.optString("errmsg").trim()
         output.optString("hint").trim().isNotBlank() -> output.optString("hint").trim()
-        output.has("exit_code") && output.optInt("exit_code") != 0 -> "Exit code: ${output.optInt("exit_code")}"
-        else -> "No output"
+        output.has("exit_code") && output.optInt("exit_code") != 0 -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "退出代码：${output.optInt("exit_code")}" else "Exit code: ${output.optInt("exit_code")}"
+        else -> strings.noOutput
     }
 
     return ToolInvocationDetail(
@@ -2200,7 +2226,7 @@ private fun formatToolInvocationDetail(toolInvocation: ChatToolInvocation): Tool
     )
 }
 
-private fun formatFetchWebUrlResult(output: JSONObject): String {
+private fun formatFetchWebUrlResult(strings: AetherStrings, output: JSONObject): String {
     val markdown = output.optString("markdown").trim()
     if (markdown.isNotBlank()) {
         return buildString {
@@ -2209,12 +2235,12 @@ private fun formatFetchWebUrlResult(output: JSONObject): String {
             if (output.optBoolean("truncated")) {
                 appendLine()
                 appendLine()
-                append("[content truncated]")
+                append(strings.contentTruncated)
             }
         }.trim()
     }
 
-    return output.optString("stdout").trim().ifBlank { "No output" }
+    return output.optString("stdout").trim().ifBlank { strings.noOutput }
 }
 
 private fun summarizeToolInvocationCommand(

--- a/app/src/main/java/com/zhousl/aether/ui/ConversationUi.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/ConversationUi.kt
@@ -122,6 +122,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.zhousl.aether.data.InstalledSkill
+import com.zhousl.aether.data.AppLanguage
 import com.zhousl.aether.data.AgentModeDisplayState
 import com.zhousl.aether.data.McpServerConfig
 import com.zhousl.aether.data.McpTransportConfig
@@ -131,12 +132,15 @@ import com.zhousl.aether.data.SessionFollowUpMode
 import com.zhousl.aether.data.quickActionLabel
 import com.zhousl.aether.termux.TermuxSetupState
 import com.zhousl.aether.ui.theme.AetherBackground
+import com.zhousl.aether.ui.theme.AetherBackgroundGradientTop
 import com.zhousl.aether.ui.theme.AetherOnSurface
+import com.zhousl.aether.ui.theme.AetherOnPrimary
 import com.zhousl.aether.ui.theme.AetherOnSurfaceVariant
 import com.zhousl.aether.ui.theme.AetherPrimary
 import com.zhousl.aether.ui.theme.AetherScrim
 import com.zhousl.aether.ui.theme.AetherSurface
 import com.zhousl.aether.ui.theme.AetherSurfaceHigh
+import com.zhousl.aether.ui.theme.AetherSurfaceHigher
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.delay
@@ -146,7 +150,6 @@ private val ConversationTopFadeHeight = 42.dp
 private val DrawerOverlayFadeHeight = 18.dp
 private val ComposerCardShape = RoundedCornerShape(26.dp)
 private val ComposerFocusedCardShape = RoundedCornerShape(28.dp)
-private val ChatGptBackground = Color(0xFFFCFCFC)
 private val ChatGptControlShadow = Color(0x14000000)
 private val ChatGptComposerShadow = Color(0x18000000)
 private val ChatGptPurple = Color(0xFF9B5CFF)
@@ -154,36 +157,36 @@ private val ChatGptMotionEasing = CubicBezierEasing(0.22f, 0.84f, 0.18f, 1f)
 
 private fun topOverlayBodyGradient(): Brush = Brush.verticalGradient(
     colorStops = arrayOf(
-        0.0f to Color.White.copy(alpha = 0.98f),
-        0.28f to Color.White.copy(alpha = 0.92f),
-        0.58f to Color.White.copy(alpha = 0.52f),
-        0.82f to Color.White.copy(alpha = 0.18f),
+        0.0f to AetherBackground.copy(alpha = 0.98f),
+        0.28f to AetherBackground.copy(alpha = 0.92f),
+        0.58f to AetherBackground.copy(alpha = 0.52f),
+        0.82f to AetherBackground.copy(alpha = 0.18f),
         1.0f to Color.Transparent,
     )
 )
 
 private fun topOverlayTailGradient(): Brush = Brush.verticalGradient(
     colorStops = arrayOf(
-        0.0f to Color.White.copy(alpha = 0.10f),
-        0.42f to Color.White.copy(alpha = 0.04f),
+        0.0f to AetherBackground.copy(alpha = 0.10f),
+        0.42f to AetherBackground.copy(alpha = 0.04f),
         1.0f to Color.Transparent,
     )
 )
 
 private fun drawerOverlayBodyGradient(): Brush = Brush.verticalGradient(
     colorStops = arrayOf(
-        0.0f to Color.White.copy(alpha = 0.94f),
-        0.20f to Color.White.copy(alpha = 0.86f),
-        0.48f to Color.White.copy(alpha = 0.54f),
-        0.78f to Color.White.copy(alpha = 0.18f),
+        0.0f to AetherSurface.copy(alpha = 0.94f),
+        0.20f to AetherSurface.copy(alpha = 0.86f),
+        0.48f to AetherSurface.copy(alpha = 0.54f),
+        0.78f to AetherSurface.copy(alpha = 0.18f),
         1.0f to Color.Transparent,
     )
 )
 
 private fun drawerOverlayTailGradient(): Brush = Brush.verticalGradient(
     colorStops = arrayOf(
-        0.0f to Color.White.copy(alpha = 0.18f),
-        0.46f to Color.White.copy(alpha = 0.06f),
+        0.0f to AetherSurface.copy(alpha = 0.18f),
+        0.46f to AetherSurface.copy(alpha = 0.06f),
         1.0f to Color.Transparent,
     )
 )
@@ -311,7 +314,7 @@ fun ConversationScreen(
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        containerColor = ChatGptBackground,
+        containerColor = AetherBackground,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
     ) { innerPadding ->
         Box(
@@ -319,7 +322,7 @@ fun ConversationScreen(
                 .fillMaxSize()
                 .background(
                     Brush.verticalGradient(
-                        listOf(Color.White, ChatGptBackground, Color.White)
+                        listOf(AetherBackgroundGradientTop, AetherBackground, AetherSurface)
                     )
                 )
                 .padding(innerPadding)
@@ -523,6 +526,7 @@ private fun ConversationTopBar(
     onMenu: () -> Unit,
     onNewChat: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -533,17 +537,17 @@ private fun ConversationTopBar(
     ) {
         HeaderCircleButton(
             icon = Icons.Rounded.Menu,
-            contentDescription = "Menu",
+            contentDescription = strings.menu,
             onClick = onMenu,
             size = 44.dp,
-            containerColor = Color.White.copy(alpha = 0.96f),
+            containerColor = AetherSurface.copy(alpha = 0.96f),
         )
         HeaderCircleButton(
             icon = LucideIcons.SquarePen,
-            contentDescription = "New chat",
+            contentDescription = strings.newChat,
             onClick = onNewChat,
             size = 44.dp,
-            containerColor = Color.White.copy(alpha = 0.96f),
+            containerColor = AetherSurface.copy(alpha = 0.96f),
         )
     }
 }
@@ -556,6 +560,7 @@ private fun ConversationEmptyState(
     onResumeOnboarding: () -> Unit,
     onStarterPromptSelected: (String) -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     val titleOffset by animateDpAsState(
         targetValue = if (inputFocused) (-34).dp else (-24).dp,
         animationSpec = tween(durationMillis = 260, easing = ChatGptMotionEasing),
@@ -574,7 +579,7 @@ private fun ConversationEmptyState(
             Spacer(modifier = Modifier.height(22.dp))
         }
         Text(
-            text = "What can I help with?",
+            text = strings.whatCanIHelpWith,
             style = MaterialTheme.typography.titleLarge.copy(
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 24.sp,
@@ -591,13 +596,13 @@ private fun ConversationEmptyState(
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 EmptyStateChip(
                     icon = Icons.Rounded.Image,
-                    label = "Analyze image",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "分析图片" else "Analyze image",
                     iconTint = Color(0xFF38A961),
                     onClick = { onStarterPromptSelected("Analyze this image and describe the important details.") },
                 )
                 EmptyStateChip(
                     icon = Icons.Rounded.Terminal,
-                    label = "Code",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "代码" else "Code",
                     iconTint = Color(0xFF7D70DD),
                     onClick = { onStarterPromptSelected("Help me write or debug this code: ") },
                 )
@@ -605,13 +610,13 @@ private fun ConversationEmptyState(
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 EmptyStateChip(
                     icon = Icons.Rounded.AutoAwesome,
-                    label = "Help me write",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "帮我写" else "Help me write",
                     iconTint = Color(0xFFE48AAE),
                     onClick = { onStarterPromptSelected("Help me write a clear, polished message about ") },
                 )
                 EmptyStateChip(
                     icon = Icons.Rounded.AttachFile,
-                    label = "Summarize file",
+                    label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "总结文件" else "Summarize file",
                     iconTint = Color(0xFF66C7D4),
                     onClick = { onStarterPromptSelected("Summarize this file and list the key points.") },
                 )
@@ -627,11 +632,12 @@ private fun EmptyStateChip(
     iconTint: Color,
     onClick: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier
             .shadow(6.dp, RoundedCornerShape(999.dp), ambientColor = ChatGptControlShadow, spotColor = ChatGptControlShadow)
             .clip(RoundedCornerShape(999.dp))
-            .background(Color.White.copy(alpha = 0.98f))
+            .background(AetherSurface.copy(alpha = 0.98f))
             .clickable(onClick = onClick)
             .padding(horizontal = 14.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -655,22 +661,23 @@ private fun EmptyStateChip(
 private fun ResumeSetupCard(
     onResumeOnboarding: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(12.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White.copy(alpha = 0.96f))
+            .background(AetherSurface.copy(alpha = 0.96f))
             .padding(18.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text(
-            text = "Finish setup",
+            text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "完成设置" else "Finish setup",
             style = MaterialTheme.typography.titleMedium,
             color = AetherOnSurface,
         )
         Text(
-            text = "Connect a model, then come back to chat.",
+            text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "连接模型后返回聊天。" else "Connect a model, then come back to chat.",
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
         )
@@ -679,18 +686,19 @@ private fun ResumeSetupCard(
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
                 containerColor = AetherPrimary,
-                contentColor = Color.White,
+                contentColor = AetherOnPrimary,
             ),
         ) {
-            Text("Resume setup")
+            Text(if (strings.appLanguage == AppLanguage.SimplifiedChinese) "继续设置" else "Resume setup")
         }
     }
 }
 
 @Composable
 private fun ConversationThinkingIndicator() {
+    val strings = rememberAetherStrings()
     ShimmerStatusText(
-        text = "Thinking",
+        text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "思考中" else "Thinking",
         modifier = Modifier.padding(top = 6.dp),
     )
 }
@@ -699,14 +707,14 @@ private fun ConversationThinkingIndicator() {
 private fun PendingSessionInputBubble(
     pendingInput: PendingSessionInput,
 ) {
+    val strings = rememberAetherStrings()
     val modeLabel = when (pendingInput.mode) {
-        SessionFollowUpMode.Queue -> "Queued"
-        SessionFollowUpMode.Steer -> "Steering"
+        SessionFollowUpMode.Queue -> strings.pendingInputModeLabel(true)
+        SessionFollowUpMode.Steer -> strings.pendingInputModeLabel(false)
     }
     val attachmentLabel = when (pendingInput.attachmentCount) {
         0 -> null
-        1 -> "1 attachment"
-        else -> "${pendingInput.attachmentCount} attachments"
+        else -> strings.attachmentCountLabel(pendingInput.attachmentCount)
     }
 
     Column(
@@ -742,7 +750,9 @@ private fun PendingSessionInputBubble(
                 }
             }
             Text(
-                text = pendingInput.preview.ifBlank { "Additional context" },
+                text = pendingInput.preview.ifBlank {
+                    if (strings.appLanguage == AppLanguage.SimplifiedChinese) "补充上下文" else "Additional context"
+                },
                 style = MaterialTheme.typography.bodyLarge,
                 color = AetherOnSurface,
             )
@@ -883,6 +893,7 @@ private fun ConversationComposerBar(
     onQueueFollowUp: () -> Unit,
     onSteerFollowUp: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var attachmentMenuExpanded by remember { mutableStateOf(false) }
     val attachmentMenuVisibility = remember { MutableTransitionState(false) }
     attachmentMenuVisibility.targetState = attachmentMenuExpanded
@@ -905,15 +916,16 @@ private fun ConversationComposerBar(
     val hasSelectedActions = selectedSkillActions.isNotEmpty() || selectedMcpActions.isNotEmpty() || agentModeSelected
     val composerPlaceholder = when {
         value.isNotBlank() -> ""
-        attachments.isNotEmpty() -> "Add a note"
-        agentModeSelected && selectedSkillActions.isEmpty() && selectedMcpActions.isEmpty() -> "Ask Agent Mode"
+        attachments.isNotEmpty() -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "添加备注" else "Add a note"
+        agentModeSelected && selectedSkillActions.isEmpty() && selectedMcpActions.isEmpty() ->
+            if (strings.appLanguage == AppLanguage.SimplifiedChinese) "询问 Agent 模式" else "Ask Agent Mode"
         selectedSkillActions.size + selectedMcpActions.size == 1 && !agentModeSelected -> {
             selectedSkillActions.firstOrNull()?.quickActionLabel()
                 ?: selectedMcpActions.firstOrNull()?.quickActionLabel()
-                ?: "Reply to Aether"
+                ?: strings.replyToAether
         }
-        hasSelectedActions -> "Ask with selected tools"
-        else -> "Ask Aether"
+        hasSelectedActions -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "使用所选工具提问" else "Ask with selected tools"
+        else -> strings.askAether
     }
     val hasDraft = value.isNotBlank() || attachments.isNotEmpty()
     val canSendDraft = attachments.all { it.workspaceState == AttachmentWorkspaceState.Ready }
@@ -1007,18 +1019,18 @@ private fun ConversationComposerBar(
         }
         if (showStarterPromptHint) {
             SurfaceNotice(
-                title = "Your first prompt is ready",
-                subtitle = "Tap send to test Aether.",
-                actionLabel = "Hide",
+                title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "你的第一条提示已准备好" else "Your first prompt is ready",
+                subtitle = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "点击发送来测试 Aether。" else "Tap send to test Aether.",
+                actionLabel = strings.hide,
                 onAction = onDismissStarterPromptHint,
                 actionEnabled = true,
             )
         }
         if (isEditing) {
             SurfaceNotice(
-                title = "Editing earlier message",
-                subtitle = "Sending will replace the replies that came after it.",
-                actionLabel = "Cancel",
+                title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "正在编辑较早的消息" else "Editing earlier message",
+                subtitle = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "发送后会替换它之后的回复。" else "Sending will replace the replies that came after it.",
+                actionLabel = strings.cancel,
                 onAction = onCancelEdit,
                 actionEnabled = true,
             )
@@ -1062,7 +1074,7 @@ private fun ConversationComposerBar(
                             animationSpec = tween(durationMillis = 320, easing = ChatGptMotionEasing),
                         )
                         .clip(fieldShape)
-                        .background(Color.White)
+                        .background(AetherSurface)
                         .padding(
                             start = fieldContentStartPadding,
                             end = 8.dp,
@@ -1201,12 +1213,12 @@ private fun ConversationComposerBar(
                                                     .widthIn(min = 252.dp, max = 284.dp)
                                                     .shadow(20.dp, RoundedCornerShape(30.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
                                                     .clip(RoundedCornerShape(30.dp))
-                                                    .background(Color.White)
+                                                    .background(AetherSurface)
                                                     .padding(horizontal = 12.dp, vertical = 12.dp),
                                                 verticalArrangement = Arrangement.spacedBy(2.dp),
                                             ) {
                                                 ComposerPlusMenuRow(
-                                                    title = "Steer current run",
+                                                    title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "引导当前运行" else "Steer current run",
                                                     icon = Icons.Rounded.AutoAwesome,
                                                     iconTint = Color(0xFF8D6C2F),
                                                     iconContainerColor = Color(0xFFFFF3DE),
@@ -1216,7 +1228,7 @@ private fun ConversationComposerBar(
                                                     },
                                                 )
                                                 ComposerPlusMenuRow(
-                                                    title = "Queue next turn",
+                                                    title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "排队下一轮" else "Queue next turn",
                                                     icon = Icons.Rounded.ArrowUpward,
                                                     iconTint = Color(0xFF2F6DA3),
                                                     iconContainerColor = Color(0xFFEAF2FF),
@@ -1235,19 +1247,19 @@ private fun ConversationComposerBar(
                 }
             }
 
-            Box(
-                modifier = Modifier
-                    .align(plusButtonAlignment)
-                    .size(48.dp)
+                Box(
+            modifier = Modifier
+                .align(plusButtonAlignment)
+                .size(48.dp)
                     .shadow(plusShadowElevation, CircleShape, ambientColor = ChatGptControlShadow, spotColor = ChatGptControlShadow)
                     .clip(CircleShape)
-                    .background(if (plusSeparated) Color.White else Color.Transparent)
+                    .background(if (plusSeparated) AetherSurface else Color.Transparent)
                     .clickable(onClick = { attachmentMenuExpanded = !attachmentMenuExpanded }),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Add,
-                    contentDescription = "Add attachment or tool",
+                    contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "添加附件或工具" else "Add attachment or tool",
                     tint = AetherOnSurface,
                     modifier = Modifier.size(27.dp),
                 )
@@ -1284,25 +1296,25 @@ private fun ConversationComposerBar(
                                     .widthIn(min = 284.dp, max = 304.dp)
                                     .shadow(20.dp, RoundedCornerShape(30.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
                                     .clip(RoundedCornerShape(30.dp))
-                                    .background(Color.White)
+                                    .background(AetherSurface)
                                     .padding(horizontal = 12.dp, vertical = 12.dp),
                                 verticalArrangement = Arrangement.spacedBy(2.dp),
                             ) {
                                 ComposerPlusMenuRow(
-                                    title = "Photos",
+                                    title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "照片" else "Photos",
                                     icon = Icons.Rounded.Image,
                                     iconTint = Color(0xFF4E8D5A),
-                                    iconContainerColor = Color(0xFFE7F6EC),
+                                    iconContainerColor = AetherSurfaceHigh,
                                     onClick = {
                                         attachmentMenuExpanded = false
                                         onPickImages()
                                     },
                                 )
                                 ComposerPlusMenuRow(
-                                    title = "Files",
+                                    title = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "文件" else "Files",
                                     icon = Icons.Rounded.AttachFile,
                                     iconTint = AetherOnSurface,
-                                    iconContainerColor = Color(0xFFF3F4F6),
+                                    iconContainerColor = AetherSurfaceHigh,
                                     onClick = {
                                         attachmentMenuExpanded = false
                                         onPickFiles()
@@ -1313,11 +1325,11 @@ private fun ConversationComposerBar(
                                 }
                                 if (agentModeAvailable) {
                                     ComposerPlusMenuRow(
-                                        title = "Agent Mode",
+                                        title = strings.agentMode,
                                         icon = LucideIcons.MousePointer2,
                                         selected = agentModeSelected,
                                         iconTint = Color(0xFF6D5CFF),
-                                        iconContainerColor = Color(0xFFEDEBFF),
+                                        iconContainerColor = AetherSurfaceHigh,
                                         onClick = {
                                             attachmentMenuExpanded = false
                                             onSetAgentModeSelected(!agentModeSelected)
@@ -1331,7 +1343,7 @@ private fun ConversationComposerBar(
                                         icon = Icons.Rounded.Extension,
                                         selected = selected,
                                         iconTint = Color(0xFF9C6B2F),
-                                        iconContainerColor = Color(0xFFFFF4E7),
+                                        iconContainerColor = AetherSurfaceHigh,
                                         onClick = {
                                             attachmentMenuExpanded = false
                                             onSetSkillSelected(skill.id, !selected)
@@ -1346,7 +1358,7 @@ private fun ConversationComposerBar(
                                         icon = if (isStdIo) Icons.Rounded.Terminal else Icons.Rounded.Cloud,
                                         selected = selected,
                                         iconTint = if (isStdIo) Color(0xFF2F6DA3) else Color(0xFF2A9C9A),
-                                        iconContainerColor = if (isStdIo) Color(0xFFEAF2FF) else Color(0xFFE8F8F7),
+                                        iconContainerColor = AetherSurfaceHigh,
                                         onClick = {
                                             attachmentMenuExpanded = false
                                             onSetMcpServerSelected(server.id, !selected)
@@ -1391,11 +1403,12 @@ private fun ComposerSubmitButton(
     isSending: Boolean,
     onClick: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     val enabled = hasDraft && canSendDraft
     val buttonColor = if (enabled) {
         ChatGptPurple
     } else {
-        Color(0xFFD3D3D3)
+        AetherSurfaceHigher
     }
     Box(
         modifier = Modifier
@@ -1410,7 +1423,11 @@ private fun ComposerSubmitButton(
     ) {
         Icon(
             imageVector = Icons.Rounded.ArrowUpward,
-            contentDescription = if (isSending) "Send follow-up" else "Send",
+            contentDescription = if (isSending) {
+                if (strings.appLanguage == AppLanguage.SimplifiedChinese) "发送跟进" else "Send follow-up"
+            } else {
+                strings.send
+            },
             tint = Color.White,
             modifier = Modifier.size(21.dp),
         )
@@ -1427,6 +1444,7 @@ private fun ComposerActionTray(
     onRemoveMcpServer: (String) -> Unit,
     onRemoveAgentMode: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -1436,7 +1454,7 @@ private fun ComposerActionTray(
     ) {
         if (agentModeSelected) {
             ComposerActionChip(
-                label = "Agent Mode",
+                label = strings.agentMode,
                 icon = LucideIcons.MousePointer2,
                 onRemove = onRemoveAgentMode,
             )
@@ -1467,6 +1485,7 @@ private fun AgentModePreviewPanel(
     displayState: AgentModeDisplayState,
     toolInvocation: ChatToolInvocation?,
 ) {
+    val strings = rememberAetherStrings()
     val bitmap = remember(displayState.latestPreviewPath, displayState.lastUpdatedMillis) {
         displayState.latestPreviewPath
             .takeIf { it.isNotBlank() }
@@ -1477,7 +1496,7 @@ private fun AgentModePreviewPanel(
             .fillMaxWidth()
             .shadow(12.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White)
+            .background(AetherSurface)
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
@@ -1497,7 +1516,7 @@ private fun AgentModePreviewPanel(
             ) {
                 Image(
                     bitmap = bitmap.asImageBitmap(),
-                    contentDescription = "Agent Mode virtual display",
+                    contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Agent 模式虚拟显示" else "Agent Mode virtual display",
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(10.dp)
@@ -1507,7 +1526,7 @@ private fun AgentModePreviewPanel(
             }
         } else {
             Text(
-                text = "Virtual display preview will appear after the agent starts.",
+                text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "代理启动后会显示虚拟屏幕预览。" else "Virtual display preview will appear after the agent starts.",
                 style = MaterialTheme.typography.bodySmall,
                 color = AetherOnSurfaceVariant,
             )
@@ -1519,6 +1538,7 @@ private fun AgentModePreviewPanel(
 private fun AgentModePreviewHeader(
     displayState: AgentModeDisplayState,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -1531,13 +1551,15 @@ private fun AgentModePreviewHeader(
             modifier = Modifier.size(16.dp),
         )
         Text(
-            text = "Agent Mode",
+            text = strings.agentMode,
             style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Medium),
             color = AetherOnSurface,
         )
         Spacer(modifier = Modifier.weight(1f))
         Text(
-            text = displayState.displayId?.let { "display $it" } ?: "standby",
+            text = displayState.displayId?.let {
+                if (strings.appLanguage == AppLanguage.SimplifiedChinese) "显示 $it" else "display $it"
+            } ?: if (strings.appLanguage == AppLanguage.SimplifiedChinese) "待机" else "standby",
             style = MaterialTheme.typography.labelSmall,
             color = AetherOnSurfaceVariant,
         )
@@ -1553,7 +1575,7 @@ private fun AgentModePreviewToolStatus(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFFF6F7FB))
+            .background(AetherSurfaceHigh)
             .padding(horizontal = 14.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -1588,30 +1610,15 @@ private fun AgentModePreviewToolStatus(
     }
 }
 
+@Composable
 private fun formatPendingAgentModeToolLabel(toolInvocation: ChatToolInvocation): String {
+    val strings = rememberAetherStrings()
     val arguments = parseJsonObject(toolInvocation.argumentsJson)
-    return when (toolInvocation.toolName.lowercase()) {
-        "agent_display" -> {
-            val action = arguments?.optString("action").orEmpty().lowercase()
-            when (action) {
-                "start" -> if (toolInvocation.isRunning) "Starting Agent Mode display" else "Started Agent Mode display"
-                "launch" -> {
-                    val target = arguments?.optString("target").orEmpty().trim()
-                    if (toolInvocation.isRunning) "Opening ${target.ifBlank { "app" }}" else "Opened ${target.ifBlank { "app" }}"
-                }
-                "tap" -> if (toolInvocation.isRunning) "Tapping screen" else "Tapped screen"
-                "swipe" -> if (toolInvocation.isRunning) "Swiping screen" else "Swiped screen"
-                "key" -> if (toolInvocation.isRunning) "Pressing ${arguments?.optString("key").orEmpty().ifBlank { "key" }}" else "Pressed ${arguments?.optString("key").orEmpty().ifBlank { "key" }}"
-                "text" -> if (toolInvocation.isRunning) "Typing text" else "Typed text"
-                "screenshot" -> if (toolInvocation.isRunning) "Capturing screen" else "Captured screen"
-                "stop" -> if (toolInvocation.isRunning) "Stopping Agent Mode" else "Stopped Agent Mode"
-                else -> if (toolInvocation.isRunning) "Using Agent Mode" else "Used Agent Mode"
-            }
-        }
-        "analyze_image" -> if (toolInvocation.isRunning) "Reading screen" else "Read screen"
-        "bash" -> if (toolInvocation.isRunning) "Running command" else "Ran command"
-        else -> if (toolInvocation.isRunning) "Using ${toolInvocation.toolName}" else "Used ${toolInvocation.toolName}"
-    }
+    return strings.toolInvocationTitleLabel(
+        toolName = toolInvocation.toolName,
+        isRunning = toolInvocation.isRunning,
+        arguments = arguments,
+    )
 }
 
 private fun parseJsonObject(rawValue: String): JSONObject? =
@@ -1744,6 +1751,7 @@ fun ConversationDrawer(
     onDeleteSession: (String) -> Unit,
     onSettingsSelected: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var searchExpanded by rememberSaveable { mutableStateOf(false) }
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var overlayHeightPx by remember { mutableIntStateOf(0) }
@@ -1764,7 +1772,7 @@ fun ConversationDrawer(
         modifier = Modifier
             .fillMaxHeight()
             .widthIn(min = 304.dp, max = 328.dp),
-        drawerContainerColor = Color(0xFFFDFCFA),
+        drawerContainerColor = AetherSurface,
         drawerShape = RoundedCornerShape(topEnd = 30.dp, bottomEnd = 30.dp),
     ) {
         Box(
@@ -1784,7 +1792,7 @@ fun ConversationDrawer(
                         )
                 ) {
                     Text(
-                        text = if (sessions.isEmpty()) "No conversations yet." else "No chats match \"$searchQuery\".",
+                        text = if (sessions.isEmpty()) strings.noConversationsYet else strings.noChatsMatchSummary(searchQuery),
                         style = MaterialTheme.typography.bodyMedium,
                         color = AetherOnSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp),
@@ -1850,7 +1858,7 @@ fun ConversationDrawer(
                         Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                             HeaderCircleButton(
                                 icon = LucideIcons.Search,
-                                contentDescription = "Search chats",
+                                contentDescription = strings.search,
                                 onClick = {
                                     if (searchExpanded || searchQuery.isNotBlank()) {
                                         searchExpanded = false
@@ -1860,18 +1868,18 @@ fun ConversationDrawer(
                                     }
                                 },
                                 size = 46.dp,
-                                containerColor = Color.White.copy(alpha = 0.90f),
+                                containerColor = AetherSurface.copy(alpha = 0.90f),
                             )
                             HeaderCircleButton(
                                 icon = LucideIcons.Settings,
-                                contentDescription = "Settings",
+                                contentDescription = strings.settings,
                                 onClick = {
                                     searchExpanded = false
                                     searchQuery = ""
                                     onSettingsSelected()
                                 },
                                 size = 46.dp,
-                                containerColor = Color.White.copy(alpha = 0.90f),
+                                containerColor = AetherSurface.copy(alpha = 0.90f),
                             )
                         }
                     }
@@ -1924,11 +1932,12 @@ private fun DrawerCompactSearchField(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = modifier
             .shadow(12.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(24.dp))
-            .background(Color.White)
+            .background(AetherSurface)
             .padding(horizontal = 14.dp, vertical = 11.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -1945,7 +1954,7 @@ private fun DrawerCompactSearchField(
         ) {
             if (value.isBlank()) {
                 Text(
-                    text = "Search chats",
+                    text = strings.search,
                     style = MaterialTheme.typography.bodyMedium,
                     color = AetherOnSurfaceVariant,
                 )
@@ -1974,11 +1983,12 @@ private fun DrawerSessionRow(
     onExport: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var menuExpanded by remember { mutableStateOf(false) }
     var isRenaming by remember { mutableStateOf(false) }
     var renameFieldHadFocus by remember { mutableStateOf(false) }
     var renameFocusRequest by remember { mutableIntStateOf(0) }
-    var titleValue by remember(session.id, session.title) { mutableStateOf(session.title.ifBlank { "New chat" }) }
+    var titleValue by remember(session.id, session.title) { mutableStateOf(session.title.ifBlank { strings.newChat }) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -2006,7 +2016,7 @@ private fun DrawerSessionRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(18.dp))
-                .background(if (selected) Color(0xFFF1F0EC) else Color.Transparent)
+                .background(if (selected) AetherSurfaceHigh else Color.Transparent)
                 .then(
                     if (isRenaming) {
                         Modifier
@@ -2047,7 +2057,7 @@ private fun DrawerSessionRow(
                 )
             } else {
                 Text(
-                    text = session.title.ifBlank { "New chat" },
+                    text = session.title.ifBlank { strings.newChat },
                     style = MaterialTheme.typography.bodyLarge.copy(
                         fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
                     ),
@@ -2079,7 +2089,7 @@ private fun DrawerSessionRow(
             onDismissRequest = { menuExpanded = false },
             onRename = {
                 menuExpanded = false
-                titleValue = session.title.ifBlank { "New chat" }
+                titleValue = session.title.ifBlank { strings.newChat }
                 renameFieldHadFocus = false
                 isRenaming = true
                 renameFocusRequest += 1
@@ -2104,6 +2114,7 @@ private fun DrawerSessionActionMenu(
     onExport: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     val menuVisibility = remember { MutableTransitionState(false) }
     menuVisibility.targetState = expanded
     if (!menuVisibility.currentState && !menuVisibility.targetState) return
@@ -2128,13 +2139,13 @@ private fun DrawerSessionActionMenu(
                     .widthIn(min = 188.dp, max = 220.dp)
                     .shadow(18.dp, RoundedCornerShape(24.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
                     .clip(RoundedCornerShape(24.dp))
-                    .background(Color.White)
+                    .background(AetherSurface)
                     .padding(8.dp),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                DrawerSessionActionRow("Rename", onRename)
-                DrawerSessionActionRow("Export", onExport)
-                DrawerSessionActionRow("Delete", onDelete, destructive = true)
+                DrawerSessionActionRow(strings.rename, onRename)
+                DrawerSessionActionRow(strings.export, onExport)
+                DrawerSessionActionRow(strings.delete, onDelete, destructive = true)
             }
         }
     }
@@ -2184,6 +2195,7 @@ private fun DrawerFloatingChatButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = modifier
             .shadow(18.dp, RoundedCornerShape(999.dp), ambientColor = AetherScrim, spotColor = AetherScrim)
@@ -2205,7 +2217,7 @@ private fun DrawerFloatingChatButton(
             modifier = Modifier.size(17.dp),
         )
         Text(
-            text = "Chat",
+            text = strings.chat,
             style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Medium),
             color = Color.White,
         )

--- a/app/src/main/java/com/zhousl/aether/ui/MarkdownRenderer.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/MarkdownRenderer.kt
@@ -66,12 +66,14 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.view.ViewCompat
+import com.zhousl.aether.data.AppLanguage
 import com.zhousl.aether.data.WorkspaceFileBridge
 import com.zhousl.aether.termux.TermuxContract
 import com.zhousl.aether.ui.theme.AetherOnSurface
 import com.zhousl.aether.ui.theme.AetherOnSurfaceVariant
 import com.zhousl.aether.ui.theme.AetherOutlineSoft
 import com.zhousl.aether.ui.theme.AetherPrimary
+import com.zhousl.aether.ui.theme.AetherSurface
 import com.zhousl.aether.ui.theme.AetherSurfaceHigh
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -378,7 +380,7 @@ private fun MarkdownTable(
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState())
             .clip(RoundedCornerShape(18.dp))
-            .background(Color.White.copy(alpha = 0.84f)),
+            .background(AetherSurface.copy(alpha = 0.92f)),
     ) {
         MarkdownTableRow(
             cells = headers,
@@ -410,7 +412,7 @@ private fun MarkdownTableRow(
         modifier = Modifier.background(
             when {
                 isHeader -> AetherSurfaceHigh
-                shaded -> Color.White.copy(alpha = 0.46f)
+                shaded -> AetherSurface.copy(alpha = 0.68f)
                 else -> Color.Transparent
             }
         )
@@ -551,8 +553,9 @@ private fun MarkdownImageBlock(
             )
         }
         if (!originalLinkTarget.isNullOrBlank()) {
+            val strings = rememberAetherStrings()
             Text(
-                text = "Open original",
+                text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "打开原图" else "Open original",
                 style = MaterialTheme.typography.bodySmall,
                 color = AetherPrimary,
                 modifier = Modifier.clickable { onLinkClick(originalLinkTarget) },
@@ -595,7 +598,7 @@ private fun MarkdownMermaidBlock(
             defaultMaxHeightDp = DefaultMermaidMaxHeightDp,
             modifier = widthModifier
                 .clip(RoundedCornerShape(18.dp))
-                .background(Color.White),
+                .background(AetherSurface),
             onTap = { showPreview = true },
         )
     }
@@ -617,7 +620,7 @@ private fun MarkdownHtmlBlock(
     defaultMinHeightDp: Int,
     defaultMaxHeightDp: Int,
     modifier: Modifier = Modifier,
-    backgroundColor: Color = Color.White,
+    backgroundColor: Color = AetherSurface,
     onTap: (() -> Unit)? = null,
     onLinkClick: ((String) -> Unit)? = null,
 ) {

--- a/app/src/main/java/com/zhousl/aether/ui/OnboardingScreen.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/OnboardingScreen.kt
@@ -76,11 +76,22 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.zhousl.aether.data.AgentModeAuthorizationMethod
+import com.zhousl.aether.data.AppLanguage
 import com.zhousl.aether.data.LlmProvider
 import com.zhousl.aether.data.LlmProviderConfig
 import com.zhousl.aether.termux.TermuxSetupIssue
 import com.zhousl.aether.termux.TermuxSetupState
 import com.zhousl.aether.R
+import com.zhousl.aether.ui.theme.AetherBackground
+import com.zhousl.aether.ui.theme.AetherOnPrimary
+import com.zhousl.aether.ui.theme.AetherOnSurface
+import com.zhousl.aether.ui.theme.AetherOnSurfaceVariant
+import com.zhousl.aether.ui.theme.AetherOutlineSoft
+import com.zhousl.aether.ui.theme.AetherPrimary
+import com.zhousl.aether.ui.theme.AetherSecondary
+import com.zhousl.aether.ui.theme.AetherSurface
+import com.zhousl.aether.ui.theme.AetherSurfaceHigh
+import com.zhousl.aether.ui.theme.AetherTertiary
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -101,17 +112,31 @@ private val FollowUpOnboardingSteps = listOf(
     OnboardingStep.McpOverview,
 )
 
-private val TourBackground = Color.White
-private val TourTextPrimary = Color(0xFF111111)
-private val TourTextSecondary = Color(0xFF6A6A66)
-private val TourTextTertiary = Color(0xFF8A8A84)
-private val TourDivider = Color(0xFFE8E8E3)
-private val TourSurface = Color(0xFFF6F6F2)
-private val TourButton = Color(0xFF171717)
-private val TourBlue = Color(0xFF3C6FE4)
-private val TourGreen = Color(0xFF297A68)
-private val TourGold = Color(0xFFB6781B)
-private val TourPurple = Color(0xFF7E61E9)
+private val TourBackground: Color
+    get() = AetherBackground
+private val TourTextPrimary: Color
+    get() = AetherOnSurface
+private val TourTextSecondary: Color
+    get() = AetherOnSurfaceVariant
+private val TourTextTertiary: Color
+    get() = AetherOnSurfaceVariant.copy(alpha = 0.72f)
+private val TourDivider: Color
+    get() = AetherOutlineSoft
+private val TourSurface: Color
+    get() = AetherSurfaceHigh
+private val TourButton: Color
+    get() = AetherPrimary
+private val TourBlue: Color
+    get() = AetherPrimary
+private val TourGreen: Color
+    get() = AetherSecondary
+private val TourGold: Color
+    get() = AetherTertiary
+private val TourPurple: Color
+    get() = AetherPrimary
+
+private fun tr(strings: AetherStrings, english: String, chinese: String): String =
+    if (strings.appLanguage == AppLanguage.SimplifiedChinese) chinese else english
 
 private enum class ProviderTourStage {
     PickProvider,
@@ -155,6 +180,7 @@ fun OnboardingScreen(
     onSaveAgentModeAuthorization: (Boolean, AgentModeAuthorizationMethod) -> Unit,
     onExploreSettings: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var currentStep by rememberSaveable(initialStep, replayMode) {
         mutableStateOf(initialStep)
     }
@@ -260,20 +286,20 @@ fun OnboardingScreen(
             OnboardingStep.SkillsOverview -> SummaryStep(
                 stepIndex = stepIndex,
                 stepCount = steps.size,
-                message = "Later, you can add Skills so Aether remembers reusable workflows you like.",
-                title = "Skills",
+                message = tr(strings, "Later, you can add Skills so Aether remembers reusable workflows you like.", "之后你可以添加技能，让 Aether 记住你喜欢的可复用工作流。"),
+                title = tr(strings, "Skills", "技能"),
                 icon = Icons.Rounded.Extension,
                 accent = TourGold,
                 lineOne = if (installedSkillCount == 0) {
-                    "You do not need this now."
+                    tr(strings, "You do not need this now.", "现在不需要也没关系。")
                 } else {
-                    "$installedSkillCount Skills are already installed."
+                    tr(strings, "$installedSkillCount Skills are already installed.", "已经安装了 $installedSkillCount 个技能。")
                 },
-                lineTwo = "Use them for prompts, checks, and templates.",
-                chips = listOf("Prompts", "Checks", "Templates"),
-                primaryLabel = "Continue",
+                lineTwo = tr(strings, "Use them for prompts, checks, and templates.", "它们可以用来放提示词、检查项和模板。"),
+                chips = listOf(tr(strings, "Prompts", "提示词"), tr(strings, "Checks", "检查项"), tr(strings, "Templates", "模板")),
+                primaryLabel = strings.continueLabel,
                 onPrimary = { currentStep = OnboardingStep.McpOverview },
-                secondaryLabel = "Back",
+                secondaryLabel = strings.back,
                 onSecondary = { currentStep = OnboardingStep.TavilySetup },
                 onClose = onClose,
             )
@@ -281,22 +307,22 @@ fun OnboardingScreen(
             OnboardingStep.McpOverview -> SummaryStep(
                 stepIndex = stepIndex,
                 stepCount = steps.size,
-                message = "If you want live docs, search, or APIs later, you can connect MCP servers in Settings.",
+                message = tr(strings, "If you want live docs, search, or APIs later, you can connect MCP servers in Settings.", "如果之后你想接入实时文档、搜索或 API，可以在设置里连接 MCP 服务器。"),
                 title = "MCP",
                 icon = Icons.Rounded.Cloud,
                 accent = TourBlue,
                 lineOne = if (mcpServerCount == 0) {
-                    "You can leave this for later."
+                    tr(strings, "You can leave this for later.", "这一步也可以留到以后。")
                 } else {
-                    "$mcpServerCount MCP servers are already available."
+                    tr(strings, "$mcpServerCount MCP servers are already available.", "已经有 $mcpServerCount 个 MCP 服务器可用。")
                 },
-                lineTwo = "This is where Aether grows beyond local tools.",
-                chips = listOf("Docs", "Search", "APIs"),
-                primaryLabel = "Done",
+                lineTwo = tr(strings, "This is where Aether grows beyond local tools.", "这里是 Aether 超出本地工具能力的入口。"),
+                chips = listOf(tr(strings, "Docs", "文档"), tr(strings, "Search", "搜索"), "APIs"),
+                primaryLabel = strings.done,
                 onPrimary = onClose,
-                secondaryLabel = "Open settings",
+                secondaryLabel = tr(strings, "Open settings", "打开设置"),
                 onSecondary = onExploreSettings,
-                tertiaryLabel = "Back",
+                tertiaryLabel = strings.back,
                 onTertiary = { currentStep = OnboardingStep.SkillsOverview },
                 onClose = onClose,
             )
@@ -312,6 +338,7 @@ private fun LandingStep(
     onPrimary: () -> Unit,
     onSecondary: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var visible by remember(stepIndex, replayMode) { mutableStateOf(false) }
     LaunchedEffect(stepIndex, replayMode) {
         delay(180)
@@ -332,7 +359,7 @@ private fun LandingStep(
                 stepIndex = stepIndex,
                 stepCount = stepCount,
                 onBack = null,
-                topRightLabel = if (replayMode) "Close" else "Skip",
+                topRightLabel = if (replayMode) if (strings.appLanguage == AppLanguage.SimplifiedChinese) "关闭" else "Close" else if (strings.appLanguage == AppLanguage.SimplifiedChinese) "跳过" else "Skip",
                 onTopRight = onSecondary,
             )
             Column(
@@ -357,13 +384,13 @@ private fun LandingStep(
                     ) {
                         Image(
                             painter = painterResource(id = R.drawable.aether_mark),
-                            contentDescription = "Aether icon",
+                            contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Aether 图标" else "Aether icon",
                             modifier = Modifier
                                 .size(104.dp),
                         )
                         Spacer(modifier = Modifier.height(28.dp))
                         Text(
-                            text = "Welcome to Aether",
+                            text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "欢迎使用 Aether" else "Welcome to Aether",
                             modifier = Modifier.fillMaxWidth(),
                             style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.SemiBold),
                             color = TourTextPrimary,
@@ -371,7 +398,7 @@ private fun LandingStep(
                         )
                         Spacer(modifier = Modifier.height(10.dp))
                         Text(
-                            text = "The on-device agent that works with everything.",
+                            text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "在设备上运行、可与一切协作的智能体。" else "The on-device agent that works with everything.",
                             modifier = Modifier.fillMaxWidth(),
                             style = MaterialTheme.typography.bodyMedium,
                             color = TourTextSecondary,
@@ -400,7 +427,7 @@ private fun LandingStep(
                             contentColor = Color.White,
                         ),
                     ) {
-                        Text("Get started")
+                        Text(if (strings.appLanguage == AppLanguage.SimplifiedChinese) "开始使用" else "Get started")
                     }
                 }
             }
@@ -541,6 +568,7 @@ private fun ProviderSetupStep(
     onReturnToLanding: () -> Unit,
     onComplete: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var stage by rememberSaveable(stepIndex, replayMode) { mutableStateOf(ProviderTourStage.PickProvider) }
     var isFinishing by rememberSaveable(stepIndex, replayMode) { mutableStateOf(false) }
     val provider = selectedProvider
@@ -557,9 +585,9 @@ private fun ProviderSetupStep(
         (provider != LlmProvider.VertexExpress || formState.apiKey.trim().isNotBlank())
 
     val message = when (stage) {
-        ProviderTourStage.PickProvider -> "First, let's choose your model provider."
-        ProviderTourStage.Credentials -> "Great. Add your key and base URL. I'll fetch the models after this."
-        ProviderTourStage.Model -> "Pick the model you want, and then we can go straight into chat."
+        ProviderTourStage.PickProvider -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "首先，我们来选择你的模型提供方。" else "First, let's choose your model provider."
+        ProviderTourStage.Credentials -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "很好。填入密钥和基础 URL，然后我会获取模型。" else "Great. Add your key and base URL. I'll fetch the models after this."
+        ProviderTourStage.Model -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "选好模型后，我们就可以直接进入聊天。" else "Pick the model you want, and then we can go straight into chat."
     }
     val backAction: (() -> Unit)? = when (stage) {
         ProviderTourStage.PickProvider -> onReturnToLanding
@@ -579,7 +607,7 @@ private fun ProviderSetupStep(
         stepCount = stepCount,
         message = message,
         onBack = backAction,
-        topRightLabel = if (replayMode) "Close" else "Skip",
+        topRightLabel = if (replayMode) if (strings.appLanguage == AppLanguage.SimplifiedChinese) "关闭" else "Close" else if (strings.appLanguage == AppLanguage.SimplifiedChinese) "跳过" else "Skip",
         onTopRight = if (replayMode) onClose else onExit,
         isExiting = isFinishing,
     ) {
@@ -609,7 +637,7 @@ private fun ProviderSetupStep(
                     ) {
                         ProviderStageButton(
                             label = "OpenAI",
-                            subtitle = "Use OpenAI-compatible APIs",
+                            subtitle = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "使用兼容 OpenAI 的 API" else "Use OpenAI-compatible APIs",
                             provider = LlmProvider.OpenAiCompatible,
                             onClick = {
                                 onSelectProvider(LlmProvider.OpenAiCompatible)
@@ -618,7 +646,7 @@ private fun ProviderSetupStep(
                         )
                         ProviderStageButton(
                             label = "Vertex",
-                            subtitle = "Use Google Cloud Vertex AI",
+                            subtitle = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "使用 Google Cloud Vertex AI" else "Use Google Cloud Vertex AI",
                             provider = LlmProvider.VertexExpress,
                             onClick = {
                                 onSelectProvider(LlmProvider.VertexExpress)
@@ -627,7 +655,7 @@ private fun ProviderSetupStep(
                         )
                         Spacer(modifier = Modifier.height(6.dp))
                         Text(
-                            text = "You can change this later in Settings.",
+                            text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "你以后可以在设置中更改。" else "You can change this later in Settings.",
                             style = MaterialTheme.typography.bodySmall,
                             color = TourTextSecondary,
                         )
@@ -641,8 +669,8 @@ private fun ProviderSetupStep(
                     ) {
                         TinyLabel(
                             text = when (provider) {
-                                LlmProvider.VertexExpress -> "Using Vertex"
-                                else -> "Using OpenAI"
+                                LlmProvider.VertexExpress -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "正在使用 Vertex" else "Using Vertex"
+                                else -> if (strings.appLanguage == AppLanguage.SimplifiedChinese) "正在使用 OpenAI" else "Using OpenAI"
                             },
                             color = when (provider) {
                                 LlmProvider.VertexExpress -> TourBlue
@@ -650,24 +678,24 @@ private fun ProviderSetupStep(
                             },
                         )
                         MinimalInputField(
-                            label = "API key",
+                            label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "API 密钥" else "API key",
                             value = formState.apiKey,
                             placeholder = if (provider == LlmProvider.VertexExpress) {
-                                "Required for Vertex"
+                                if (strings.appLanguage == AppLanguage.SimplifiedChinese) "Vertex 需要" else "Required for Vertex"
                             } else {
-                                "Optional"
+                                if (strings.appLanguage == AppLanguage.SimplifiedChinese) "可选" else "Optional"
                             },
                             onValueChange = { formState.apiKey = it },
                         )
                         MinimalInputField(
-                            label = "Base URL",
+                            label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "基础 URL" else "Base URL",
                             value = formState.baseUrl,
                             placeholder = "https://...",
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
                             onValueChange = { formState.baseUrl = it },
                         )
                         PrimaryActionButton(
-                            label = if (isLoadingModels) "Loading models..." else "Next",
+                            label = if (isLoadingModels) if (strings.appLanguage == AppLanguage.SimplifiedChinese) "正在加载模型..." else "Loading models..." else if (strings.appLanguage == AppLanguage.SimplifiedChinese) "下一步" else "Next",
                             enabled = canContinueFromCredentials && !isLoadingModels,
                             onClick = {
                                 formState.isFetchingModelsLocally = true
@@ -696,7 +724,7 @@ private fun ProviderSetupStep(
                         verticalArrangement = Arrangement.spacedBy(18.dp),
                     ) {
                         Text(
-                            text = "I'll place the best matches first when I can find them.",
+                            text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "如果我能找到更合适的模型，我会把它们排在前面。" else "I'll place the best matches first when I can find them.",
                             style = MaterialTheme.typography.bodySmall,
                             color = TourTextSecondary,
                         )
@@ -713,18 +741,18 @@ private fun ProviderSetupStep(
                             }
                         }
                         MinimalInputField(
-                            label = "Model",
+                            label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "模型" else "Model",
                             value = if (modelChoices.any { it.equals(formState.modelId.trim(), ignoreCase = true) }) {
                                 ""
                             } else {
                                 formState.modelId
                             },
-                            placeholder = "Or type your own model",
+                            placeholder = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "或者输入你自己的模型" else "Or type your own model",
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
                             onValueChange = { formState.modelId = it },
                         )
                         PrimaryActionButton(
-                            label = "Start chat",
+                            label = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "开始聊天" else "Start chat",
                             enabled = provider != null && formState.isValid,
                             onClick = { isFinishing = true },
                         )
@@ -749,6 +777,7 @@ private fun TermuxStep(
     onInstallTermux: () -> Unit,
     onRefresh: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var shouldAutoContinue by rememberSaveable(stepIndex) { mutableStateOf(!setupState.isReady) }
     LaunchedEffect(setupState.isReady) {
         if (shouldAutoContinue && setupState.isReady) {
@@ -763,7 +792,7 @@ private fun TermuxStep(
         stepCount = stepCount,
         message = "Great. Now let’s give Aether access to your device so tools can run locally.",
         onBack = null,
-        topRightLabel = "Close",
+        topRightLabel = strings.close,
         onTopRight = onClose,
     ) {
         Column(
@@ -773,52 +802,52 @@ private fun TermuxStep(
             StepLead(
                 icon = Icons.Rounded.Terminal,
                 accent = termuxStatusColor(setupState.issue),
-                title = "Termux",
-                body = termuxStatusSentence(setupState),
+                title = strings.termux,
+                body = termuxStatusSentence(setupState, strings.appLanguage),
             )
             when (setupState.issue) {
                 TermuxSetupIssue.Ready -> TourActionRow(
-                    primaryLabel = "Continue",
+                    primaryLabel = strings.continueLabel,
                     onPrimary = onContinue,
-                    secondaryLabel = "Refresh",
+                    secondaryLabel = strings.refresh,
                     onSecondary = onRefresh,
                 )
 
                 TermuxSetupIssue.NotInstalled -> TourActionRow(
-                    primaryLabel = "Install",
+                    primaryLabel = strings.install,
                     onPrimary = onInstallTermux,
-                    secondaryLabel = "Skip",
+                    secondaryLabel = strings.skip,
                     onSecondary = onContinue,
                 )
 
                 TermuxSetupIssue.PermissionMissing -> {
                     TourActionRow(
-                        primaryLabel = "Grant access",
+                        primaryLabel = strings.grantAccess,
                         onPrimary = onRequestPermission,
-                        secondaryLabel = "Skip",
+                        secondaryLabel = strings.skip,
                         onSecondary = onContinue,
                     )
-                    SecondaryTextAction(label = "App settings", onClick = onOpenAppPermissions)
+                    SecondaryTextAction(label = tr(strings, "App settings", "应用设置"), onClick = onOpenAppPermissions)
                 }
 
                 TermuxSetupIssue.ExternalAppsDisabled -> {
                     TourActionRow(
-                        primaryLabel = "Termux settings",
+                        primaryLabel = tr(strings, "Termux settings", "Termux 设置"),
                         onPrimary = onOpenTermuxSettings,
-                        secondaryLabel = "Skip",
+                        secondaryLabel = strings.skip,
                         onSecondary = onContinue,
                     )
-                    SecondaryTextAction(label = "Open Termux", onClick = onOpenTermux)
+                    SecondaryTextAction(label = strings.openTermux, onClick = onOpenTermux)
                 }
 
                 TermuxSetupIssue.DispatchFailed -> {
                     TourActionRow(
-                        primaryLabel = "Open Termux",
+                        primaryLabel = strings.openTermux,
                         onPrimary = onOpenTermux,
-                        secondaryLabel = "Skip",
+                        secondaryLabel = strings.skip,
                         onSecondary = onContinue,
                     )
-                    SecondaryTextAction(label = "Termux settings", onClick = onOpenTermuxSettings)
+                    SecondaryTextAction(label = tr(strings, "Termux settings", "Termux 设置"), onClick = onOpenTermuxSettings)
                 }
             }
         }
@@ -834,12 +863,13 @@ private fun AgentModeAuthorizationStep(
     onClose: () -> Unit,
     onContinue: (Boolean, AgentModeAuthorizationMethod) -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     ConversationStepPage(
         stepIndex = stepIndex,
         stepCount = stepCount,
-        message = "Agent Mode is optional. It needs Root or Shizuku to control an isolated Android display.",
+        message = tr(strings, "Agent Mode is optional. It needs Root or Shizuku to control an isolated Android display.", "Agent 模式是可选项。它需要 Root 或 Shizuku 来控制隔离的 Android 显示。"),
         onBack = onBack,
-        topRightLabel = "Close",
+        topRightLabel = strings.close,
         onTopRight = onClose,
     ) {
         Column(
@@ -849,8 +879,8 @@ private fun AgentModeAuthorizationStep(
             StepLead(
                 icon = Icons.Rounded.SmartToy,
                 accent = TourGreen,
-                title = "Agent Mode",
-                body = "Choose an authorization method, or skip this for now.",
+                title = strings.agentMode,
+                body = tr(strings, "Choose an authorization method, or skip this for now.", "选择一种授权方式，或者暂时先跳过。"),
             )
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -858,19 +888,19 @@ private fun AgentModeAuthorizationStep(
             ) {
                 AgentModeStageButton(
                     label = "Shizuku",
-                    subtitle = "Use the elevated Shizuku service when the app is installed.",
+                    subtitle = tr(strings, "Use the elevated Shizuku service when the app is installed.", "安装应用后使用提权的 Shizuku 服务。"),
                     drawableRes = R.drawable.shizuku_mark,
                     onClick = { onContinue(true, AgentModeAuthorizationMethod.Shizuku) },
                 )
                 AgentModeStageButton(
                     label = "Root",
-                    subtitle = "Use a root shell for privileged input on rooted devices.",
+                    subtitle = tr(strings, "Use a root shell for privileged input on rooted devices.", "在已 root 的设备上使用 root shell 进行特权输入。"),
                     drawableRes = R.drawable.root_mark,
                     onClick = { onContinue(true, AgentModeAuthorizationMethod.Root) },
                 )
                 AgentModeStageButton(
-                    label = "Skip",
-                    subtitle = "Leave Agent Mode off and enable it later from Settings.",
+                    label = strings.skip,
+                    subtitle = tr(strings, "Leave Agent Mode off and enable it later from Settings.", "先关闭 Agent 模式，之后再到设置中启用。"),
                     drawableRes = R.drawable.skip_mark,
                     onClick = { onContinue(false, initialMethod) },
                 )
@@ -889,12 +919,13 @@ private fun TavilyStep(
     onClose: () -> Unit,
     onContinue: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     ConversationStepPage(
         stepIndex = stepIndex,
         stepCount = stepCount,
-        message = "If you want fresher web answers later, you can add search here.",
+        message = tr(strings, "If you want fresher web answers later, you can add search here.", "如果你之后想获得更新鲜的网页答案，可以在这里补上搜索能力。"),
         onBack = onBack,
-        topRightLabel = "Close",
+        topRightLabel = strings.close,
         onTopRight = onClose,
     ) {
         Column(
@@ -904,16 +935,16 @@ private fun TavilyStep(
             BrandStepLead(
                 drawableRes = R.drawable.tavily_mark,
                 title = "Tavily",
-                body = "This is optional. URL fetch already works without it.",
+                body = tr(strings, "This is optional. URL fetch already works without it.", "这是可选项。即使不填，URL 抓取也已经可以使用。"),
             )
             MinimalInputField(
-                label = "API key",
+                label = tr(strings, "API key", "API 密钥"),
                 value = value,
-                placeholder = "Paste it here",
+                placeholder = tr(strings, "Paste it here", "粘贴到这里"),
                 onValueChange = onValueChange,
             )
             PrimaryActionButton(
-                label = "Continue",
+                label = strings.continueLabel,
                 onClick = onContinue,
             )
         }
@@ -939,12 +970,13 @@ private fun SummaryStep(
     onTertiary: (() -> Unit)? = null,
     onClose: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     ConversationStepPage(
         stepIndex = stepIndex,
         stepCount = stepCount,
         message = message,
         onBack = onTertiary,
-        topRightLabel = "Close",
+        topRightLabel = strings.close,
         onTopRight = onClose,
     ) {
         Column(
@@ -1580,13 +1612,14 @@ private fun providerModelRank(
 
 private fun termuxStatusSentence(
     setupState: TermuxSetupState,
+    appLanguage: AppLanguage,
 ): String = setupState.detail.ifBlank {
     when (setupState.issue) {
-        TermuxSetupIssue.Ready -> "Local tools are ready."
-        TermuxSetupIssue.NotInstalled -> "Install Termux first, then come back here."
-        TermuxSetupIssue.PermissionMissing -> "Grant the Termux command permission, then return here."
-        TermuxSetupIssue.ExternalAppsDisabled -> "Open Termux settings and allow external apps."
-        TermuxSetupIssue.DispatchFailed -> "Open Termux once, then refresh here."
+        TermuxSetupIssue.Ready -> if (appLanguage == AppLanguage.SimplifiedChinese) "本地工具已就绪。" else "Local tools are ready."
+        TermuxSetupIssue.NotInstalled -> if (appLanguage == AppLanguage.SimplifiedChinese) "先安装 Termux，然后再回到这里。" else "Install Termux first, then come back here."
+        TermuxSetupIssue.PermissionMissing -> if (appLanguage == AppLanguage.SimplifiedChinese) "授予 Termux 命令权限后再回来。" else "Grant the Termux command permission, then return here."
+        TermuxSetupIssue.ExternalAppsDisabled -> if (appLanguage == AppLanguage.SimplifiedChinese) "打开 Termux 设置并允许外部应用。" else "Open Termux settings and allow external apps."
+        TermuxSetupIssue.DispatchFailed -> if (appLanguage == AppLanguage.SimplifiedChinese) "先打开一次 Termux，然后回到这里刷新。" else "Open Termux once, then refresh here."
     }
 }
 

--- a/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Cloud
 import androidx.compose.material.icons.rounded.Code
+import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.Extension
@@ -57,6 +58,7 @@ import androidx.compose.material.icons.rounded.Link
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Terminal
+import androidx.compose.material.icons.rounded.WbSunny
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -101,6 +103,8 @@ import com.zhousl.aether.BuildConfig
 import com.zhousl.aether.R
 import com.zhousl.aether.data.AgentModeAuthorizationMethod
 import com.zhousl.aether.data.AgentModeDisplayState
+import com.zhousl.aether.data.AppLanguage
+import com.zhousl.aether.data.AppThemeMode
 import com.zhousl.aether.data.LlmProvider
 import com.zhousl.aether.data.LlmProviderConfig
 import com.zhousl.aether.data.normalizeLlmInactivityReconnectTimeoutSeconds
@@ -108,8 +112,11 @@ import com.zhousl.aether.data.quickActionLabel
 import com.zhousl.aether.termux.TermuxSetupState
 import com.zhousl.aether.ui.theme.AetherBackground
 import com.zhousl.aether.ui.theme.AetherOnSurface
+import com.zhousl.aether.ui.theme.AetherOnPrimary
 import com.zhousl.aether.ui.theme.AetherOnSurfaceVariant
+import com.zhousl.aether.ui.theme.AetherPrimary
 import com.zhousl.aether.ui.theme.AetherScrim
+import com.zhousl.aether.ui.theme.AetherSurface
 import com.zhousl.aether.ui.theme.AetherSurfaceHigh
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -120,6 +127,7 @@ import kotlinx.coroutines.launch
 
 private enum class SettingsPage {
     Hub,
+    General,
     Providers,
     AddProvider,
     EditProvider,
@@ -139,6 +147,7 @@ private enum class SettingsPage {
 
 private fun SettingsPage.depth(): Int = when (this) {
     SettingsPage.Hub -> 0
+    SettingsPage.General,
     SettingsPage.Providers,
     SettingsPage.Personalization,
     SettingsPage.WebTools,
@@ -156,8 +165,6 @@ private fun SettingsPage.depth(): Int = when (this) {
     SettingsPage.EditMcpServer -> 2
 }
 
-private val AetherPrimary = Color(0xFF5C5C5C)
-
 // ──────────────────────────────────────────────────────────────────────────────
 // Animation constants
 // ──────────────────────────────────────────────────────────────────────────────
@@ -166,20 +173,23 @@ private const val PageTransitionDuration = 320
 private val PageTransitionEasing = CubicBezierEasing(0.22f, 0.84f, 0.18f, 1f)
 private val SettingsTopFadeHeight = 40.dp
 
+private fun tr(strings: AetherStrings, english: String, chinese: String): String =
+    if (strings.appLanguage == AppLanguage.SimplifiedChinese) chinese else english
+
 private fun settingsTopOverlayBodyGradient(): Brush = Brush.verticalGradient(
     colorStops = arrayOf(
-        0.0f to Color.White.copy(alpha = 0.96f),
-        0.18f to Color.White.copy(alpha = 0.86f),
-        0.42f to Color.White.copy(alpha = 0.48f),
-        0.72f to Color.White.copy(alpha = 0.22f),
-        1.0f to Color.White.copy(alpha = 0.12f),
+        0.0f to AetherBackground.copy(alpha = 0.96f),
+        0.18f to AetherBackground.copy(alpha = 0.86f),
+        0.42f to AetherBackground.copy(alpha = 0.48f),
+        0.72f to AetherBackground.copy(alpha = 0.22f),
+        1.0f to AetherBackground.copy(alpha = 0.12f),
     )
 )
 
 private fun settingsTopOverlayTailGradient(): Brush = Brush.verticalGradient(
     colorStops = arrayOf(
-        0.0f to Color.White.copy(alpha = 0.12f),
-        0.42f to Color.White.copy(alpha = 0.05f),
+        0.0f to AetherBackground.copy(alpha = 0.12f),
+        0.42f to AetherBackground.copy(alpha = 0.05f),
         1.0f to Color.Transparent,
     )
 )
@@ -201,13 +211,31 @@ fun SettingsScreen(
     notifyOnTaskCompletion: Boolean,
     agentModeAuthorizationEnabled: Boolean,
     agentModeAuthorizationMethod: AgentModeAuthorizationMethod,
+    language: AppLanguage,
+    themeMode: AppThemeMode,
     agentModeDisplayState: AgentModeDisplayState,
     providerConfigs: List<LlmProviderConfig>,
     termuxSetupState: TermuxSetupState,
     installedSkills: List<com.zhousl.aether.data.InstalledSkill>,
     mcpServers: List<com.zhousl.aether.data.McpServerConfig>,
     isFetchingModels: Boolean,
-    onSave: (LlmProvider, String, String, String, String, String, Int, Boolean, Boolean, Boolean, AgentModeAuthorizationMethod) -> Unit,
+    onSave: (
+        LlmProvider,
+        String,
+        String,
+        String,
+        String,
+        String,
+        Int,
+        Boolean,
+        Boolean,
+        Boolean,
+        AgentModeAuthorizationMethod,
+        AppLanguage,
+        AppThemeMode,
+    ) -> Unit,
+    onUpdateLanguage: (AppLanguage) -> Unit,
+    onUpdateThemeMode: (AppThemeMode) -> Unit,
     onUpsertProviderConfig: (LlmProviderConfig) -> Unit,
     onRemoveProviderConfig: (String) -> Unit,
     onSetActiveProvider: (String) -> Unit,
@@ -257,6 +285,13 @@ fun SettingsScreen(
     var agentModeAuthorizationMethodValue by rememberSaveable {
         mutableStateOf(agentModeAuthorizationMethod)
     }
+    var languageValue by rememberSaveable {
+        mutableStateOf(language)
+    }
+    var themeModeValue by rememberSaveable {
+        mutableStateOf(themeMode)
+    }
+    val strings = remember(languageValue) { aetherStringsFor(languageValue) }
 
     // Track which provider is being edited
     var editingProviderId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -278,6 +313,8 @@ fun SettingsScreen(
             notifyOnTaskCompletionValue,
             agentModeAuthorizationEnabledValue,
             agentModeAuthorizationMethodValue,
+            languageValue,
+            themeModeValue,
         )
         onBack()
     }
@@ -298,6 +335,8 @@ fun SettingsScreen(
             notifyOnTaskCompletionValue,
             agentModeAuthorizationEnabledValue,
             agentModeAuthorizationMethodValue,
+            languageValue,
+            themeModeValue,
         )
         onReplayOnboarding()
     }
@@ -318,6 +357,8 @@ fun SettingsScreen(
             notifyOnTaskCompletionValue,
             agentModeAuthorizationEnabledValue,
             agentModeAuthorizationMethodValue,
+            languageValue,
+            themeModeValue,
         )
         onReplayFollowUpOnboarding()
     }
@@ -359,6 +400,11 @@ fun SettingsScreen(
     ) { targetPage ->
         when (targetPage) {
             SettingsPage.Hub -> SettingsHub(
+                strings = strings,
+                generalSettingsSummary = strings.generalSettingsSummary(
+                    language = languageValue,
+                    themeMode = themeModeValue,
+                ),
                 activeProviderName = providerConfigs.firstOrNull { it.isActive }?.name
                     ?: provider.displayName,
                 systemPromptSnippet = systemPromptValue.text.take(60),
@@ -386,6 +432,21 @@ fun SettingsScreen(
                 onReplayOnboarding = ::persistAndReplayOnboarding,
                 onNavigate = { currentPage = it.name },
                 onBack = ::persistAndExit,
+            )
+
+            SettingsPage.General -> GeneralSettingsPageV2(
+                strings = strings,
+                selectedLanguage = languageValue,
+                onLanguageSelected = {
+                    languageValue = it
+                    onUpdateLanguage(it)
+                },
+                selectedThemeMode = themeModeValue,
+                onThemeModeSelected = {
+                    themeModeValue = it
+                    onUpdateThemeMode(it)
+                },
+                onBack = { currentPage = SettingsPage.Hub.name },
             )
 
             SettingsPage.Providers -> ProvidersListPage(
@@ -426,18 +487,21 @@ fun SettingsScreen(
             }
 
             SettingsPage.Personalization -> PersonalizationPage(
+                title = strings.personalization,
                 systemPromptValue = systemPromptValue,
                 onSystemPromptChanged = { systemPromptValue = it },
                 onBack = { currentPage = SettingsPage.Hub.name },
             )
 
             SettingsPage.WebTools -> WebToolsPage(
+                title = strings.webTools,
                 tavilyApiKeyValue = tavilyApiKeyValue,
                 onTavilyApiKeyChanged = { tavilyApiKeyValue = it },
                 onBack = { currentPage = SettingsPage.Hub.name },
             )
 
             SettingsPage.Reliability -> ReliabilityPage(
+                title = strings.reliability,
                 llmInactivityReconnectTimeoutValue = llmInactivityReconnectTimeoutValue,
                 onLlmInactivityReconnectTimeoutChanged = { llmInactivityReconnectTimeoutValue = it },
                 keepTasksRunningInBackground = keepTasksRunningInBackgroundValue,
@@ -448,6 +512,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.Skills -> SkillsListPage(
+                title = strings.agentSkills,
                 installedSkills = installedSkills,
                 onToggleSkillEnabled = onToggleSkillEnabled,
                 onRemoveSkill = onRemoveSkill,
@@ -456,6 +521,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.AddSkill -> AddSkillPage(
+                title = strings.agentSkills,
                 onImportSkillFolder = onImportSkillFolder,
                 onImportSkillZip = { callback ->
                     onImportSkillZip { success ->
@@ -473,6 +539,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.McpServers -> McpServersListPage(
+                title = strings.mcpServers,
                 mcpServers = mcpServers,
                 onToggleMcpServerEnabled = onToggleMcpServerEnabled,
                 onRemoveMcpServer = onRemoveMcpServer,
@@ -485,6 +552,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.AddMcpServer -> AddMcpServerPage(
+                title = strings.mcpServers,
                 existingServer = null,
                 onSaveHttpMcpServer = { serverId, name, url, headers ->
                     onSaveHttpMcpServer(serverId, name, url, headers)
@@ -498,6 +566,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.EditMcpServer -> AddMcpServerPage(
+                title = strings.mcpServers,
                 existingServer = mcpServers.firstOrNull { it.id == editingMcpServerId },
                 onSaveHttpMcpServer = { serverId, name, url, headers ->
                     onSaveHttpMcpServer(serverId, name, url, headers)
@@ -511,6 +580,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.Termux -> TermuxSettingsPage(
+                title = strings.termux,
                 termuxSetupState = termuxSetupState,
                 onRequestTermuxPermission = onRequestTermuxPermission,
                 onOpenAppPermissions = onOpenAppPermissions,
@@ -522,6 +592,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.AgentMode -> AgentModeSettingsPage(
+                title = strings.agentMode,
                 agentModeAuthorizationEnabled = agentModeAuthorizationEnabledValue,
                 agentModeAuthorizationMethod = agentModeAuthorizationMethodValue,
                 onAgentModeAuthorizationEnabledChanged = { agentModeAuthorizationEnabledValue = it },
@@ -533,6 +604,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.Developer -> DeveloperSettingsPage(
+                title = strings.developerSettings,
                 onReplayFollowUpOnboarding = ::persistAndReplayFollowUpOnboarding,
                 onImportAppData = onImportAppData,
                 onExportAppData = onExportAppData,
@@ -540,6 +612,7 @@ fun SettingsScreen(
             )
 
             SettingsPage.About -> AboutPage(
+                title = strings.about,
                 onBack = { currentPage = SettingsPage.Hub.name },
             )
         }
@@ -552,6 +625,8 @@ fun SettingsScreen(
 
 @Composable
 private fun SettingsHub(
+    strings: AetherStrings,
+    generalSettingsSummary: String,
     activeProviderName: String,
     systemPromptSnippet: String,
     tavilyConfigured: Boolean,
@@ -591,37 +666,47 @@ private fun SettingsHub(
                     .navigationBarsPadding(),
             ) {
                 Spacer(Modifier.height(6.dp))
+                SettingsCardGroup {
+                    SettingsNavRow(
+                        icon = Icons.Rounded.AutoAwesome,
+                        title = strings.generalSettings,
+                        subtitle = generalSettingsSummary.ifBlank { strings.generalSettingsHubHint },
+                        onClick = { onNavigate(SettingsPage.General) },
+                    )
+                }
+
+                Spacer(Modifier.height(16.dp))
 
             // ── Configuration card ──
             SettingsCardGroup {
                 SettingsNavRow(
                     icon = Icons.Rounded.Cloud,
-                    title = "Model Providers",
+                    title = strings.modelProviders,
                     subtitle = activeProviderName,
                     onClick = { onNavigate(SettingsPage.Providers) },
                 )
                 CardDivider()
                 SettingsNavRow(
                     icon = Icons.Rounded.Person,
-                    title = "Personalization",
-                    subtitle = systemPromptSnippet.ifBlank { "Custom instructions" },
+                    title = strings.personalization,
+                    subtitle = systemPromptSnippet.ifBlank { strings.customInstructions },
                     onClick = { onNavigate(SettingsPage.Personalization) },
                 )
                 CardDivider()
                 SettingsNavRow(
                     icon = Icons.Rounded.Link,
-                    title = "Web Tools",
+                    title = strings.webTools,
                     subtitle = if (tavilyConfigured) {
-                        "Tavily search configured"
+                        strings.tavilyConfigured
                     } else {
-                        "URL fetch ready, Tavily not configured"
+                        strings.tavilyNotConfigured
                     },
                     onClick = { onNavigate(SettingsPage.WebTools) },
                 )
                 CardDivider()
                 SettingsNavRow(
                     icon = Icons.Rounded.Refresh,
-                    title = "Reliability",
+                    title = strings.reliability,
                     subtitle = reliabilitySummary,
                     onClick = { onNavigate(SettingsPage.Reliability) },
                 )
@@ -633,29 +718,29 @@ private fun SettingsHub(
             SettingsCardGroup {
                 SettingsNavRow(
                     icon = Icons.Rounded.Extension,
-                    title = "Agent Skills",
-                    subtitle = if (skillCount == 0) "No skills installed" else "$skillCount installed",
+                    title = strings.agentSkills,
+                    subtitle = strings.skillCountSummary(skillCount),
                     onClick = { onNavigate(SettingsPage.Skills) },
                 )
                 CardDivider()
                 SettingsNavRow(
                     icon = Icons.Rounded.Code,
-                    title = "MCP Servers",
-                    subtitle = if (mcpServerCount == 0) "No servers" else "$mcpServerCount configured",
+                    title = strings.mcpServers,
+                    subtitle = strings.serverCountSummary(mcpServerCount),
                     onClick = { onNavigate(SettingsPage.McpServers) },
                 )
                 CardDivider()
                 SettingsNavRow(
                     icon = Icons.Rounded.Terminal,
-                    title = "Termux",
-                    subtitle = if (termuxReady) "Connected" else "Setup required",
+                    title = strings.termux,
+                    subtitle = if (termuxReady) strings.connected else strings.setupRequired,
                     onClick = { onNavigate(SettingsPage.Termux) },
                 )
                 CardDivider()
                 SettingsNavRow(
                     icon = LucideIcons.MousePointer2,
-                    title = "Agent Mode",
-                    subtitle = "Authorization and virtual display",
+                    title = strings.agentMode,
+                    subtitle = strings.agentModeSubtitle,
                     onClick = { onNavigate(SettingsPage.AgentMode) },
                 )
             }
@@ -666,15 +751,15 @@ private fun SettingsHub(
             SettingsCardGroup {
                 SettingsNavRow(
                     icon = Icons.Rounded.AutoAwesome,
-                    title = "Get Started Tour",
-                    subtitle = "Replay the first-run landing and setup flow",
+                    title = strings.getStartedTour,
+                    subtitle = strings.getStartedTourSubtitle,
                     onClick = onReplayOnboarding,
                 )
                 CardDivider()
                 SettingsNavRow(
                     icon = Icons.Rounded.Code,
-                    title = "Developer Settings",
-                    subtitle = "Replay the follow-up onboarding flow",
+                    title = strings.developerSettings,
+                    subtitle = strings.developerSettingsSubtitle,
                     onClick = { onNavigate(SettingsPage.Developer) },
                 )
             }
@@ -684,7 +769,7 @@ private fun SettingsHub(
             SettingsCardGroup {
                 SettingsNavRow(
                     icon = Icons.Rounded.Info,
-                    title = "About",
+                    title = strings.about,
                     subtitle = "Release ${BuildConfig.VERSION_NAME}",
                     onClick = { onNavigate(SettingsPage.About) },
                 )
@@ -695,7 +780,7 @@ private fun SettingsHub(
 
             SettingsTopBarOverlay(
                 modifier = Modifier.align(Alignment.TopCenter),
-                title = "Settings",
+                title = strings.settings,
                 onBack = onBack,
                 onBodyHeightChanged = { topBarBodyHeightPx = it },
             )
@@ -708,6 +793,149 @@ private fun SettingsHub(
 // ──────────────────────────────────────────────────────────────────────────────
 
 @Composable
+private fun GeneralSettingsPage(
+    strings: AetherStrings,
+    selectedLanguage: AppLanguage,
+    onLanguageSelected: (AppLanguage) -> Unit,
+    selectedThemeMode: AppThemeMode,
+    onThemeModeSelected: (AppThemeMode) -> Unit,
+    onBack: () -> Unit,
+) {
+    SubPageScaffold(title = strings.generalSettings, onBack = onBack) {
+        SettingsCardGroup {
+            Text(
+                text = strings.language,
+                style = MaterialTheme.typography.titleMedium,
+                color = AetherOnSurface,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = strings.languageDescription,
+                style = MaterialTheme.typography.bodySmall,
+                color = AetherOnSurfaceVariant,
+            )
+            Spacer(Modifier.height(14.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                AppLanguage.entries.forEach { option ->
+                    SettingsChoiceRow(
+                        title = strings.languageDisplayName(option),
+                        subtitle = if (option == AppLanguage.English) {
+                            "English interface"
+                        } else {
+                            "简体中文界面"
+                        },
+                        selected = option == selectedLanguage,
+                        onClick = { onLanguageSelected(option) },
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        SettingsCardGroup {
+            Text(
+                text = strings.theme,
+                style = MaterialTheme.typography.titleMedium,
+                color = AetherOnSurface,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = strings.themeDescription,
+                style = MaterialTheme.typography.bodySmall,
+                color = AetherOnSurfaceVariant,
+            )
+            Spacer(Modifier.height(14.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                AppThemeMode.entries.forEach { option ->
+                    SettingsChoiceRow(
+                        title = strings.themeDisplayName(option),
+                        subtitle = if (option == AppThemeMode.Light) {
+                            strings.lightThemeSubtitle
+                        } else {
+                            strings.darkThemeSubtitle
+                        },
+                        selected = option == selectedThemeMode,
+                        onClick = { onThemeModeSelected(option) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class SelectionOption(
+    val key: String,
+    val title: String,
+    val subtitle: String,
+    val selected: Boolean,
+    val onClick: () -> Unit,
+)
+
+@Composable
+private fun GeneralSettingsPageV2(
+    strings: AetherStrings,
+    selectedLanguage: AppLanguage,
+    onLanguageSelected: (AppLanguage) -> Unit,
+    selectedThemeMode: AppThemeMode,
+    onThemeModeSelected: (AppThemeMode) -> Unit,
+    onBack: () -> Unit,
+) {
+    SubPageScaffold(title = strings.generalSettings, onBack = onBack) {
+        SettingsCardGroup {
+            SelectionDropdownField(
+                label = strings.language,
+                supportingText = strings.languageDescription,
+                selectedLabel = strings.languageDisplayName(selectedLanguage),
+                options = AppLanguage.entries.map { option ->
+                    SelectionOption(
+                        key = option.storageValue,
+                        title = strings.languageDisplayName(option),
+                        subtitle = if (option == AppLanguage.English) {
+                            "English interface"
+                        } else {
+                            "简体中文界面"
+                        },
+                        selected = option == selectedLanguage,
+                        onClick = { onLanguageSelected(option) },
+                    )
+                },
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        SettingsCardGroup {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = strings.theme,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = AetherOnSurface,
+                )
+                ThemeModeToggle(
+                    isDark = selectedThemeMode == AppThemeMode.Dark,
+                    onToggle = {
+                        onThemeModeSelected(
+                            if (selectedThemeMode == AppThemeMode.Dark) {
+                                AppThemeMode.Light
+                            } else {
+                                AppThemeMode.Dark
+                            }
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun ProvidersListPage(
     providerConfigs: List<LlmProviderConfig>,
     onSetActive: (String) -> Unit,
@@ -716,8 +944,9 @@ private fun ProvidersListPage(
     onAddNew: () -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     SubPageScaffold(
-        title = "Model Providers",
+        title = strings.modelProviders,
         onBack = onBack,
         trailingIcon = Icons.Rounded.Add,
         onTrailingAction = onAddNew,
@@ -731,19 +960,19 @@ private fun ProvidersListPage(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(
-                        "No providers configured",
+                        tr(strings, "No providers configured", "未配置模型提供方"),
                         style = MaterialTheme.typography.titleMedium,
                         color = AetherOnSurface,
                     )
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Add a provider to connect to an LLM API.",
+                        tr(strings, "Add a provider to connect to an LLM API.", "添加一个提供方以连接 LLM API。"),
                         style = MaterialTheme.typography.bodyMedium,
                         color = AetherOnSurfaceVariant,
                     )
                     Spacer(Modifier.height(16.dp))
                     SettingsActionButton(
-                        label = "Add Provider",
+                        label = tr(strings, "Add Provider", "添加提供方"),
                         onClick = onAddNew,
                     )
                 }
@@ -769,6 +998,7 @@ private fun ProviderCard(
     onEdit: () -> Unit,
     onRemove: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -795,7 +1025,7 @@ private fun ProviderCard(
             if (config.isActive) {
                 Icon(
                     Icons.Rounded.Check,
-                    contentDescription = "Active",
+                    contentDescription = tr(strings, "Active", "当前启用"),
                     tint = Color.White,
                     modifier = Modifier.size(14.dp),
                 )
@@ -830,7 +1060,7 @@ private fun ProviderCard(
         IconButton(onClick = onEdit) {
             Icon(
                 Icons.Rounded.Edit,
-                contentDescription = "Edit",
+                contentDescription = tr(strings, "Edit", "编辑"),
                 tint = AetherOnSurfaceVariant,
             )
         }
@@ -838,7 +1068,7 @@ private fun ProviderCard(
         IconButton(onClick = onRemove) {
             Icon(
                 Icons.Rounded.Delete,
-                contentDescription = "Remove",
+                contentDescription = tr(strings, "Remove", "移除"),
                 tint = Color(0xFFD25757),
             )
         }
@@ -857,11 +1087,12 @@ private fun ProviderEditPage(
     onFetchModels: (LlmProviderConfig, (List<String>) -> Unit) -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     val isNew = existingConfig == null
     val formState = rememberProviderFormState(existingConfig)
 
     SubPageScaffold(
-        title = if (isNew) "Add Provider" else "Edit Provider",
+        title = if (isNew) tr(strings, "Add Provider", "添加提供方") else tr(strings, "Edit Provider", "编辑提供方"),
         onBack = onBack,
         trailingIcon = Icons.Rounded.Check,
         trailingEnabled = formState.isValid,
@@ -881,19 +1112,21 @@ private fun ProviderEditPage(
 
 @Composable
 private fun PersonalizationPage(
+    title: String,
     systemPromptValue: TextFieldValue,
     onSystemPromptChanged: (TextFieldValue) -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     SubPageScaffold(
-        title = "Personalization",
+        title = title,
         onBack = onBack,
         trailingIcon = Icons.Rounded.Check,
         onTrailingAction = onBack,
     ) {
         SettingsCardGroup {
             ChatGptTextField(
-                label = "Custom instructions",
+                label = strings.customInstructions,
                 value = systemPromptValue,
                 onValueChange = onSystemPromptChanged,
                 minLines = 8,
@@ -902,7 +1135,11 @@ private fun PersonalizationPage(
 
         Spacer(Modifier.height(8.dp))
         Text(
-            text = "This is the system prompt Aether uses in every conversation. It doesn't affect tool capabilities.",
+            text = tr(
+                strings,
+                "This is the system prompt Aether uses in every conversation. It doesn't affect tool capabilities.",
+                "这是 Aether 在每次对话中使用的系统提示词，不会改变工具能力。",
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -916,6 +1153,7 @@ private fun PersonalizationPage(
 
 @Composable
 private fun ReliabilityPage(
+    title: String,
     llmInactivityReconnectTimeoutValue: TextFieldValue,
     onLlmInactivityReconnectTimeoutChanged: (TextFieldValue) -> Unit,
     keepTasksRunningInBackground: Boolean,
@@ -924,14 +1162,15 @@ private fun ReliabilityPage(
     onNotifyOnTaskCompletionChanged: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     SubPageScaffold(
-        title = "Reliability",
+        title = title,
         onBack = onBack,
         trailingIcon = Icons.Rounded.Check,
         onTrailingAction = onBack,
     ) {
         Text(
-            text = "Multitasking",
+            text = tr(strings, "Multitasking", "后台运行"),
             style = MaterialTheme.typography.labelLarge,
             color = AetherOnSurface,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -944,15 +1183,15 @@ private fun ReliabilityPage(
                 verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 SettingsToggleRow(
-                    title = "Keep tasks running in background",
-                    subtitle = "Uses an Android foreground service so active chats can keep working after you leave Aether.",
+                    title = tr(strings, "Keep tasks running in background", "保持任务在后台运行"),
+                    subtitle = tr(strings, "Uses an Android foreground service so active chats can keep working after you leave Aether.", "通过 Android 前台服务让正在运行的对话在离开 Aether 后继续执行。"),
                     checked = keepTasksRunningInBackground,
                     onCheckedChange = onKeepTasksRunningInBackgroundChanged,
                 )
                 Spacer(Modifier.height(4.dp))
                 SettingsToggleRow(
-                    title = "Notify when background tasks finish",
-                    subtitle = "Shows a completion alert when a run ends while Aether is not on screen.",
+                    title = tr(strings, "Notify when background tasks finish", "后台任务结束时通知"),
+                    subtitle = tr(strings, "Shows a completion alert when a run ends while Aether is not on screen.", "当 Aether 不在前台且一次运行结束时显示完成提醒。"),
                     checked = notifyOnTaskCompletion,
                     onCheckedChange = onNotifyOnTaskCompletionChanged,
                 )
@@ -961,7 +1200,7 @@ private fun ReliabilityPage(
 
         Spacer(Modifier.height(16.dp))
         Text(
-            text = "Reconnect",
+            text = tr(strings, "Reconnect", "重连"),
             style = MaterialTheme.typography.labelLarge,
             color = AetherOnSurface,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -970,7 +1209,7 @@ private fun ReliabilityPage(
 
         SettingsCardGroup {
             ChatGptTextField(
-                label = "Reconnect after idle seconds",
+                label = tr(strings, "Reconnect after idle seconds", "空闲多少秒后重连"),
                 value = llmInactivityReconnectTimeoutValue,
                 onValueChange = {
                     val digitsOnly = it.text.filter(Char::isDigit)
@@ -987,7 +1226,7 @@ private fun ReliabilityPage(
 
         Spacer(Modifier.height(8.dp))
         Text(
-            text = "If a request produces no response activity at all for this many seconds, Aether cancels that attempt and reconnects with backoff. Range: 30-3600 seconds.",
+            text = tr(strings, "If a request produces no response activity at all for this many seconds, Aether cancels that attempt and reconnects with backoff. Range: 30-3600 seconds.", "如果一次请求在这么多秒内完全没有任何响应活动，Aether 会取消该尝试并按退避策略重新连接。范围：30-3600 秒。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -997,19 +1236,21 @@ private fun ReliabilityPage(
 
 @Composable
 private fun WebToolsPage(
+    title: String,
     tavilyApiKeyValue: TextFieldValue,
     onTavilyApiKeyChanged: (TextFieldValue) -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     SubPageScaffold(
-        title = "Web Tools",
+        title = title,
         onBack = onBack,
         trailingIcon = Icons.Rounded.Check,
         onTrailingAction = onBack,
     ) {
         SettingsCardGroup {
             ChatGptTextField(
-                label = "Tavily API Key",
+                label = tr(strings, "Tavily API Key", "Tavily API 密钥"),
                 value = tavilyApiKeyValue,
                 onValueChange = onTavilyApiKeyChanged,
             )
@@ -1017,7 +1258,7 @@ private fun WebToolsPage(
 
         Spacer(Modifier.height(8.dp))
         Text(
-            text = "fetch_web_url works without extra setup and converts pages to Markdown on-device. tavily_search uses this API key for public web search.",
+            text = tr(strings, "fetch_web_url works without extra setup and converts pages to Markdown on-device. tavily_search uses this API key for public web search.", "fetch_web_url 无需额外设置即可使用，并会在设备上把网页转换为 Markdown。tavily_search 会使用这个密钥进行公网搜索。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -1027,20 +1268,22 @@ private fun WebToolsPage(
 
 @Composable
 private fun SkillsListPage(
+    title: String,
     installedSkills: List<com.zhousl.aether.data.InstalledSkill>,
     onToggleSkillEnabled: (String, Boolean) -> Unit,
     onRemoveSkill: (String) -> Unit,
     onAddNew: () -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     SubPageScaffold(
-        title = "Agent Skills",
+        title = title,
         onBack = onBack,
         trailingIcon = Icons.Rounded.Add,
         onTrailingAction = onAddNew,
     ) {
         Text(
-            text = "Manage installed skills and keep only the bundles you want Aether to use in chat.",
+            text = tr(strings, "Manage installed skills and keep only the bundles you want Aether to use in chat.", "管理已安装技能，只保留你希望 Aether 在聊天中使用的能力包。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -1057,19 +1300,19 @@ private fun SkillsListPage(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(
-                        "No skills installed",
+                        tr(strings, "No skills installed", "未安装技能"),
                         style = MaterialTheme.typography.titleMedium,
                         color = AetherOnSurface,
                     )
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Import skills from a folder, zip, or remote URL.",
+                        tr(strings, "Import skills from a folder, zip, or remote URL.", "可从文件夹、zip 包或远程 URL 导入技能。"),
                         style = MaterialTheme.typography.bodyMedium,
                         color = AetherOnSurfaceVariant,
                     )
                     Spacer(Modifier.height(16.dp))
                     SettingsActionButton(
-                        label = "Add Skill",
+                        label = tr(strings, "Add Skill", "添加技能"),
                         onClick = onAddNew,
                     )
                 }
@@ -1093,6 +1336,7 @@ private fun SkillCard(
     onToggleEnabled: (Boolean) -> Unit,
     onRemove: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var expanded by rememberSaveable(skill.id) { mutableStateOf(false) }
     Column(
         modifier = Modifier
@@ -1129,7 +1373,7 @@ private fun SkillCard(
             IconButton(onClick = { expanded = !expanded }, modifier = Modifier.size(36.dp)) {
                 Icon(
                     if (expanded) Icons.Rounded.ArrowDropDown else Icons.AutoMirrored.Rounded.ArrowForwardIos,
-                    contentDescription = if (expanded) "Collapse" else "Expand",
+                    contentDescription = if (expanded) tr(strings, "Collapse", "收起") else tr(strings, "Expand", "展开"),
                     tint = AetherOnSurfaceVariant,
                     modifier = Modifier.size(20.dp),
                 )
@@ -1137,7 +1381,7 @@ private fun SkillCard(
             IconButton(onClick = onRemove, modifier = Modifier.size(36.dp)) {
                 Icon(
                     Icons.Rounded.Delete,
-                    contentDescription = "Remove",
+                    contentDescription = tr(strings, "Remove", "移除"),
                     tint = Color(0xFFD25757),
                     modifier = Modifier.size(20.dp),
                 )
@@ -1154,16 +1398,16 @@ private fun SkillCard(
         if (expanded) {
             Spacer(Modifier.height(14.dp))
             Spacer(Modifier.height(14.dp))
-            DetailLine("Skill ID", skill.id)
-            DetailLine("Files", "${skill.resourceEntries.size}")
-            DetailLine("Allowed tools", skill.allowedTools.ifEmpty { listOf("Any") }.joinToString(", "))
+            DetailLine(tr(strings, "Skill ID", "技能 ID"), skill.id)
+            DetailLine(tr(strings, "Files", "文件数"), "${skill.resourceEntries.size}")
+            DetailLine(tr(strings, "Allowed tools", "允许的工具"), skill.allowedTools.ifEmpty { listOf(tr(strings, "Any", "任意")) }.joinToString(", "))
             if (skill.compatibility.isNotBlank()) {
-                DetailLine("Compatibility", skill.compatibility)
+                DetailLine(tr(strings, "Compatibility", "兼容性"), skill.compatibility)
             }
             if (skill.source.label.isNotBlank()) {
-                DetailLine("Source", skill.source.label)
+                DetailLine(tr(strings, "Source", "来源"), skill.source.label)
             }
-            DetailLine("Path", skill.skillRootPath)
+            DetailLine(tr(strings, "Path", "路径"), skill.skillRootPath)
         }
     }
 }
@@ -1174,6 +1418,7 @@ private fun SkillCard(
 
 @Composable
 private fun AddSkillPage(
+    title: String,
     onImportSkillFolder: () -> Unit,
     onImportSkillZip: ((Boolean) -> Unit) -> Unit,
     onInstallSkillUrl: (String, (Boolean) -> Unit) -> Unit,
@@ -1184,12 +1429,17 @@ private fun AddSkillPage(
         mutableStateOf(TextFieldValue(""))
     }
     var isInstalling by remember { mutableStateOf(false) }
+    val strings = rememberAetherStrings()
 
-    val tabOptions = listOf("Folder", "Zip", "URL")
+    val tabOptions = listOf(
+        tr(strings, "Folder", "文件夹"),
+        "Zip",
+        "URL",
+    )
 
-    SubPageScaffold(title = "Add Skill", onBack = onBack) {
+    SubPageScaffold(title = title, onBack = onBack) {
         Text(
-            text = "Import Agent Skills from a local folder, zip file, or remote URL.",
+            text = tr(strings, "Import Agent Skills from a local folder, zip file, or remote URL.", "从本地文件夹、zip 文件或远程 URL 导入 Agent 技能。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -1236,13 +1486,13 @@ private fun AddSkillPage(
                         )
                         Spacer(Modifier.height(12.dp))
                         Text(
-                            "Select a folder containing SKILL.md",
+                            tr(strings, "Select a folder containing SKILL.md", "选择包含 SKILL.md 的文件夹"),
                             style = MaterialTheme.typography.bodyMedium,
                             color = AetherOnSurfaceVariant,
                         )
                         Spacer(Modifier.height(16.dp))
                         SettingsActionButton(
-                            label = "Choose Folder",
+                            label = tr(strings, "Choose Folder", "选择文件夹"),
                             onClick = {
                                 onImportSkillFolder()
                                 // Will navigate back via callback on success
@@ -1269,13 +1519,13 @@ private fun AddSkillPage(
                         )
                         Spacer(Modifier.height(12.dp))
                         Text(
-                            "Select a .zip file containing SKILL.md",
+                            tr(strings, "Select a .zip file containing SKILL.md", "选择包含 SKILL.md 的 .zip 文件"),
                             style = MaterialTheme.typography.bodyMedium,
                             color = AetherOnSurfaceVariant,
                         )
                         Spacer(Modifier.height(16.dp))
                         SettingsActionButton(
-                            label = "Choose Zip",
+                            label = tr(strings, "Choose Zip", "选择 Zip"),
                             onClick = {
                                 onImportSkillZip {}
                             },
@@ -1288,7 +1538,7 @@ private fun AddSkillPage(
                 // URL import
                 SettingsCardGroup {
                     ChatGptTextField(
-                        label = "Remote skill URL",
+                        label = tr(strings, "Remote skill URL", "远程技能 URL"),
                         value = skillUrlValue,
                         onValueChange = { skillUrlValue = it },
                     )
@@ -1296,7 +1546,7 @@ private fun AddSkillPage(
 
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = "GitHub repo/tree URLs and direct zip links are supported.",
+                    text = tr(strings, "GitHub repo/tree URLs and direct zip links are supported.", "支持 GitHub 仓库或目录链接，以及直接的 zip 下载链接。"),
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 4.dp),
@@ -1315,11 +1565,11 @@ private fun AddSkillPage(
                             color = AetherPrimary,
                         )
                         Spacer(Modifier.width(12.dp))
-                        Text("Installing...", color = AetherOnSurfaceVariant)
+                        Text(tr(strings, "Installing...", "安装中..."), color = AetherOnSurfaceVariant)
                     }
                 } else {
                     SettingsActionButton(
-                        label = "Install from URL",
+                        label = tr(strings, "Install from URL", "从 URL 安装"),
                         onClick = {
                             if (skillUrlValue.text.isNotBlank()) {
                                 isInstalling = true
@@ -1345,6 +1595,7 @@ private fun AddSkillPage(
 
 @Composable
 private fun McpServersListPage(
+    title: String,
     mcpServers: List<com.zhousl.aether.data.McpServerConfig>,
     onToggleMcpServerEnabled: (String, Boolean) -> Unit,
     onRemoveMcpServer: (String) -> Unit,
@@ -1352,14 +1603,15 @@ private fun McpServersListPage(
     onAddNew: () -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     SubPageScaffold(
-        title = "MCP Servers",
+        title = title,
         onBack = onBack,
         trailingIcon = Icons.Rounded.Add,
         onTrailingAction = onAddNew,
     ) {
         Text(
-            text = "Manage MCP servers, inspect each transport config, and keep only the connections you want active.",
+            text = tr(strings, "Manage MCP servers, inspect each transport config, and keep only the connections you want active.", "管理 MCP 服务器，查看各自的传输配置，只保留你想启用的连接。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -1376,19 +1628,19 @@ private fun McpServersListPage(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(
-                        "No MCP servers",
+                        tr(strings, "No MCP servers", "没有 MCP 服务器"),
                         style = MaterialTheme.typography.titleMedium,
                         color = AetherOnSurface,
                     )
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Add HTTP or stdio servers to extend capabilities.",
+                        tr(strings, "Add HTTP or stdio servers to extend capabilities.", "添加 HTTP 或 stdio 服务器以扩展能力。"),
                         style = MaterialTheme.typography.bodyMedium,
                         color = AetherOnSurfaceVariant,
                     )
                     Spacer(Modifier.height(16.dp))
                     SettingsActionButton(
-                        label = "Add Server",
+                        label = tr(strings, "Add Server", "添加服务器"),
                         onClick = onAddNew,
                     )
                 }
@@ -1414,6 +1666,7 @@ private fun McpServerCard(
     onEdit: () -> Unit,
     onRemove: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     var expanded by rememberSaveable(server.id) { mutableStateOf(false) }
     Column(
         modifier = Modifier
@@ -1446,7 +1699,7 @@ private fun McpServerCard(
             IconButton(onClick = { expanded = !expanded }, modifier = Modifier.size(36.dp)) {
                 Icon(
                     if (expanded) Icons.Rounded.ArrowDropDown else Icons.AutoMirrored.Rounded.ArrowForwardIos,
-                    contentDescription = if (expanded) "Collapse" else "Expand",
+                    contentDescription = if (expanded) tr(strings, "Collapse", "收起") else tr(strings, "Expand", "展开"),
                     tint = AetherOnSurfaceVariant,
                     modifier = Modifier.size(20.dp),
                 )
@@ -1454,7 +1707,7 @@ private fun McpServerCard(
             IconButton(onClick = onEdit, modifier = Modifier.size(36.dp)) {
                 Icon(
                     Icons.Rounded.Edit,
-                    contentDescription = "Edit",
+                    contentDescription = tr(strings, "Edit", "编辑"),
                     tint = AetherOnSurface,
                     modifier = Modifier.size(18.dp),
                 )
@@ -1462,7 +1715,7 @@ private fun McpServerCard(
             IconButton(onClick = onRemove, modifier = Modifier.size(36.dp)) {
                 Icon(
                     Icons.Rounded.Delete,
-                    contentDescription = "Remove",
+                    contentDescription = tr(strings, "Remove", "移除"),
                     tint = Color(0xFFD25757),
                     modifier = Modifier.size(20.dp),
                 )
@@ -1479,25 +1732,25 @@ private fun McpServerCard(
         if (expanded) {
             Spacer(Modifier.height(14.dp))
             Spacer(Modifier.height(14.dp))
-            DetailLine("Server ID", server.id)
-            DetailLine("Quick action", server.quickActionLabel())
-            DetailLine("Transport", server.transport.transportType.storageValue.uppercase())
+            DetailLine(tr(strings, "Server ID", "服务器 ID"), server.id)
+            DetailLine(tr(strings, "Quick action", "快捷操作"), server.quickActionLabel())
+            DetailLine(tr(strings, "Transport", "传输方式"), server.transport.transportType.storageValue.uppercase())
             when (val transport = server.transport) {
                 is com.zhousl.aether.data.McpTransportConfig.StreamableHttp -> {
                     DetailLine("URL", transport.url)
-                    DetailLine("Headers", transport.headers.size.toString())
+                    DetailLine(tr(strings, "Headers", "请求头"), transport.headers.size.toString())
                 }
 
                 is com.zhousl.aether.data.McpTransportConfig.StdIo -> {
-                    DetailLine("Command", transport.command)
+                    DetailLine(tr(strings, "Command", "命令"), transport.command)
                     if (transport.workingDirectory.isNotBlank()) {
-                        DetailLine("Working dir", transport.workingDirectory)
+                        DetailLine(tr(strings, "Working dir", "工作目录"), transport.workingDirectory)
                     }
-                    DetailLine("Environment", transport.environment.size.toString())
+                    DetailLine(tr(strings, "Environment", "环境变量"), transport.environment.size.toString())
                 }
             }
-            DetailLine("Connect timeout", "${server.connectTimeoutMillis} ms")
-            DetailLine("Request timeout", "${server.requestTimeoutMillis} ms")
+            DetailLine(tr(strings, "Connect timeout", "连接超时"), "${server.connectTimeoutMillis} ms")
+            DetailLine(tr(strings, "Request timeout", "请求超时"), "${server.requestTimeoutMillis} ms")
         }
     }
 }
@@ -1508,11 +1761,13 @@ private fun McpServerCard(
 
 @Composable
 private fun AddMcpServerPage(
+    title: String,
     existingServer: com.zhousl.aether.data.McpServerConfig?,
     onSaveHttpMcpServer: (String?, String, String, String) -> Unit,
     onSaveStdIoMcpServer: (String?, String, String, String, String) -> Unit,
     onBack: () -> Unit,
 ) {
+    val strings = rememberAetherStrings()
     val isEditing = existingServer != null
     val existingHttpTransport = existingServer?.transport as? com.zhousl.aether.data.McpTransportConfig.StreamableHttp
     val existingStdIoTransport = existingServer?.transport as? com.zhousl.aether.data.McpTransportConfig.StdIo
@@ -1555,14 +1810,14 @@ private fun AddMcpServerPage(
         )
     }
 
-    val tabOptions = listOf("HTTP", "Stdio")
+    val tabOptions = listOf("HTTP", tr(strings, "Stdio", "标准输入输出"))
 
-    SubPageScaffold(title = if (isEditing) "Edit MCP Server" else "Add MCP Server", onBack = onBack) {
+    SubPageScaffold(title = title, onBack = onBack) {
         Text(
             text = if (isEditing) {
-                "Update the transport config and quick action source for this MCP server."
+                tr(strings, "Update the transport config and quick action source for this MCP server.", "更新这个 MCP 服务器的传输配置和快捷操作来源。")
             } else {
-                "Add an HTTP server for remote APIs or a stdio server for local Termux processes."
+                tr(strings, "Add an HTTP server for remote APIs or a stdio server for local Termux processes.", "添加用于远程 API 的 HTTP 服务器，或用于本地 Termux 进程的 stdio 服务器。")
             },
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
@@ -1596,22 +1851,22 @@ private fun AddMcpServerPage(
             0 -> {
                 // HTTP server
                 SettingsCardGroup {
-                    ChatGptTextField("Server name", httpServerNameValue) { httpServerNameValue = it }
+                    ChatGptTextField(tr(strings, "Server name", "服务器名称"), httpServerNameValue) { httpServerNameValue = it }
                     CardDivider()
-                    ChatGptTextField("Server URL", httpServerUrlValue) { httpServerUrlValue = it }
+                    ChatGptTextField(tr(strings, "Server URL", "服务器 URL"), httpServerUrlValue) { httpServerUrlValue = it }
                     CardDivider()
-                    ChatGptTextField("Headers", httpHeadersValue, minLines = 2) { httpHeadersValue = it }
+                    ChatGptTextField(tr(strings, "Headers", "请求头"), httpHeadersValue, minLines = 2) { httpHeadersValue = it }
                 }
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    "Optional headers, one KEY=VALUE per line.",
+                    tr(strings, "Optional headers, one KEY=VALUE per line.", "可选请求头，每行一个 KEY=VALUE。"),
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 4.dp),
                 )
                 Spacer(Modifier.height(16.dp))
                 SettingsActionButton(
-                    label = if (isEditing) "Save HTTP Server" else "Add HTTP Server",
+                    label = if (isEditing) tr(strings, "Save HTTP Server", "保存 HTTP 服务器") else tr(strings, "Add HTTP Server", "添加 HTTP 服务器"),
                     onClick = {
                         if (httpServerNameValue.text.isNotBlank() && httpServerUrlValue.text.isNotBlank()) {
                             onSaveHttpMcpServer(
@@ -1629,24 +1884,24 @@ private fun AddMcpServerPage(
             1 -> {
                 // Stdio server
                 SettingsCardGroup {
-                    ChatGptTextField("Server name", stdioServerNameValue) { stdioServerNameValue = it }
+                    ChatGptTextField(tr(strings, "Server name", "服务器名称"), stdioServerNameValue) { stdioServerNameValue = it }
                     CardDivider()
-                    ChatGptTextField("Command", stdioCommandValue, minLines = 2) { stdioCommandValue = it }
+                    ChatGptTextField(tr(strings, "Command", "命令"), stdioCommandValue, minLines = 2) { stdioCommandValue = it }
                     CardDivider()
-                    ChatGptTextField("Working directory", stdioWorkingDirectoryValue) { stdioWorkingDirectoryValue = it }
+                    ChatGptTextField(tr(strings, "Working directory", "工作目录"), stdioWorkingDirectoryValue) { stdioWorkingDirectoryValue = it }
                     CardDivider()
-                    ChatGptTextField("Environment", stdioEnvValue, minLines = 2) { stdioEnvValue = it }
+                    ChatGptTextField(tr(strings, "Environment", "环境变量"), stdioEnvValue, minLines = 2) { stdioEnvValue = it }
                 }
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    "Optional environment variables, one KEY=VALUE per line.",
+                    tr(strings, "Optional environment variables, one KEY=VALUE per line.", "可选环境变量，每行一个 KEY=VALUE。"),
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 4.dp),
                 )
                 Spacer(Modifier.height(16.dp))
                 SettingsActionButton(
-                    label = if (isEditing) "Save Stdio Server" else "Add Stdio Server",
+                    label = if (isEditing) tr(strings, "Save Stdio Server", "保存 Stdio 服务器") else tr(strings, "Add Stdio Server", "添加 Stdio 服务器"),
                     onClick = {
                         if (stdioServerNameValue.text.isNotBlank() && stdioCommandValue.text.isNotBlank()) {
                             onSaveStdIoMcpServer(
@@ -1671,6 +1926,7 @@ private fun AddMcpServerPage(
 
 @Composable
 private fun TermuxSettingsPage(
+    title: String,
     termuxSetupState: TermuxSetupState,
     onRequestTermuxPermission: () -> Unit,
     onOpenAppPermissions: () -> Unit,
@@ -1680,9 +1936,10 @@ private fun TermuxSettingsPage(
     onRefreshTermuxSetup: () -> Unit,
     onBack: () -> Unit,
 ) {
-    SubPageScaffold(title = "Termux", onBack = onBack) {
+    val strings = rememberAetherStrings()
+    SubPageScaffold(title = title, onBack = onBack) {
         Text(
-            text = "Aether runs bash through Termux. Finish setup here so tool calls work for every user without manual adb steps.",
+            text = tr(strings, "Aether runs bash through Termux. Finish setup here so tool calls work for every user without manual adb steps.", "Aether 通过 Termux 运行 bash。请在这里完成设置，让工具调用无需手动 adb 步骤即可正常工作。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -1693,17 +1950,17 @@ private fun TermuxSettingsPage(
         if (termuxSetupState.isReady) {
             SettingsCardGroup {
                 Column(modifier = Modifier.padding(16.dp)) {
-                    Text("Termux is connected", style = MaterialTheme.typography.labelLarge, color = AetherOnSurface)
+                    Text(tr(strings, "Termux is connected", "Termux 已连接"), style = MaterialTheme.typography.labelLarge, color = AetherOnSurface)
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        "Permission is granted and the setup probe succeeded.",
+                        tr(strings, "Permission is granted and the setup probe succeeded.", "权限已授予，且设置检测已成功。"),
                         style = MaterialTheme.typography.bodySmall,
                         color = AetherOnSurfaceVariant,
                     )
                 }
             }
             Spacer(Modifier.height(12.dp))
-            SettingsActionButton(label = "Refresh status", onClick = onRefreshTermuxSetup, modifier = Modifier.fillMaxWidth())
+            SettingsActionButton(label = tr(strings, "Refresh status", "刷新状态"), onClick = onRefreshTermuxSetup, modifier = Modifier.fillMaxWidth())
         } else {
             TermuxSetupNotice(
                 setupState = termuxSetupState,
@@ -1720,6 +1977,7 @@ private fun TermuxSettingsPage(
 
 @Composable
 private fun AgentModeSettingsPage(
+    title: String,
     agentModeAuthorizationEnabled: Boolean,
     agentModeAuthorizationMethod: AgentModeAuthorizationMethod,
     onAgentModeAuthorizationEnabledChanged: (Boolean) -> Unit,
@@ -1729,9 +1987,10 @@ private fun AgentModeSettingsPage(
     onRefreshAgentModeDisplays: () -> Unit,
     onBack: () -> Unit,
 ) {
-    SubPageScaffold(title = "Agent Mode", onBack = onBack) {
+    val strings = rememberAetherStrings()
+    SubPageScaffold(title = title, onBack = onBack) {
         Text(
-            text = "Authorize isolated virtual-display tools with Shizuku or Root. Skip this on devices without either option.",
+            text = tr(strings, "Authorize isolated virtual-display tools with Shizuku or Root. Skip this on devices without either option.", "通过 Shizuku 或 Root 为隔离虚拟显示工具授权。没有这些条件的设备可以先跳过。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -1742,14 +2001,14 @@ private fun AgentModeSettingsPage(
         SettingsCardGroup {
             Column(modifier = Modifier.padding(16.dp)) {
                 SettingsToggleRow(
-                    title = "Agent Mode authorization",
-                    subtitle = "Enables isolated virtual-display tools. Requires Shizuku or Root.",
+                    title = tr(strings, "Agent Mode authorization", "Agent 模式授权"),
+                    subtitle = tr(strings, "Enables isolated virtual-display tools. Requires Shizuku or Root.", "启用隔离虚拟显示工具。需要 Shizuku 或 Root。"),
                     checked = agentModeAuthorizationEnabled,
                     onCheckedChange = onAgentModeAuthorizationEnabledChanged,
                 )
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    text = "Authorization method",
+                    text = tr(strings, "Authorization method", "授权方式"),
                     style = MaterialTheme.typography.labelLarge,
                     color = AetherOnSurface,
                 )
@@ -1759,8 +2018,8 @@ private fun AgentModeSettingsPage(
                         SettingsChoiceRow(
                             title = method.displayName,
                             subtitle = when (method) {
-                                AgentModeAuthorizationMethod.Shizuku -> "Uses an elevated Shizuku service."
-                                AgentModeAuthorizationMethod.Root -> "Uses root shell for privileged input."
+                                AgentModeAuthorizationMethod.Shizuku -> tr(strings, "Uses an elevated Shizuku service.", "使用提权后的 Shizuku 服务。")
+                                AgentModeAuthorizationMethod.Root -> tr(strings, "Uses root shell for privileged input.", "使用 root shell 进行特权输入。")
                             },
                             selected = agentModeAuthorizationMethod == method,
                             onClick = { onAgentModeAuthorizationMethodChanged(method) },
@@ -1769,7 +2028,7 @@ private fun AgentModeSettingsPage(
                 }
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = "Shizuku mode creates the display from a Shizuku user service so apps can render off the main screen. Root mode remains experimental.",
+                    text = tr(strings, "Shizuku mode creates the display from a Shizuku user service so apps can render off the main screen. Root mode remains experimental.", "Shizuku 模式会通过用户服务创建显示，让应用在主屏幕之外渲染。Root 模式仍属实验特性。"),
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                 )
@@ -1781,16 +2040,16 @@ private fun AgentModeSettingsPage(
         SettingsCardGroup {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = "Virtual Display",
+                    text = tr(strings, "Virtual Display", "虚拟显示"),
                     style = MaterialTheme.typography.labelLarge,
                     color = AetherOnSurface,
                 )
                 Spacer(Modifier.height(6.dp))
                 Text(
                     text = if (agentModeDisplayState.isActive) {
-                        "Display ${agentModeDisplayState.displayId ?: "-"} is active at ${agentModeDisplayState.width} x ${agentModeDisplayState.height}."
+                        tr(strings, "Display ${agentModeDisplayState.displayId ?: "-"} is active at ${agentModeDisplayState.width} x ${agentModeDisplayState.height}.", "显示 ${agentModeDisplayState.displayId ?: "-"} 正在运行，分辨率为 ${agentModeDisplayState.width} x ${agentModeDisplayState.height}。")
                     } else {
-                        "No Agent Mode virtual display is active."
+                        tr(strings, "No Agent Mode virtual display is active.", "当前没有活动的 Agent 模式虚拟显示。")
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
@@ -1807,14 +2066,14 @@ private fun AgentModeSettingsPage(
                 }
                 Spacer(Modifier.height(12.dp))
                 Text(
-                    text = "Visible displays",
+                    text = tr(strings, "Visible displays", "可见显示"),
                     style = MaterialTheme.typography.labelMedium,
                     color = AetherOnSurface,
                 )
                 Spacer(Modifier.height(8.dp))
                 if (agentModeDisplayState.displays.isEmpty()) {
                     Text(
-                        text = "No displays are currently visible to Aether.",
+                        text = tr(strings, "No displays are currently visible to Aether.", "当前没有 Aether 可见的显示。"),
                         style = MaterialTheme.typography.bodySmall,
                         color = AetherOnSurfaceVariant,
                     )
@@ -1826,20 +2085,24 @@ private fun AgentModeSettingsPage(
                                     .fillMaxWidth()
                                     .clip(RoundedCornerShape(14.dp))
                                     .background(
-                                        if (display.isAetherDisplay) Color(0xFFEDEBFF) else AetherBackground
+                                if (display.isAetherDisplay) {
+                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.78f)
+                                } else {
+                                    AetherBackground
+                                }
                                     )
                                     .padding(horizontal = 14.dp, vertical = 12.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(
-                                        text = "Display ${display.displayId}",
+                                        text = tr(strings, "Display ${display.displayId}", "显示 ${display.displayId}"),
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = AetherOnSurface,
                                     )
                                     Text(
                                         text = listOf(
-                                            display.name.ifBlank { "Unnamed" },
+                                            display.name.ifBlank { tr(strings, "Unnamed", "未命名") },
                                             "${display.width} x ${display.height}",
                                             if (display.isAetherDisplay) "Aether" else "",
                                         ).filter { it.isNotBlank() }.joinToString(" · "),
@@ -1855,13 +2118,13 @@ private fun AgentModeSettingsPage(
                 }
                 Spacer(Modifier.height(16.dp))
                 SettingsActionButton(
-                    label = "Refresh displays",
+                    label = tr(strings, "Refresh displays", "刷新显示列表"),
                     onClick = onRefreshAgentModeDisplays,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Spacer(Modifier.height(10.dp))
                 SettingsActionButton(
-                    label = "Stop virtual display",
+                    label = tr(strings, "Stop virtual display", "停止虚拟显示"),
                     onClick = onStopAgentModeDisplay,
                     modifier = Modifier.fillMaxWidth(),
                     enabled = agentModeDisplayState.isActive,
@@ -1873,14 +2136,16 @@ private fun AgentModeSettingsPage(
 
 @Composable
 private fun DeveloperSettingsPage(
+    title: String,
     onReplayFollowUpOnboarding: () -> Unit,
     onImportAppData: () -> Unit,
     onExportAppData: () -> Unit,
     onBack: () -> Unit,
 ) {
-    SubPageScaffold(title = "Developer Settings", onBack = onBack) {
+    val strings = rememberAetherStrings()
+    SubPageScaffold(title = title, onBack = onBack) {
         Text(
-            text = "Developer-only tools and replay controls.",
+            text = tr(strings, "Developer-only tools and replay controls.", "仅面向开发者的工具与引导回放控制。"),
             style = MaterialTheme.typography.bodySmall,
             color = AetherOnSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -1891,25 +2156,25 @@ private fun DeveloperSettingsPage(
         SettingsCardGroup {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = "App Data",
+                    text = tr(strings, "App Data", "应用数据"),
                     style = MaterialTheme.typography.labelLarge,
                     color = AetherOnSurface,
                 )
                 Spacer(Modifier.height(6.dp))
                 Text(
-                    text = "Import or export the complete local Aether data set as JSON.",
+                    text = tr(strings, "Import or export the complete local Aether data set as JSON.", "以 JSON 形式导入或导出完整的本地 Aether 数据。"),
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                 )
                 Spacer(Modifier.height(16.dp))
                 SettingsActionButton(
-                    label = "Import app data",
+                    label = tr(strings, "Import app data", "导入应用数据"),
                     onClick = onImportAppData,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Spacer(Modifier.height(10.dp))
                 SettingsActionButton(
-                    label = "Export app data",
+                    label = tr(strings, "Export app data", "导出应用数据"),
                     onClick = onExportAppData,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -1921,19 +2186,19 @@ private fun DeveloperSettingsPage(
         SettingsCardGroup {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = "Replay Follow-up Tour",
+                    text = tr(strings, "Replay Follow-up Tour", "重播后续引导"),
                     style = MaterialTheme.typography.labelLarge,
                     color = AetherOnSurface,
                 )
                 Spacer(Modifier.height(6.dp))
                 Text(
-                    text = "Starts from Termux, then goes through Agent Mode, Tavily, Skills, and MCP.",
+                    text = tr(strings, "Starts from Termux, then goes through Agent Mode, Tavily, Skills, and MCP.", "从 Termux 开始，随后依次经过 Agent 模式、Tavily、技能和 MCP。"),
                     style = MaterialTheme.typography.bodySmall,
                     color = AetherOnSurfaceVariant,
                 )
                 Spacer(Modifier.height(16.dp))
                 SettingsActionButton(
-                    label = "Replay second part",
+                    label = tr(strings, "Replay second part", "重播第二部分"),
                     onClick = onReplayFollowUpOnboarding,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -1950,10 +2215,12 @@ private fun DeveloperSettingsPage(
 
 @Composable
 private fun AboutPage(
+    title: String,
     onBack: () -> Unit,
 ) {
-    val releaseLabel = "Release ${BuildConfig.VERSION_NAME}"
-    SubPageScaffold(title = "About", onBack = onBack) {
+    val strings = rememberAetherStrings()
+    val releaseLabel = tr(strings, "Release ${BuildConfig.VERSION_NAME}", "版本 ${BuildConfig.VERSION_NAME}")
+    SubPageScaffold(title = title, onBack = onBack) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1962,7 +2229,7 @@ private fun AboutPage(
         ) {
             Image(
                 painter = painterResource(R.drawable.aether_mark),
-                contentDescription = "Aether logo",
+                contentDescription = tr(strings, "Aether logo", "Aether 标志"),
                 modifier = Modifier.size(112.dp),
             )
             Spacer(Modifier.height(14.dp))
@@ -1982,11 +2249,11 @@ private fun AboutPage(
         Spacer(Modifier.height(24.dp))
 
         SettingsCardGroup {
-            AboutInfoRow(label = "Author", value = "Zhou-Shilin")
+            AboutInfoRow(label = tr(strings, "Author", "作者"), value = "Zhou-Shilin")
             CardDivider()
-            AboutInfoRow(label = "Version", value = releaseLabel)
+            AboutInfoRow(label = tr(strings, "Version", "版本"), value = releaseLabel)
             CardDivider()
-            AboutInfoRow(label = "Website", value = "github.com/Zhou-Shilin")
+            AboutInfoRow(label = tr(strings, "Website", "网站"), value = "github.com/Zhou-Shilin")
         }
     }
 }
@@ -2160,7 +2427,7 @@ private fun SettingsCircleButton(
             .size(44.dp)
             .shadow(10.dp, RoundedCornerShape(50), ambientColor = AetherScrim, spotColor = AetherScrim)
             .clip(RoundedCornerShape(50))
-            .background(if (enabled) Color.White else Color.White.copy(alpha = 0.55f))
+            .background(if (enabled) AetherSurface else AetherSurface.copy(alpha = 0.55f))
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
@@ -2348,7 +2615,7 @@ private fun ChatGptDropdownField(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier.background(Color.White),
+            modifier = Modifier.background(AetherSurface),
         ) {
             options.forEach { option ->
                 DropdownMenuItem(
@@ -2373,6 +2640,133 @@ private fun ChatGptDropdownField(
 // ── Action button ────────────────────────────────────────────────────────────
 
 @Composable
+private fun SelectionDropdownField(
+    label: String,
+    supportingText: String,
+    selectedLabel: String,
+    options: List<SelectionOption>,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = true }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleMedium,
+            color = AetherOnSurface,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = supportingText,
+            style = MaterialTheme.typography.bodySmall,
+            color = AetherOnSurfaceVariant,
+        )
+        Spacer(Modifier.height(14.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(AetherBackground)
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = selectedLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                color = AetherOnSurface,
+            )
+            Icon(
+                imageVector = Icons.Rounded.ArrowDropDown,
+                contentDescription = label,
+                tint = AetherOnSurfaceVariant,
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(AetherSurface),
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = {
+                        Column {
+                            Text(option.title, color = AetherOnSurface)
+                            Text(
+                                text = option.subtitle,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = AetherOnSurfaceVariant,
+                            )
+                        }
+                    },
+                    trailingIcon = if (option.selected) {
+                        { Icon(Icons.Rounded.Check, contentDescription = null, tint = AetherPrimary) }
+                    } else {
+                        null
+                    },
+                    onClick = {
+                        expanded = false
+                        option.onClick()
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemeModeToggle(
+    isDark: Boolean,
+    onToggle: () -> Unit,
+) {
+    val trackColor = if (isDark) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        AetherBackground
+    }
+    val thumbColor = if (isDark) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        AetherSurface
+    }
+    val icon = if (isDark) Icons.Rounded.DarkMode else Icons.Rounded.WbSunny
+    val iconTint = if (isDark) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        AetherOnSurfaceVariant
+    }
+
+    Box(
+        modifier = Modifier
+            .size(width = 68.dp, height = 38.dp)
+            .clip(CircleShape)
+            .background(trackColor)
+            .clickable(onClick = onToggle)
+            .padding(4.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .align(if (isDark) Alignment.CenterEnd else Alignment.CenterStart)
+                .size(30.dp)
+                .clip(CircleShape)
+                .background(thumbColor),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+@Composable
 private fun SettingsActionButton(
     label: String,
     onClick: () -> Unit,
@@ -2386,7 +2780,7 @@ private fun SettingsActionButton(
         shape = RoundedCornerShape(14.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = AetherPrimary,
-            contentColor = Color.White,
+            contentColor = AetherOnPrimary,
         ),
     ) {
         Text(label, style = MaterialTheme.typography.labelLarge)
@@ -2402,11 +2796,17 @@ private fun SmallChipButton(
     modifier: Modifier = Modifier,
     isDestructive: Boolean = false,
 ) {
-    val textColor = if (isDestructive) Color(0xFFD25757) else AetherOnSurface
+    val textColor = if (isDestructive) MaterialTheme.colorScheme.error else AetherOnSurface
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(10.dp))
-            .background(if (isDestructive) Color(0xFFFFF0F0) else AetherSurfaceHigh)
+            .background(
+                if (isDestructive) {
+                    MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.75f)
+                } else {
+                    AetherSurfaceHigh
+                }
+            )
             .clickable(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,
@@ -2486,38 +2886,39 @@ private fun SettingsChoiceRow(
     selected: Boolean,
     onClick: () -> Unit,
 ) {
-      Row(
-          modifier = Modifier
-              .fillMaxWidth()
-              .clip(RoundedCornerShape(14.dp))
-              .background(if (selected) Color(0xFFEDEBFF) else AetherBackground)
-              .clickable(onClick = onClick)
-              .padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalAlignment = Alignment.CenterVertically,
-      ) {
-          Column(modifier = Modifier.weight(1f)) {
-              Text(
-                  text = title,
-                  style = MaterialTheme.typography.bodyMedium,
-                  color = AetherOnSurface,
-              )
-              Spacer(Modifier.height(2.dp))
-              Text(
-                  text = subtitle,
-                  style = MaterialTheme.typography.bodySmall,
-                  color = AetherOnSurfaceVariant,
-              )
-          }
-          if (selected) {
-              Icon(
-                  imageVector = Icons.Rounded.Check,
-                  contentDescription = null,
-                  tint = AetherPrimary,
-                  modifier = Modifier.size(18.dp),
-              )
-          }
-      }
-  }
+    val selectedBackground = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.78f)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(if (selected) selectedBackground else AetherBackground)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = AetherOnSurface,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = AetherOnSurfaceVariant,
+            )
+        }
+        if (selected) {
+            Icon(
+                imageVector = Icons.Rounded.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
 
 @Composable
 private fun DetailLine(

--- a/app/src/main/java/com/zhousl/aether/ui/theme/Color.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/theme/Color.kt
@@ -1,26 +1,161 @@
 package com.zhousl.aether.ui.theme
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import com.zhousl.aether.data.AppThemeMode
 
-val AetherBackground = Color(0xFFF7F7F3)
-val AetherBackgroundGradientTop = Color(0xFFF3F1EA)
-val AetherSurface = Color(0xFFFFFFFF)
-val AetherSurfaceHigh = Color(0xFFF5F4EF)
-val AetherSurfaceHigher = Color(0xFFEEECE6)
-val AetherSurfaceVariant = Color(0xFFE8E4DB)
-val AetherOutline = Color(0xFFD9D5CC)
-val AetherOutlineSoft = Color(0xFFE7E3DA)
-val AetherOnSurface = Color(0xFF202123)
-val AetherOnSurfaceVariant = Color(0xFF6E6A62)
-val AetherPrimary = Color(0xFF7C5CFA)
-val AetherOnPrimary = Color(0xFFFFFFFF)
-val AetherPrimaryContainer = Color(0xFFF1E5FF)
-val AetherOnPrimaryContainer = Color(0xFF4D2F8E)
-val AetherSecondary = Color(0xFF4A7B6B)
-val AetherOnSecondary = Color(0xFFFFFFFF)
-val AetherSecondaryContainer = Color(0xFFDDF1E8)
-val AetherOnSecondaryContainer = Color(0xFF1E4A3B)
-val AetherTertiary = Color(0xFF9A7DF8)
-val AetherError = Color(0xFFD25757)
-val AetherMessageBubble = Color(0xFFF0E3FF)
-val AetherScrim = Color(0x22000000)
+data class AetherPalette(
+    val background: Color,
+    val backgroundGradientTop: Color,
+    val surface: Color,
+    val surfaceHigh: Color,
+    val surfaceHigher: Color,
+    val surfaceVariant: Color,
+    val outline: Color,
+    val outlineSoft: Color,
+    val onSurface: Color,
+    val onSurfaceVariant: Color,
+    val primary: Color,
+    val onPrimary: Color,
+    val primaryContainer: Color,
+    val onPrimaryContainer: Color,
+    val secondary: Color,
+    val onSecondary: Color,
+    val secondaryContainer: Color,
+    val onSecondaryContainer: Color,
+    val tertiary: Color,
+    val error: Color,
+    val messageBubble: Color,
+    val scrim: Color,
+)
+
+internal val LightAetherPalette = AetherPalette(
+    background = Color(0xFFF7F7F3),
+    backgroundGradientTop = Color(0xFFF3F1EA),
+    surface = Color(0xFFFFFFFF),
+    surfaceHigh = Color(0xFFF5F4EF),
+    surfaceHigher = Color(0xFFEEECE6),
+    surfaceVariant = Color(0xFFE8E4DB),
+    outline = Color(0xFFD9D5CC),
+    outlineSoft = Color(0xFFE7E3DA),
+    onSurface = Color(0xFF202123),
+    onSurfaceVariant = Color(0xFF6E6A62),
+    primary = Color(0xFF7C5CFA),
+    onPrimary = Color(0xFFFFFFFF),
+    primaryContainer = Color(0xFFF1E5FF),
+    onPrimaryContainer = Color(0xFF4D2F8E),
+    secondary = Color(0xFF4A7B6B),
+    onSecondary = Color(0xFFFFFFFF),
+    secondaryContainer = Color(0xFFDDF1E8),
+    onSecondaryContainer = Color(0xFF1E4A3B),
+    tertiary = Color(0xFF9A7DF8),
+    error = Color(0xFFD25757),
+    messageBubble = Color(0xFFF0E3FF),
+    scrim = Color(0x22000000),
+)
+
+internal val DarkAetherPalette = AetherPalette(
+    background = Color(0xFF151619),
+    backgroundGradientTop = Color(0xFF1B1D22),
+    surface = Color(0xFF1C1F23),
+    surfaceHigh = Color(0xFF24282D),
+    surfaceHigher = Color(0xFF2C3036),
+    surfaceVariant = Color(0xFF343941),
+    outline = Color(0xFF4A5059),
+    outlineSoft = Color(0xFF3D424A),
+    onSurface = Color(0xFFF3F1EC),
+    onSurfaceVariant = Color(0xFFB9B4AA),
+    primary = Color(0xFFC0AEFF),
+    onPrimary = Color(0xFF251448),
+    primaryContainer = Color(0xFF3A275F),
+    onPrimaryContainer = Color(0xFFF0E9FF),
+    secondary = Color(0xFF89C8AF),
+    onSecondary = Color(0xFF143126),
+    secondaryContainer = Color(0xFF24483A),
+    onSecondaryContainer = Color(0xFFDDF6EA),
+    tertiary = Color(0xFFD1C2FF),
+    error = Color(0xFFFF8E8E),
+    messageBubble = Color(0xFF32264A),
+    scrim = Color(0x66000000),
+)
+
+private var currentPalette by mutableStateOf(LightAetherPalette)
+
+internal fun updateAetherPalette(themeMode: AppThemeMode) {
+    val palette = if (themeMode == AppThemeMode.Dark) {
+        DarkAetherPalette
+    } else {
+        LightAetherPalette
+    }
+    if (currentPalette != palette) {
+        currentPalette = palette
+    }
+}
+
+val AetherBackground: Color
+    get() = currentPalette.background
+
+val AetherBackgroundGradientTop: Color
+    get() = currentPalette.backgroundGradientTop
+
+val AetherSurface: Color
+    get() = currentPalette.surface
+
+val AetherSurfaceHigh: Color
+    get() = currentPalette.surfaceHigh
+
+val AetherSurfaceHigher: Color
+    get() = currentPalette.surfaceHigher
+
+val AetherSurfaceVariant: Color
+    get() = currentPalette.surfaceVariant
+
+val AetherOutline: Color
+    get() = currentPalette.outline
+
+val AetherOutlineSoft: Color
+    get() = currentPalette.outlineSoft
+
+val AetherOnSurface: Color
+    get() = currentPalette.onSurface
+
+val AetherOnSurfaceVariant: Color
+    get() = currentPalette.onSurfaceVariant
+
+val AetherPrimary: Color
+    get() = currentPalette.primary
+
+val AetherOnPrimary: Color
+    get() = currentPalette.onPrimary
+
+val AetherPrimaryContainer: Color
+    get() = currentPalette.primaryContainer
+
+val AetherOnPrimaryContainer: Color
+    get() = currentPalette.onPrimaryContainer
+
+val AetherSecondary: Color
+    get() = currentPalette.secondary
+
+val AetherOnSecondary: Color
+    get() = currentPalette.onSecondary
+
+val AetherSecondaryContainer: Color
+    get() = currentPalette.secondaryContainer
+
+val AetherOnSecondaryContainer: Color
+    get() = currentPalette.onSecondaryContainer
+
+val AetherTertiary: Color
+    get() = currentPalette.tertiary
+
+val AetherError: Color
+    get() = currentPalette.error
+
+val AetherMessageBubble: Color
+    get() = currentPalette.messageBubble
+
+val AetherScrim: Color
+    get() = currentPalette.scrim

--- a/app/src/main/java/com/zhousl/aether/ui/theme/Theme.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/theme/Theme.kt
@@ -2,30 +2,52 @@ package com.zhousl.aether.ui.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.zhousl.aether.data.AppThemeMode
 
-private val AetherColors = lightColorScheme(
-    primary = AetherPrimary,
-    onPrimary = AetherOnPrimary,
-    primaryContainer = AetherPrimaryContainer,
-    onPrimaryContainer = AetherOnPrimaryContainer,
-    secondary = AetherSecondary,
-    onSecondary = AetherOnSecondary,
-    secondaryContainer = AetherSecondaryContainer,
-    onSecondaryContainer = AetherOnSecondaryContainer,
-    background = AetherBackground,
-    surface = AetherSurface,
-    surfaceVariant = AetherSurfaceVariant,
-    onSurface = AetherOnSurface,
-    onSurfaceVariant = AetherOnSurfaceVariant,
-    tertiary = AetherTertiary,
-    error = AetherError,
-    outline = AetherOutline
+private val LightAetherColors = lightColorScheme(
+    primary = LightAetherPalette.primary,
+    onPrimary = LightAetherPalette.onPrimary,
+    primaryContainer = LightAetherPalette.primaryContainer,
+    onPrimaryContainer = LightAetherPalette.onPrimaryContainer,
+    secondary = LightAetherPalette.secondary,
+    onSecondary = LightAetherPalette.onSecondary,
+    secondaryContainer = LightAetherPalette.secondaryContainer,
+    onSecondaryContainer = LightAetherPalette.onSecondaryContainer,
+    background = LightAetherPalette.background,
+    surface = LightAetherPalette.surface,
+    surfaceVariant = LightAetherPalette.surfaceVariant,
+    onSurface = LightAetherPalette.onSurface,
+    onSurfaceVariant = LightAetherPalette.onSurfaceVariant,
+    tertiary = LightAetherPalette.tertiary,
+    error = LightAetherPalette.error,
+    outline = LightAetherPalette.outline,
+)
+
+private val DarkAetherColors = darkColorScheme(
+    primary = DarkAetherPalette.primary,
+    onPrimary = DarkAetherPalette.onPrimary,
+    primaryContainer = DarkAetherPalette.primaryContainer,
+    onPrimaryContainer = DarkAetherPalette.onPrimaryContainer,
+    secondary = DarkAetherPalette.secondary,
+    onSecondary = DarkAetherPalette.onSecondary,
+    secondaryContainer = DarkAetherPalette.secondaryContainer,
+    onSecondaryContainer = DarkAetherPalette.onSecondaryContainer,
+    background = DarkAetherPalette.background,
+    surface = DarkAetherPalette.surface,
+    surfaceVariant = DarkAetherPalette.surfaceVariant,
+    onSurface = DarkAetherPalette.onSurface,
+    onSurfaceVariant = DarkAetherPalette.onSurfaceVariant,
+    tertiary = DarkAetherPalette.tertiary,
+    error = DarkAetherPalette.error,
+    outline = DarkAetherPalette.outline,
 )
 
 private val AetherTypography = Typography(
@@ -89,10 +111,14 @@ private val AetherTypography = Typography(
 
 @Composable
 fun AetherTheme(
+    themeMode: AppThemeMode = AppThemeMode.Light,
     content: @Composable () -> Unit
 ) {
+    SideEffect {
+        updateAetherPalette(themeMode)
+    }
     MaterialTheme(
-        colorScheme = AetherColors,
+        colorScheme = if (themeMode == AppThemeMode.Dark) DarkAetherColors else LightAetherColors,
         typography = AetherTypography,
         content = content
     )


### PR DESCRIPTION
## Summary
- Add localized string handling across the app UI
- Update onboarding, settings, conversation, and markdown rendering to use the new string flow
- Refresh the theme palette and related UI surfaces

## Testing
- Not run (not requested)