### PR TITLE
Add interleaved assistant tool/text rendering

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -125,6 +125,7 @@ private fun parseMessages(messages: JSONArray?): List<ChatMessage> {
                         null
                     },
                     branchGroup = parseBranchGroup(message.optJSONObject("branchGroup")),
+                    responseGroupId = message.optString("responseGroupId").ifBlank { null },
                 )
             )
         }
@@ -140,6 +141,7 @@ private fun ChatMessage.toJson(): JSONObject = JSONObject().apply {
     }
     thoughtDurationMillis?.let { put("thoughtDurationMillis", it) }
     branchGroup?.let { put("branchGroup", it.toJson()) }
+    responseGroupId?.let { put("responseGroupId", it) }
     put("toolInvocations", JSONArray().apply { toolInvocations.forEach { put(it.toJson()) } })
     put("attachments", JSONArray().apply { attachments.forEach { put(it.toJson()) } })
 }

--- a/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
@@ -7,13 +7,13 @@ import com.zhousl.aether.AetherNotificationController
 import com.zhousl.aether.AppForegroundTracker
 import com.zhousl.aether.termux.TermuxBashTool
 import com.zhousl.aether.ui.AttachmentKind
+import com.zhousl.aether.ui.AssistantResponseBlock
 import com.zhousl.aether.ui.ChatAttachment
 import com.zhousl.aether.ui.ChatMessage
 import com.zhousl.aether.ui.ChatSession
 import com.zhousl.aether.ui.ChatToolInvocation
 import com.zhousl.aether.ui.MessageAuthor
 import com.zhousl.aether.ui.syncActiveBranches
