### PR TITLE
Fix null working directory tool arguments

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,0 +1,34 @@
+name: Build Debug APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master, aether-null-workdir-fix ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug --stacktrace
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: Aether-debug-null-workdir-fix
+          path: app/build/outputs/apk/debug/*.apk

--- a/app/src/main/java/com/zhousl/aether/data/AetherAgent.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AetherAgent.kt
@@ -1448,9 +1448,19 @@ class AetherAgent(
         workspaceDirectory: String,
     ): String {
         val arguments = runCatching { JSONObject(argumentsJson) }.getOrNull() ?: return argumentsJson
-        if (!arguments.has("workingDirectory") && !arguments.has("working_directory")) {
-            arguments.put("working_directory", workspaceDirectory)
+
+        val snake = arguments.cleanOptionalString("working_directory")
+        val camel = arguments.cleanOptionalString("workingDirectory")
+
+        arguments.remove("working_directory")
+        arguments.remove("workingDirectory")
+
+        when {
+            snake.isNotBlank() -> arguments.put("working_directory", snake)
+            camel.isNotBlank() -> arguments.put("working_directory", camel)
+            else -> arguments.put("working_directory", workspaceDirectory)
         }
+
         return arguments.toString()
     }
 

--- a/app/src/main/java/com/zhousl/aether/data/OpenAiCompatibleClient.kt
+++ b/app/src/main/java/com/zhousl/aether/data/OpenAiCompatibleClient.kt
@@ -413,7 +413,10 @@ class OpenAiCompatibleClient(
         }
 
         val toolCalls = buildList {
-            val toolCallsArray = message.optJSONArray("tool_calls") ?: JSONArray()
+            // Guard against "tool_calls": null which some providers (e.g. mimo)
+            // may include in non-streaming responses.
+            val toolCallsArray = if (message.isNull("tool_calls")) JSONArray()
+                else message.optJSONArray("tool_calls") ?: JSONArray()
             for (index in 0 until toolCallsArray.length()) {
                 val toolCall = toolCallsArray.optJSONObject(index) ?: continue
                 val function = toolCall.optJSONObject("function") ?: continue
@@ -1703,6 +1706,12 @@ private class OpenAiStreamAccumulator(
                 onTextDelta(textDelta)
             }
 
+            // Skip when tool_calls is explicitly null (e.g. mimo-v2.5-pro sends
+            // "tool_calls": null in deltas that carry no tool invocation). Without
+            // this guard, has("tool_calls") returns true even for a null value and
+            // getJSONArray("tool_calls") would throw JSONException, dropping the
+            // entire chunk so that real tool_calls never accumulate.
+            if (delta.isNull("tool_calls")) continue
             val toolCallDeltas = delta.optJSONArray("tool_calls") ?: continue
             for (toolCallIndex in 0 until toolCallDeltas.length()) {
                 val toolCallDelta = toolCallDeltas.optJSONObject(toolCallIndex) ?: continue

--- a/app/src/test/java/com/zhousl/aether/data/OpenAiCompatibleClientStreamingTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/OpenAiCompatibleClientStreamingTest.kt
@@ -520,4 +520,57 @@ class OpenAiCompatibleClientStreamingTest {
             server.shutdown()
         }
     }
+
+    @Test
+    fun streamChatCompletionIgnoresNullToolCallsOnDeltaAndAccumulatesRealToolCalls() = runBlocking {
+        // Reproduces mimo-v2.5-pro behavior where deltas include
+        // \"tool_calls\": null before the actual tool_calls delta arrives.
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "text/event-stream")
+                .setBody(
+                    """
+                    data: {"choices":[{"delta":{"reasoning_content":"Need to read the file.","tool_calls":null}}]}
+
+                    data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"read","arguments":"{\"path\":\""}}]}}]}
+
+                    data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"README.md\"}"}}]}}]}
+
+                    data: [DONE]
+
+                    """.trimIndent()
+                )
+        )
+        server.start()
+
+        try {
+            val settings = AppSettings(
+                provider = LlmProvider.OpenAiCompatible,
+                apiKey = "test-key",
+                baseUrl = server.url("/v1").toString(),
+                modelId = "mimo-v2.5-pro",
+            )
+            val reasoningDeltas = StringBuilder()
+
+            val result = client.streamChatCompletion(
+                settings = settings,
+                systemPrompt = "",
+                conversation = listOf(
+                    JSONObject().apply {
+                        put("role", "user")
+                        put("content", "Read README.md")
+                    }
+                ),
+                onReasoningDelta = { reasoningDeltas.append(it) },
+            ).getOrThrow()
+
+            assertEquals("Need to read the file.", reasoningDeltas.toString())
+            assertEquals(1, result.toolCalls.size)
+            assertEquals("read", result.toolCalls.single().name)
+            assertEquals("""{"path":"README.md"}""", result.toolCalls.single().arguments)
+        } finally {
+            server.shutdown()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Treat null/blank/`"null"`/`"undefined"` `workingDirectory` and `working_directory` tool arguments as omitted.
- Normalize the working directory aliases to a single usable `working_directory` value before tool execution.
- Fall back to the current workspace directory when no usable working directory is provided.

## Why

Some tool-call-compatible models may emit optional fields explicitly as `null`, for example:

```json
{
  "path": ".",
  "workingDirectory": null,
  "working_directory": null
}
```

The previous implementation only checked whether the keys existed. Because JSON null keys still exist, the default workspace directory was not injected, and later path resolution could treat the value as `"null"`, causing failures such as:

```text
The working directory not found at path "/null".
```

## Testing

- Built a debug APK via GitHub Actions.
- Installed the APK locally.
- Verified that a tool call with both `workingDirectory: null` and `working_directory: null` now succeeds and uses the current workspace instead of failing with `/null`.