-import java.util.LinkedHashMap
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -50,6 +50,7 @@ data class SessionExecutionState(
     val sessionId: String,
     val isRunning: Boolean = false,
     val pendingToolInvocations: List<ChatToolInvocation> = emptyList(),
+    val pendingResponseBlocks: List<AssistantResponseBlock> = emptyList(),
     val pendingAssistantText: String = "",
     val pendingStatusText: String = "",
     val pendingInputs: List<PendingSessionInput> = emptyList(),
@@ -121,8 +122,12 @@ class SessionExecutionManager(
         if (validationError != null) {
             val completion = appendAgentMessage(
                 sessionId = request.sessionId,
-                text = validationError,
-                toolInvocations = emptyList(),
+                blocks = listOf(
+                    AssistantResponseBlock.Text(
+                        id = "agent-validation-${System.currentTimeMillis()}",
+                        text = validationError,
+                    )
+                ),
                 thoughtDurationMillis = null,
                 outcome = SessionTurnOutcome.ValidationError,
             )
@@ -137,6 +142,7 @@ class SessionExecutionManager(
                 sessionId = request.sessionId,
                 isRunning = true,
                 pendingToolInvocations = emptyList(),
+                pendingResponseBlocks = emptyList(),
                 pendingAssistantText = "",
                 pendingStatusText = "",
                 activeTurnStartedAtMillis = System.currentTimeMillis(),
@@ -221,6 +227,7 @@ class SessionExecutionManager(
                     sessionId = handle.sessionId,
                     isRunning = false,
                     pendingToolInvocations = emptyList(),
+                    pendingResponseBlocks = emptyList(),
                     pendingAssistantText = "",
                     pendingStatusText = "",
                     pendingInputs = emptyList(),
@@ -249,7 +256,6 @@ class SessionExecutionManager(
         request: SessionTurnRequest,
     ): CompletionSummary {
         val turnStartedAtMillis = System.currentTimeMillis()
-        val completedToolInvocations = LinkedHashMap<String, ChatToolInvocation>()
         val mcpClientManager = McpClientManager(bashTool = bashTool)
         val agent = AetherAgent(
             client = OpenAiCompatibleClient(),
@@ -266,6 +272,7 @@ class SessionExecutionManager(
                 sessionId = handle.sessionId,
                 isRunning = true,
                 pendingToolInvocations = emptyList(),
+                pendingResponseBlocks = emptyList(),
                 pendingAssistantText = "",
                 pendingStatusText = "",
                 activeTurnStartedAtMillis = turnStartedAtMillis,
@@ -315,24 +322,32 @@ class SessionExecutionManager(
                         startedAtUptimeMillis = now,
                         completedAtUptimeMillis = if (event.outputJson == null) null else now,
                     )
-                    if (!invocation.isRunning) {
-                        completedToolInvocations[invocation.id] = invocation
-                    }
                     updateExecutionState(handle.sessionId) { current ->
+                        val pendingToolInvocations = upsertToolInvocation(
+                            current.pendingToolInvocations,
+                            invocation,
+                        )
+                        val pendingResponseBlocks = upsertAssistantResponseToolInvocation(
+                            blocks = current.pendingResponseBlocks,
+                            toolInvocation = invocation,
+                        ) { handle.nextPendingBlockId("pending-tools") }
                         current.copy(
-                            pendingToolInvocations = upsertToolInvocation(
-                                current.pendingToolInvocations,
-                                invocation,
-                            )
+                            pendingToolInvocations = pendingToolInvocations,
+                            pendingResponseBlocks = pendingResponseBlocks,
                         )
                     }
                 },
                 onAssistantTextDelta = { delta ->
                     if (delta.isEmpty()) return@runTurn
                     updateExecutionState(handle.sessionId) { current ->
+                        val pendingResponseBlocks = appendAssistantResponseText(
+                            blocks = current.pendingResponseBlocks,
+                            delta = delta,
+                        ) { handle.nextPendingBlockId("pending-text") }
                         current.copy(
                             pendingStatusText = "",
-                            pendingAssistantText = current.pendingAssistantText + delta
+                            pendingAssistantText = pendingTrailingAssistantText(pendingResponseBlocks),
+                            pendingResponseBlocks = pendingResponseBlocks,
                         )
                     }
                 },
@@ -377,8 +392,10 @@ class SessionExecutionManager(
                 onSuccess = { reply ->
                     appendAgentMessage(
                         sessionId = handle.sessionId,
-                        text = reply,
-                        toolInvocations = completedToolInvocations.values.toList(),
+                        blocks = ensureAssistantResponseFinalText(
+                            blocks = currentAssistantResponseBlocks(handle.sessionId),
+                            finalText = reply,
+                        ) { handle.nextPendingBlockId("agent-text") },
                         thoughtDurationMillis = thoughtDurationMillis,
                         outcome = SessionTurnOutcome.Success,
                     )
@@ -386,8 +403,15 @@ class SessionExecutionManager(
                 onFailure = { throwable ->
                     appendAgentMessage(
                         sessionId = handle.sessionId,
-                        text = "Request failed: ${throwable.message ?: "Unknown error"}",
-                        toolInvocations = completedToolInvocations.values.toList(),
+                        blocks = appendAssistantResponseText(
+                            blocks = currentAssistantResponseBlocks(handle.sessionId),
+                            delta = buildString {
+                                if (currentAssistantResponseBlocks(handle.sessionId).lastOrNull() is AssistantResponseBlock.Text) {
+                                    append("\n\n")
+                                }
+                                append("Request failed: ${throwable.message ?: "Unknown error"}")
+                            },
+                        ) { handle.nextPendingBlockId("agent-text") },
                         thoughtDurationMillis = thoughtDurationMillis,
                         outcome = SessionTurnOutcome.Failure,
                     )
@@ -398,9 +422,11 @@ class SessionExecutionManager(
         } catch (_: CancellationException) {
             val snapshot = _executionStates.value[handle.sessionId] ?: SessionExecutionState(sessionId = handle.sessionId)
             val finalizedToolInvocations = finalizeInterruptedToolInvocations(snapshot.pendingToolInvocations)
+            val finalizedResponseBlocks = finalizeInterruptedAssistantResponseBlocks(snapshot.pendingResponseBlocks)
             val thoughtDurationMillis = (System.currentTimeMillis() - turnStartedAtMillis).coerceAtLeast(0L)
             clearPendingInputs(handle)
             val completion = if (
+                finalizedResponseBlocks.isEmpty() &&
                 snapshot.pendingAssistantText.isBlank() &&
                 finalizedToolInvocations.isEmpty()
             ) {
@@ -412,8 +438,26 @@ class SessionExecutionManager(
             } else {
                 appendAgentMessage(
                     sessionId = handle.sessionId,
-                    text = snapshot.pendingAssistantText,
-                    toolInvocations = finalizedToolInvocations,
+                    blocks = finalizedResponseBlocks.ifEmpty {
+                        buildList {
+                            if (snapshot.pendingAssistantText.isNotBlank()) {
+                                add(
+                                    AssistantResponseBlock.Text(
+                                        id = handle.nextPendingBlockId("agent-text"),
+                                        text = snapshot.pendingAssistantText,
+                                    )
+                                )
+                            }
+                            if (finalizedToolInvocations.isNotEmpty()) {
+                                add(
+                                    AssistantResponseBlock.ToolGroup(
+                                        id = handle.nextPendingBlockId("agent-tools"),
+                                        toolInvocations = finalizedToolInvocations,
+                                    )
+                                )
+                            }
+                        }
+                    },
                     thoughtDurationMillis = thoughtDurationMillis,
                     outcome = SessionTurnOutcome.Neutral,
                 )
@@ -427,6 +471,7 @@ class SessionExecutionManager(
             updateExecutionState(handle.sessionId) { current ->
                 current.copy(
                     pendingToolInvocations = emptyList(),
+                    pendingResponseBlocks = emptyList(),
                     pendingAssistantText = "",
                     activeTurnStartedAtMillis = null,
                 )
@@ -540,13 +585,59 @@ class SessionExecutionManager(
 
     private fun appendAgentMessage(
         sessionId: String,
-        text: String,
-        toolInvocations: List<ChatToolInvocation>,
+        blocks: List<AssistantResponseBlock>,
         thoughtDurationMillis: Long?,
         outcome: SessionTurnOutcome,
     ): CompletionSummary {
         var sessionTitle = resolveSessionTitle(sessionId)
-        var replySummary = text.trim()
+        var replySummary = blocks.lastOrNull()
+            ?.let(::assistantResponseBlockSummaryText)
+            .orEmpty()
+
+        val normalizedBlocks = normalizeAssistantResponseBlocks(blocks)
+        val messageTimestamp = System.currentTimeMillis()
+        val responseGroupId = "agent-group-$messageTimestamp"
+        val appendedMessages = normalizedBlocks.mapIndexedNotNull { index, block ->
+            when (block) {
+                is AssistantResponseBlock.Text -> {
+                    if (block.text.isBlank()) {
+                        null
+                    } else {
+                        ChatMessage(
+                            id = "agent-${messageTimestamp + index}",
+                            author = MessageAuthor.Agent,
+                            text = block.text,
+                            createdAtMillis = messageTimestamp + index,
+                            responseGroupId = responseGroupId,
+                        )
+                    }
+                }
+
+                is AssistantResponseBlock.ToolGroup -> {
+                    if (block.toolInvocations.isEmpty()) {
+                        null
+                    } else {
+                        ChatMessage(
+                            id = "agent-${messageTimestamp + index}",
+                            author = MessageAuthor.Agent,
+                            text = "",
+                            createdAtMillis = messageTimestamp + index,
+                            toolInvocations = block.toolInvocations,
+                            responseGroupId = responseGroupId,
+                        )
+                    }
+                }
+            }
+        }.let { messages ->
+            if (messages.isEmpty()) {
+                emptyList()
+            } else {
+                messages.toMutableList().apply {
+                    val lastIndex = lastIndex
+                    set(lastIndex, get(lastIndex).copy(thoughtDurationMillis = thoughtDurationMillis))
+                }
+            }
+        }
 
         chatStateStore.update { persisted ->
             val sessionIndex = persisted.sessions.indexOfFirst { it.id == sessionId }
@@ -555,15 +646,7 @@ class SessionExecutionManager(
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
             val updatedSession = session.withDerivedMessages(
-                session.messages +
-                    ChatMessage(
-                        id = "agent-${System.currentTimeMillis()}",
-                        author = MessageAuthor.Agent,
-                        text = text,
-                        createdAtMillis = System.currentTimeMillis(),
-                        toolInvocations = toolInvocations,
-                        thoughtDurationMillis = thoughtDurationMillis,
-                    )
+                session.messages + appendedMessages
             )
             sessionTitle = updatedSession.title
             replySummary = updatedSession.preview
@@ -577,6 +660,9 @@ class SessionExecutionManager(
             outcome = outcome,
         )
     }
+
+    private fun currentAssistantResponseBlocks(sessionId: String): List<AssistantResponseBlock> =
+        _executionStates.value[sessionId]?.pendingResponseBlocks.orEmpty()
 
     private fun appendConsumedUserMessages(
         sessionId: String,
@@ -850,6 +936,148 @@ class SessionExecutionManager(
         }
     }
 
+    private fun appendAssistantResponseText(
+        blocks: List<AssistantResponseBlock>,
+        delta: String,
+        newBlockId: () -> String,
+    ): List<AssistantResponseBlock> {
+        if (delta.isEmpty()) return blocks
+        val lastBlock = blocks.lastOrNull()
+        return if (lastBlock is AssistantResponseBlock.Text) {
+            blocks.toMutableList().apply {
+                set(lastIndex, lastBlock.copy(text = lastBlock.text + delta))
+            }
+        } else {
+            blocks + AssistantResponseBlock.Text(
+                id = newBlockId(),
+                text = delta,
+            )
+        }
+    }
+
+    private fun upsertAssistantResponseToolInvocation(
+        blocks: List<AssistantResponseBlock>,
+        toolInvocation: ChatToolInvocation,
+        newBlockId: () -> String,
+    ): List<AssistantResponseBlock> {
+        val existingIndex = blocks.indexOfFirst { block ->
+            block is AssistantResponseBlock.ToolGroup &&
+                block.toolInvocations.any { it.id == toolInvocation.id }
+        }
+        if (existingIndex >= 0) {
+            val toolBlock = blocks[existingIndex] as AssistantResponseBlock.ToolGroup
+            return blocks.toMutableList().apply {
+                set(
+                    existingIndex,
+                    toolBlock.copy(
+                        toolInvocations = upsertToolInvocation(toolBlock.toolInvocations, toolInvocation),
+                    ),
+                )
+            }
+        }
+
+        val lastBlock = blocks.lastOrNull()
+        return if (lastBlock is AssistantResponseBlock.ToolGroup) {
+            blocks.toMutableList().apply {
+                set(
+                    lastIndex,
+                    lastBlock.copy(
+                        toolInvocations = upsertToolInvocation(lastBlock.toolInvocations, toolInvocation),
+                    ),
+                )
+            }
+        } else {
+            blocks + AssistantResponseBlock.ToolGroup(
+                id = newBlockId(),
+                toolInvocations = upsertToolInvocation(emptyList(), toolInvocation),
+            )
+        }
+    }
+
+    private fun pendingTrailingAssistantText(
+        blocks: List<AssistantResponseBlock>,
+    ): String = (blocks.lastOrNull() as? AssistantResponseBlock.Text)?.text.orEmpty()
+
+    private fun ensureAssistantResponseFinalText(
+        blocks: List<AssistantResponseBlock>,
+        finalText: String,
+        newBlockId: () -> String,
+    ): List<AssistantResponseBlock> {
+        if (finalText.isBlank()) return normalizeAssistantResponseBlocks(blocks)
+        val normalized = normalizeAssistantResponseBlocks(blocks)
+        val lastTextIndex = normalized.indexOfLast { it is AssistantResponseBlock.Text }
+        if (lastTextIndex < 0) {
+            return normalized + AssistantResponseBlock.Text(
+                id = newBlockId(),
+                text = finalText,
+            )
+        }
+        val lastTextBlock = normalized[lastTextIndex] as AssistantResponseBlock.Text
+        if (lastTextBlock.text == finalText) return normalized
+        return normalized.toMutableList().apply {
+            set(lastTextIndex, lastTextBlock.copy(text = finalText))
+        }
+    }
+
+    private fun normalizeAssistantResponseBlocks(
+        blocks: List<AssistantResponseBlock>,
+    ): List<AssistantResponseBlock> = buildList {
+        blocks.forEach { block ->
+            when (block) {
+                is AssistantResponseBlock.Text -> {
+                    if (block.text.isBlank()) return@forEach
+                    val previous = lastOrNull()
+                    if (previous is AssistantResponseBlock.Text) {
+                        removeAt(lastIndex)
+                        add(previous.copy(text = previous.text + block.text))
+                    } else {
+                        add(block)
+                    }
+                }
+
+                is AssistantResponseBlock.ToolGroup -> {
+                    if (block.toolInvocations.isEmpty()) return@forEach
+                    val previous = lastOrNull()
+                    if (previous is AssistantResponseBlock.ToolGroup) {
+                        removeAt(lastIndex)
+                        add(
+                            previous.copy(
+                                toolInvocations = previous.toolInvocations + block.toolInvocations,
+                            ),
+                        )
+                    } else {
+                        add(block)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun finalizeInterruptedAssistantResponseBlocks(
+        blocks: List<AssistantResponseBlock>,
+    ): List<AssistantResponseBlock> = normalizeAssistantResponseBlocks(
+        blocks.map { block ->
+            when (block) {
+                is AssistantResponseBlock.Text -> block
+                is AssistantResponseBlock.ToolGroup -> block.copy(
+                    toolInvocations = finalizeInterruptedToolInvocations(block.toolInvocations),
+                )
+            }
+        }
+    )
+
+    private fun assistantResponseBlockSummaryText(
+        block: AssistantResponseBlock,
+    ): String = when (block) {
+        is AssistantResponseBlock.Text -> block.text.trim()
+        is AssistantResponseBlock.ToolGroup -> ChatMessage(
+            id = block.id,
+            author = MessageAuthor.Agent,
+            text = "",
+            toolInvocations = block.toolInvocations,
+        ).summaryText()
+    }
+
     private fun finalizeInterruptedToolInvocations(
         invocations: List<ChatToolInvocation>,
     ): List<ChatToolInvocation> = invocations.map { invocation ->
@@ -925,12 +1153,19 @@ class SessionExecutionManager(
         val lock = Any()
         val queuedInputs = ArrayDeque<PendingEnvelope>()
         val steerInputs = ArrayDeque<PendingEnvelope>()
+        private var pendingBlockCounter: Long = 0
 
         @Volatile
         var pauseRequested: Boolean = false
 
         @Volatile
         var job: Job? = null
+
+        fun nextPendingBlockId(prefix: String): String {
+            val nextId = pendingBlockCounter
+            pendingBlockCounter += 1
+            return "$prefix-$sessionId-$nextId"
+        }
     }
 }
 

--- a/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
@@ -183,7 +183,7 @@ private fun AetherAppContent(
     val selectedMcpServerIds = activeSession?.activeMcpServerIds ?: uiState.draftSelectedMcpServerIds
     val agentModeSelected = activeSession?.agentModeEnabled ?: uiState.draftAgentModeEnabled
     val pendingToolInvocations = currentSessionExecution?.pendingToolInvocations.orEmpty()
-    val pendingAssistantText = currentSessionExecution?.pendingAssistantText.orEmpty()
+    val pendingResponseBlocks = currentSessionExecution?.pendingResponseBlocks.orEmpty()
     val pendingInputs = currentSessionExecution?.pendingInputs.orEmpty()
     val isCurrentSessionRunning = currentSessionExecution?.isRunning == true
     val currentWorkspaceDirectory = workspaceFileBridge.workspaceDirectory(uiState.currentSessionId)
@@ -432,8 +432,8 @@ private fun AetherAppContent(
                     workspaceDirectory = currentWorkspaceDirectory,
                     pendingToolInvocations = pendingToolInvocations,
                     pendingToolInvocationStateKey = "pending-tools-${uiState.currentSessionId}",
-                    pendingAssistantText = pendingAssistantText,
-                    pendingStatusText = uiState.pendingStatusText,
+                    pendingResponseBlocks = pendingResponseBlocks,
+                    pendingStatusText = currentSessionExecution?.pendingStatusText.orEmpty(),
                     pendingInputs = pendingInputs,
                     inputValue = uiState.draftInput,
                     draftAttachments = uiState.draftAttachments,

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -147,6 +147,20 @@ data class ChatToolInvocation(
     val completedAtUptimeMillis: Long? = null,
 )
 
+sealed interface AssistantResponseBlock {
+    val id: String
+
+    data class Text(
+        override val id: String,
+        val text: String,
+    ) : AssistantResponseBlock
+
+    data class ToolGroup(
+        override val id: String,
+        val toolInvocations: List<ChatToolInvocation>,
+    ) : AssistantResponseBlock
+}
+
 data class ChatMessage(
     val id: String,
     val author: MessageAuthor,
@@ -156,6 +170,7 @@ data class ChatMessage(
     val toolInvocations: List<ChatToolInvocation> = emptyList(),
     val thoughtDurationMillis: Long? = null,
     val branchGroup: ChatBranchGroup? = null,
+    val responseGroupId: String? = null,
 )
 
 data class ChatSession(
@@ -190,6 +205,7 @@ data class AetherUiState(
     val isSending: Boolean = false,
     val pendingResponseSessionId: String? = null,
     val pendingToolInvocations: List<ChatToolInvocation> = emptyList(),
+    val pendingResponseBlocks: List<AssistantResponseBlock> = emptyList(),
     val pendingAssistantText: String = "",
     val pendingStatusText: String = "",
     val sessionExecutionStates: Map<String, SessionExecutionState> = emptyMap(),
@@ -274,6 +290,7 @@ class AetherViewModel(
                         isSending = currentExecution?.isRunning == true,
                         pendingResponseSessionId = currentExecution?.sessionId,
                         pendingToolInvocations = currentExecution?.pendingToolInvocations.orEmpty(),
+                        pendingResponseBlocks = currentExecution?.pendingResponseBlocks.orEmpty(),
                         pendingAssistantText = currentExecution?.pendingAssistantText.orEmpty(),
                         pendingStatusText = currentExecution?.pendingStatusText.orEmpty(),
                     )
@@ -290,6 +307,7 @@ class AetherViewModel(
                         isSending = currentExecution?.isRunning == true,
                         pendingResponseSessionId = currentExecution?.sessionId,
                         pendingToolInvocations = currentExecution?.pendingToolInvocations.orEmpty(),
+                        pendingResponseBlocks = currentExecution?.pendingResponseBlocks.orEmpty(),
                         pendingAssistantText = currentExecution?.pendingAssistantText.orEmpty(),
                         pendingStatusText = currentExecution?.pendingStatusText.orEmpty(),
                     )
@@ -835,7 +853,8 @@ class AetherViewModel(
             val messageIndex = session.messages.indexOfFirst { it.id == messageId }
             if (messageIndex < 0) return@update current
 
-            val trimmedMessages = session.messages.take(messageIndex)
+            val trimFromIndex = session.messages.resolveConversationTrimIndex(messageIndex)
+            val trimmedMessages = session.messages.take(trimFromIndex)
             val updatedSessions = current.sessions.toMutableList().apply {
                 removeAt(sessionIndex)
                 if (trimmedMessages.isNotEmpty()) {
@@ -906,7 +925,8 @@ class AetherViewModel(
             }
             if (messageIndex < 0) return@update current
 
-            val trimmedMessages = session.messages.take(messageIndex)
+            val trimFromIndex = session.messages.resolveConversationTrimIndex(messageIndex)
+            val trimmedMessages = session.messages.take(trimFromIndex)
             if (trimmedMessages.lastOrNull()?.author != MessageAuthor.User) {
                 return@update current
             }
@@ -2505,6 +2525,48 @@ class AetherViewModel(
         if (attachments.isEmpty()) return "Empty message"
         if (attachments.size == 1) return attachments.first().name
         return "${attachments.size} attachments"
+    }
+
+    private fun List<ChatMessage>.resolveConversationTrimIndex(
+        targetIndex: Int,
+    ): Int {
+        val targetMessage = getOrNull(targetIndex) ?: return targetIndex
+        val responseGroupId = targetMessage.responseGroupId
+        if (
+            targetMessage.author != MessageAuthor.Agent ||
+            responseGroupId.isNullOrBlank()
+        ) {
+            return targetIndex
+        }
+        if (responseGroupId.isNullOrBlank()) {
+            return resolveLegacyAssistantGroupStartIndex(targetIndex)
+        }
+        val groupStartIndex = indexOfFirst { message ->
+            message.author == MessageAuthor.Agent && message.responseGroupId == responseGroupId
+        }
+        return if (groupStartIndex >= 0) groupStartIndex else targetIndex
+    }
+
+    private fun List<ChatMessage>.resolveLegacyAssistantGroupStartIndex(
+        targetIndex: Int,
+    ): Int {
+        val targetMessage = getOrNull(targetIndex) ?: return targetIndex
+        if (targetMessage.author != MessageAuthor.Agent) return targetIndex
+        var groupStartIndex = targetIndex
+        var expectedCreatedAtMillis = targetMessage.createdAtMillis
+        while (groupStartIndex > 0) {
+            val previous = this[groupStartIndex - 1]
+            if (
+                previous.author != MessageAuthor.Agent ||
+                !previous.responseGroupId.isNullOrBlank() ||
+                previous.createdAtMillis != expectedCreatedAtMillis - 1
+            ) {
+                break
+            }
+            groupStartIndex -= 1
+            expectedCreatedAtMillis = previous.createdAtMillis
+        }
+        return groupStartIndex
     }
 
     private fun formatBytes(bytes: Long): String = when {

--- a/app/src/main/java/com/zhousl/aether/ui/ConversationMessages.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/ConversationMessages.kt
@@ -776,6 +776,84 @@ private fun AssistantMessageBlock(
 }
 
 @Composable
+fun ConversationAssistantGroupBubble(
+    messages: List<ChatMessage>,
+    actionsEnabled: Boolean,
+    workspaceDirectory: String?,
+    onOpenAttachment: (ChatAttachment) -> Unit,
+    onOpenLink: (String) -> Unit,
+    onCopy: () -> Unit,
+    onRedo: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    if (messages.isEmpty()) return
+    val strings = rememberAetherStrings()
+    val thoughtDurationMillis = messages.lastOrNull()?.thoughtDurationMillis
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        thoughtDurationMillis?.let { duration ->
+            Text(
+                text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) {
+                    "鎬濊€冧簡 ${formatThoughtDuration(duration)}"
+                } else {
+                    "Thought for ${formatThoughtDuration(duration)}"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = AetherOnSurfaceVariant,
+            )
+        }
+        messages.forEach { message ->
+            val agentModeFrames = remember(message.toolInvocations) {
+                buildAgentModeReplayFrames(message.toolInvocations)
+            }
+            if (agentModeFrames.isNotEmpty()) {
+                AgentModeReplayPanel(
+                    frames = agentModeFrames,
+                    stateKey = "agent-mode-replay-${message.id}",
+                )
+            } else {
+                ToolInvocationList(
+                    toolInvocations = message.toolInvocations,
+                    stateKey = "message-tools-${message.id}",
+                )
+            }
+            AssistantAttachments(
+                attachments = message.attachments,
+                onOpenAttachment = onOpenAttachment,
+            )
+            if (message.text.isNotBlank()) {
+                MarkdownContent(
+                    markdown = message.text,
+                    workspaceDirectory = workspaceDirectory,
+                    onLinkClick = onOpenLink,
+                )
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            AssistantMessageAction(
+                icon = LucideIcons.Copy,
+                contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "澶嶅埗鍥炲" else "Copy reply",
+                onClick = onCopy,
+            )
+            AssistantMessageAction(
+                icon = LucideIcons.RotateCcw,
+                contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "閲嶆柊鎵ц鍥炲" else "Redo reply",
+                enabled = actionsEnabled,
+                onClick = onRedo,
+            )
+            AssistantMessageAction(
+                icon = LucideIcons.Trash2,
+                contentDescription = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "鍒犻櫎鍥炲" else "Delete reply",
+                enabled = actionsEnabled,
+                onClick = onDelete,
+            )
+        }
+    }
+}
+
+@Composable
 private fun AgentModeReplayPanel(
     frames: List<AgentModeReplayFrame>,
     stateKey: String,

--- a/app/src/main/java/com/zhousl/aether/ui/ConversationUi.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/ConversationUi.kt
@@ -146,6 +146,24 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.delay
 import org.json.JSONObject
 
+private sealed interface ConversationListItem {
+    val key: String
+
+    data class Message(
+        val message: ChatMessage,
+    ) : ConversationListItem {
+        override val key: String = message.id
+    }
+
+    data class AssistantGroup(
+        val messages: List<ChatMessage>,
+    ) : ConversationListItem {
+        override val key: String = messages.firstOrNull()?.responseGroupId
+            ?: messages.firstOrNull()?.id
+            ?: "assistant-group"
+    }
+}
+
 private val ConversationTopFadeHeight = 42.dp
 private val DrawerOverlayFadeHeight = 18.dp
 private val ComposerCardShape = RoundedCornerShape(26.dp)
@@ -198,7 +216,7 @@ fun ConversationScreen(
     workspaceDirectory: String,
     pendingToolInvocations: List<ChatToolInvocation>,
     pendingToolInvocationStateKey: String,
-    pendingAssistantText: String,
+    pendingResponseBlocks: List<AssistantResponseBlock>,
     pendingStatusText: String,
     pendingInputs: List<PendingSessionInput>,
     inputValue: String,
@@ -248,6 +266,7 @@ fun ConversationScreen(
     isSending: Boolean,
 ) {
     val listState = rememberLazyListState()
+    val conversationItems = remember(messages) { buildConversationListItems(messages) }
     val bottomAnchorRequester = remember { BringIntoViewRequester() }
     var previewAttachment by remember { mutableStateOf<ChatAttachment?>(null) }
     var shouldAutoFollow by rememberSaveable { mutableStateOf(true) }
@@ -352,25 +371,51 @@ fun ConversationScreen(
                     ),
                     verticalArrangement = Arrangement.spacedBy(22.dp),
                 ) {
-                    items(messages, key = { it.id }) { message ->
-                        ConversationMessageBubble(
-                            message = message,
-                            actionsEnabled = !isSending,
-                            workspaceDirectory = workspaceDirectory,
-                            onOpenAttachment = { previewAttachment = it },
-                            onOpenLink = onOpenLink,
-                            onEdit = { onEditMessage(message.id) },
-                            onDelete = { onDeleteMessage(message.id) },
-                            onCopy = { onCopyMessage(message) },
-                            onRedo = { onRedoAgentMessage(message.id) },
-                            onRetry = { onRetryUserMessage(message.id) },
-                            onSwitchBranch = { delta -> onSwitchUserMessageBranch(message.id, delta) },
-                        )
+                    items(conversationItems, key = { it.key }) { item ->
+                        when (item) {
+                            is ConversationListItem.Message -> {
+                                val message = item.message
+                                ConversationMessageBubble(
+                                    message = message,
+                                    actionsEnabled = !isSending,
+                                    workspaceDirectory = workspaceDirectory,
+                                    onOpenAttachment = { previewAttachment = it },
+                                    onOpenLink = onOpenLink,
+                                    onEdit = { onEditMessage(message.id) },
+                                    onDelete = { onDeleteMessage(message.id) },
+                                    onCopy = { onCopyMessage(message) },
+                                    onRedo = { onRedoAgentMessage(message.id) },
+                                    onRetry = { onRetryUserMessage(message.id) },
+                                    onSwitchBranch = { delta -> onSwitchUserMessageBranch(message.id, delta) },
+                                )
+                            }
+
+                            is ConversationListItem.AssistantGroup -> {
+                                val lastMessage = item.messages.last()
+                                ConversationAssistantGroupBubble(
+                                    messages = item.messages,
+                                    actionsEnabled = !isSending,
+                                    workspaceDirectory = workspaceDirectory,
+                                    onOpenAttachment = { previewAttachment = it },
+                                    onOpenLink = onOpenLink,
+                                    onCopy = {
+                                        onCopyMessage(
+                                            lastMessage.copy(
+                                                text = item.messages.joinToString("\n\n") { message -> message.text }
+                                                    .trim(),
+                                            )
+                                        )
+                                    },
+                                    onRedo = { onRedoAgentMessage(lastMessage.id) },
+                                    onDelete = { onDeleteMessage(lastMessage.id) },
+                                )
+                            }
+                        }
                     }
                     items(pendingInputs, key = { it.id }) { pendingInput ->
                         PendingSessionInputBubble(pendingInput = pendingInput)
                     }
-                    if (pendingToolInvocations.isNotEmpty() || isSending) {
+                    if (pendingResponseBlocks.isNotEmpty() || pendingToolInvocations.isNotEmpty() || isSending) {
                         item(key = "pending-generation-block") {
                             Column(
                                 modifier = Modifier
@@ -378,37 +423,28 @@ fun ConversationScreen(
                                     .animateContentSize(),
                                 verticalArrangement = Arrangement.spacedBy(10.dp),
                             ) {
-                                val agentModePreviewVisible =
-                                    agentModeSelected ||
-                                    agentModeDisplayState.isActive ||
-                                    agentModeDisplayState.latestPreviewPath.isNotBlank()
-                                if (agentModePreviewVisible) {
-                                    AgentModePreviewPanel(
-                                        displayState = agentModeDisplayState,
-                                        toolInvocation = pendingToolInvocations.lastOrNull(),
-                                    )
-                                }
-                                if (pendingToolInvocations.isNotEmpty() && !agentModePreviewVisible) {
-                                    ToolInvocationList(
-                                        toolInvocations = pendingToolInvocations,
-                                        stateKey = pendingToolInvocationStateKey,
-                                        autoExpand = pendingAssistantText.isBlank(),
-                                    )
-                                }
+                                PendingAssistantTimeline(
+                                    blocks = pendingResponseBlocks,
+                                    workspaceDirectory = workspaceDirectory,
+                                    onOpenLink = onOpenLink,
+                                    pendingToolInvocationStateKey = pendingToolInvocationStateKey,
+                                    pendingToolInvocations = pendingToolInvocations,
+                                    agentModeSelected = agentModeSelected,
+                                    agentModeDisplayState = agentModeDisplayState,
+                                )
                                 if (isSending) {
-                                    if (pendingAssistantText.isNotBlank()) {
-                                        PendingAssistantResponseBlock(
-                                            text = pendingAssistantText,
-                                            workspaceDirectory = workspaceDirectory,
-                                            onOpenLink = onOpenLink,
+                                    if (pendingResponseBlocks.isEmpty() && pendingStatusText.isNotBlank()) {
+                                        ShimmerStatusText(
+                                            text = pendingStatusText,
+                                            modifier = Modifier.padding(top = 6.dp),
                                         )
+                                    } else if (pendingResponseBlocks.isEmpty()) {
+                                        ConversationThinkingIndicator()
                                     } else if (pendingStatusText.isNotBlank()) {
                                         ShimmerStatusText(
                                             text = pendingStatusText,
                                             modifier = Modifier.padding(top = 6.dp),
                                         )
-                                    } else {
-                                        ConversationThinkingIndicator()
                                     }
                                 }
                             }
@@ -701,6 +737,130 @@ private fun ConversationThinkingIndicator() {
         text = if (strings.appLanguage == AppLanguage.SimplifiedChinese) "思考中" else "Thinking",
         modifier = Modifier.padding(top = 6.dp),
     )
+}
+
+@Composable
+private fun PendingAssistantTimeline(
+    blocks: List<AssistantResponseBlock>,
+    workspaceDirectory: String,
+    onOpenLink: (String) -> Unit,
+    pendingToolInvocationStateKey: String,
+    pendingToolInvocations: List<ChatToolInvocation>,
+    agentModeSelected: Boolean,
+    agentModeDisplayState: AgentModeDisplayState,
+) {
+    if (blocks.isEmpty()) {
+        val agentModePreviewVisible =
+            pendingToolInvocations.isNotEmpty() &&
+                (agentModeSelected ||
+                    agentModeDisplayState.isActive ||
+                    agentModeDisplayState.latestPreviewPath.isNotBlank())
+        if (agentModePreviewVisible) {
+            AgentModePreviewPanel(
+                displayState = agentModeDisplayState,
+                toolInvocation = pendingToolInvocations.lastOrNull(),
+            )
+        } else if (pendingToolInvocations.isNotEmpty()) {
+            ToolInvocationList(
+                toolInvocations = pendingToolInvocations,
+                stateKey = pendingToolInvocationStateKey,
+                autoExpand = true,
+            )
+        }
+        return
+    }
+
+    blocks.forEachIndexed { index, block ->
+        when (block) {
+            is AssistantResponseBlock.Text -> PendingAssistantResponseBlock(
+                text = block.text,
+                workspaceDirectory = workspaceDirectory,
+                onOpenLink = onOpenLink,
+            )
+
+            is AssistantResponseBlock.ToolGroup -> {
+                val isLastBlock = index == blocks.lastIndex
+                val shouldShowAgentModePreview =
+                    isLastBlock &&
+                        (agentModeSelected ||
+                            agentModeDisplayState.isActive ||
+                            agentModeDisplayState.latestPreviewPath.isNotBlank()) &&
+                        block.toolInvocations.any { it.toolName.equals("agent_display", ignoreCase = true) }
+                if (shouldShowAgentModePreview) {
+                    AgentModePreviewPanel(
+                        displayState = agentModeDisplayState,
+                        toolInvocation = block.toolInvocations.lastOrNull(),
+                    )
+                } else {
+                    ToolInvocationList(
+                        toolInvocations = block.toolInvocations,
+                        stateKey = "$pendingToolInvocationStateKey-${block.id}",
+                        autoExpand = isLastBlock,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun buildConversationListItems(
+    messages: List<ChatMessage>,
+): List<ConversationListItem> = buildList {
+    var index = 0
+    while (index < messages.size) {
+        val message = messages[index]
+        val responseGroupId = message.responseGroupId
+        if (
+            message.author == MessageAuthor.Agent &&
+            (!responseGroupId.isNullOrBlank() || isLegacyAssistantGroupStart(messages, index))
+        ) {
+            val groupedMessages = buildList {
+                var groupIndex = index
+                while (groupIndex < messages.size) {
+                    val candidate = messages[groupIndex]
+                    if (candidate.author != MessageAuthor.Agent) {
+                        break
+                    }
+                    val matchesGroup = if (!responseGroupId.isNullOrBlank()) {
+                        candidate.responseGroupId == responseGroupId
+                    } else {
+                        val offset = groupIndex - index
+                        candidate.responseGroupId.isNullOrBlank() &&
+                            candidate.createdAtMillis == message.createdAtMillis + offset
+                    }
+                    if (!matchesGroup) {
+                        break
+                    }
+                    add(candidate)
+                    groupIndex += 1
+                }
+            }
+            if (groupedMessages.isNotEmpty()) {
+                add(ConversationListItem.AssistantGroup(groupedMessages))
+                index += groupedMessages.size
+                continue
+            }
+        }
+        add(ConversationListItem.Message(message))
+        index += 1
+    }
+}
+
+private fun isLegacyAssistantGroupStart(
+    messages: List<ChatMessage>,
+    index: Int,
+): Boolean {
+    val message = messages.getOrNull(index) ?: return false
+    if (
+        message.author != MessageAuthor.Agent ||
+        !message.responseGroupId.isNullOrBlank()
+    ) {
+        return false
+    }
+    val next = messages.getOrNull(index + 1) ?: return false
+    return next.author == MessageAuthor.Agent &&
+        next.responseGroupId.isNullOrBlank() &&
+        next.createdAtMillis == message.createdAtMillis + 1
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- render assistant output as ordered text/tool blocks so streamed text can appear between tool invocations
- preserve tool collapse behavior while grouping consecutive tool runs and keeping a single action row for one assistant reply
- persist assistant response grouping so redo/delete act on the whole reply instead of individual sub-blocks

## Verification
- ./gradlew.bat --no-daemon testDebugUnitTest assembleDebug
- installed debug APK on connected device and verified update path