### PR TITLE
feat(runtime): clean deleted chat runtime data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,6 +127,11 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    lint {
+        // targetSdk is intentionally capped at API 28 for local runtime execution.
+        disable += "ExpiredTargetSdkVersion"
+    }
 }
 
 kotlin {

--- a/app/src/main/java/com/zhousl/aether/data/AppSettings.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AppSettings.kt
@@ -162,6 +162,8 @@ data class AppSettings(
     val keepTasksRunningInBackground: Boolean = true,
     val notifyOnTaskCompletion: Boolean = true,
     val agentWorkspaceMode: AgentWorkspaceMode = AgentWorkspaceMode.Shared,
+    val autoCleanOldCommandHistory: Boolean = true,
+    val oldCommandHistoryRetentionHours: Int = DefaultOldCommandHistoryRetentionHours,
     val termuxSetupCompleted: Boolean = false,
     val termuxSetupNoticeDismissed: Boolean = false,
     val termuxLiveOutputEnabled: Boolean = true,
@@ -199,6 +201,9 @@ data class TermuxEnvironmentVariable(
 
 const val CurrentOnboardingVersion = 1
 const val DefaultLlmInactivityReconnectTimeoutSeconds = 360
+const val DefaultOldCommandHistoryRetentionHours = 6
+const val MinOldCommandHistoryRetentionHours = 1
+const val MaxOldCommandHistoryRetentionHours = 168
 private const val MinLlmInactivityReconnectTimeoutSeconds = 30
 private const val MaxLlmInactivityReconnectTimeoutSeconds = 3600
 const val OnboardingStarterPrompt = "Hi"
@@ -211,6 +216,17 @@ fun defaultAppLanguage(
     AppLanguage.SimplifiedChinese
 } else {
     AppLanguage.English
+}
+
+
+fun normalizeOldCommandHistoryRetentionHours(
+    value: Int?,
+): Int = when (value) {
+    null -> DefaultOldCommandHistoryRetentionHours
+    else -> value.coerceIn(
+        minimumValue = MinOldCommandHistoryRetentionHours,
+        maximumValue = MaxOldCommandHistoryRetentionHours,
+    )
 }
 
 fun normalizeLlmInactivityReconnectTimeoutSeconds(

--- a/app/src/main/java/com/zhousl/aether/data/SettingsRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SettingsRepository.kt
@@ -39,6 +39,11 @@ class SettingsRepository(
             } else {
                 defaults.agentWorkspaceMode
             },
+            autoCleanOldCommandHistory =
+                preferences[AUTO_CLEAN_OLD_COMMAND_HISTORY] ?: true,
+            oldCommandHistoryRetentionHours = normalizeOldCommandHistoryRetentionHours(
+                preferences[OLD_COMMAND_HISTORY_RETENTION_HOURS],
+            ),
             termuxSetupCompleted = preferences[TERMUX_SETUP_COMPLETED] ?: false,
             termuxSetupNoticeDismissed = preferences[TERMUX_SETUP_NOTICE_DISMISSED] ?: false,
             termuxLiveOutputEnabled = preferences[TERMUX_LIVE_OUTPUT_ENABLED] ?: true,
@@ -181,6 +186,9 @@ class SettingsRepository(
             it[NOTIFY_ON_TASK_COMPLETION] = settings.notifyOnTaskCompletion
             it[AGENT_WORKSPACE_MODE] = settings.agentWorkspaceMode.storageValue
             it[WORKSPACE_MODE_INITIALIZED] = true
+            it[AUTO_CLEAN_OLD_COMMAND_HISTORY] = settings.autoCleanOldCommandHistory
+            it[OLD_COMMAND_HISTORY_RETENTION_HOURS] =
+                normalizeOldCommandHistoryRetentionHours(settings.oldCommandHistoryRetentionHours)
             it[TERMUX_SETUP_COMPLETED] = settings.termuxSetupCompleted
             it[TERMUX_SETUP_NOTICE_DISMISSED] = settings.termuxSetupNoticeDismissed
             it[TERMUX_LIVE_OUTPUT_ENABLED] = settings.termuxLiveOutputEnabled
@@ -262,6 +270,9 @@ class SettingsRepository(
             it[NOTIFY_ON_TASK_COMPLETION] = settings.notifyOnTaskCompletion
             it[AGENT_WORKSPACE_MODE] = settings.agentWorkspaceMode.storageValue
             it[WORKSPACE_MODE_INITIALIZED] = true
+            it[AUTO_CLEAN_OLD_COMMAND_HISTORY] = settings.autoCleanOldCommandHistory
+            it[OLD_COMMAND_HISTORY_RETENTION_HOURS] =
+                normalizeOldCommandHistoryRetentionHours(settings.oldCommandHistoryRetentionHours)
             it[TERMUX_SETUP_COMPLETED] = settings.termuxSetupCompleted
             it[TERMUX_SETUP_NOTICE_DISMISSED] = settings.termuxSetupNoticeDismissed
             it[TERMUX_LIVE_OUTPUT_ENABLED] = settings.termuxLiveOutputEnabled
@@ -351,6 +362,10 @@ class SettingsRepository(
         val AGENT_WORKSPACE_MODE = stringPreferencesKey("agent_workspace_mode")
         val WORKSPACE_MODE_INITIALIZED =
             booleanPreferencesKey("workspace_mode_initialized")
+        val AUTO_CLEAN_OLD_COMMAND_HISTORY =
+            booleanPreferencesKey("auto_clean_old_command_history")
+        val OLD_COMMAND_HISTORY_RETENTION_HOURS =
+            intPreferencesKey("old_command_history_retention_hours")
         val TERMUX_SETUP_COMPLETED =
             booleanPreferencesKey("termux_setup_completed")
         val TERMUX_SETUP_NOTICE_DISMISSED =

--- a/app/src/main/java/com/zhousl/aether/data/WorkspaceFileBridge.kt
+++ b/app/src/main/java/com/zhousl/aether/data/WorkspaceFileBridge.kt
@@ -98,6 +98,143 @@ class WorkspaceFileBridge(
         parseStructuredStdout(raw.optString("stdout"))["legacy"] == "true"
     }
 
+    suspend fun deleteSessionRuntimeData(
+        sessionId: String,
+        sharedWorkspaceFilePaths: Collection<String> = emptyList(),
+    ): Result<Unit> = deleteSessionsRuntimeData(
+        sessionIds = listOf(sessionId),
+        sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+    )
+
+    private suspend fun deletePathUnderRoot(
+        path: String,
+        rootPath: String,
+        targetLabel: String,
+        skipUnsafePath: Boolean = false,
+        requireFile: Boolean = false,
+    ): Result<Unit> = runCatching {
+        val command = buildString {
+            appendCommonShellPreamble(this)
+            appendSafePathUnderRoot(
+                builder = this,
+                variableName = "delete_path",
+                path = path,
+                rootPath = rootPath,
+                skipUnsafePath = skipUnsafePath,
+            )
+            if (requireFile) {
+                appendLine("if [ -d \"\$delete_path\" ]; then")
+                appendLine("  emit_kv error 'refusing_directory_delete'")
+                appendLine("  exit 1")
+                appendLine("fi")
+                appendLine("if [ -e \"\$delete_path\" ] && [ ! -f \"\$delete_path\" ]; then")
+                appendLine("  emit_kv error 'refusing_non_file_delete'")
+                appendLine("  exit 1")
+                appendLine("fi")
+            }
+            appendLine("path_deleted=false")
+            appendLine("if [ -e \"\$delete_path\" ]; then")
+            appendLine("  rm -rf -- \"\$delete_path\"")
+            appendLine("  path_deleted=true")
+            appendLine("fi")
+            appendLine("emit_kv path_deleted \"\$path_deleted\"")
+        }
+        val raw = JSONObject(bashTool.executeCommand(command, awaitTimeoutMillis = 60_000L))
+        if (!raw.optBoolean("ok")) {
+            error(raw.optString("errmsg").ifBlank { raw.optString("stderr").ifBlank { "Couldn't delete $targetLabel." } })
+        }
+    }
+
+    private suspend fun deleteSessionWorkspace(sessionId: String): Result<Unit> = deletePathUnderRoot(
+        path = sessionWorkspaceDirectory(sessionId),
+        rootPath = perSessionWorkspacesRootDirectory(),
+        targetLabel = "session workspace",
+    )
+
+    private suspend fun deleteSharedWorkspaceFile(path: String): Result<Unit> = deletePathUnderRoot(
+        path = path,
+        rootPath = sharedWorkspaceUploadsDirectory(),
+        targetLabel = "shared workspace file",
+        skipUnsafePath = true,
+        requireFile = true,
+    )
+
+    suspend fun deleteSessionsRuntimeData(
+        sessionIds: Collection<String>,
+        sharedWorkspaceFilePaths: Collection<String> = emptyList(),
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val failures = mutableListOf<String>()
+            val uniqueSessionIds = sessionIds
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .distinct()
+            val uniqueSharedWorkspaceFilePaths = sharedWorkspaceFilePaths
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .distinct()
+
+            uniqueSessionIds.forEach { sessionId ->
+                deleteSessionWorkspace(sessionId = sessionId).onFailure { error ->
+                    failures += "workspace $sessionId: ${error.message.orEmpty()}"
+                }
+            }
+            uniqueSharedWorkspaceFilePaths.forEach { path ->
+                deleteSharedWorkspaceFile(path = path).onFailure { error ->
+                    failures += "shared file $path: ${error.message.orEmpty()}"
+                }
+            }
+            if (failures.isNotEmpty()) {
+                error(
+                    "Failed to clean up ${failures.size} runtime item(s): " +
+                        failures.joinToString(" | ")
+                )
+            }
+        }
+    }
+
+    private fun sessionWorkspaceDirectory(sessionId: String): String = workspaceDirectory(
+        sessionId = sessionId,
+        mode = AgentWorkspaceMode.PerSession,
+    )
+
+    private fun perSessionWorkspacesRootDirectory(): String =
+        "${TermuxContract.HomeDirectory}/$PerSessionWorkspaceBaseDirectoryName"
+
+    private fun sharedWorkspaceUploadsDirectory(): String =
+        "${TermuxContract.HomeDirectory}/$SharedWorkspaceBaseDirectoryName/uploads"
+
+    private fun appendSafePathUnderRoot(
+        builder: StringBuilder,
+        variableName: String,
+        path: String,
+        rootPath: String,
+        skipUnsafePath: Boolean = false,
+    ) {
+        builder.appendLine("$variableName=\"\$(decode_b64 '${encodeBase64(path)}')\"")
+        builder.appendLine("delete_root=\"\$(decode_b64 '${encodeBase64(rootPath)}')\"")
+        builder.appendLine("${variableName}_real=\"\$(realpath -m \"\$$variableName\")\"")
+        builder.appendLine("delete_root_real=\"\$(realpath -m \"\$delete_root\")\"")
+        builder.appendLine("if [ \"\$${variableName}_real\" = \"\$delete_root_real\" ]; then")
+        if (skipUnsafePath) {
+            builder.appendLine("  emit_kv path_skipped true")
+            builder.appendLine("  exit 0")
+        } else {
+            builder.appendLine("  emit_kv error 'refusing_delete_root_delete'")
+            builder.appendLine("  exit 1")
+        }
+        builder.appendLine("fi")
+        builder.appendLine("case \"\$${variableName}_real\" in")
+        builder.appendLine("  \"\$delete_root_real\"/*) ;;")
+        if (skipUnsafePath) {
+            builder.appendLine("  *) emit_kv path_skipped true; exit 0 ;;")
+        } else {
+            builder.appendLine("  *) emit_kv error 'refusing_unsafe_delete_path'; exit 1 ;;")
+        }
+        builder.appendLine("esac")
+        builder.appendLine("$variableName=\"\$${variableName}_real\"")
+    }
+
     suspend fun readWorkspaceFile(
         path: String,
         workingDirectory: String = TermuxContract.HomeDirectory,

--- a/app/src/main/java/com/zhousl/aether/termux/TermuxBashTool.kt
+++ b/app/src/main/java/com/zhousl/aether/termux/TermuxBashTool.kt
@@ -9,10 +9,14 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import com.zhousl.aether.BuildConfig
 import com.zhousl.aether.data.AetherDiagnosticLogger
+import com.zhousl.aether.data.DefaultOldCommandHistoryRetentionHours
+import com.zhousl.aether.data.MaxOldCommandHistoryRetentionHours
+import com.zhousl.aether.data.MinOldCommandHistoryRetentionHours
 import com.zhousl.aether.data.TermuxEnvironmentVariable
 import com.zhousl.aether.data.normalizeTermuxEnvironmentVariables
 import java.util.Base64
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -32,6 +36,7 @@ private const val TermuxLogTag = "AetherTermux"
 private val EnableTermuxLogging: Boolean
     get() = BuildConfig.DEBUG
 private const val EarlyManagedLaunchGraceMillis = 5_000L
+private const val ManagedBashRunPruneThrottleMillis = 60 * 60 * 1000L
 
 enum class TermuxSetupIssue {
     Ready,
@@ -55,9 +60,25 @@ class TermuxBashTool(
     private val diagnosticLogger: AetherDiagnosticLogger = AetherDiagnosticLogger.NoOp,
 ) {
     private val environmentVariables = AtomicReference<List<TermuxEnvironmentVariable>>(emptyList())
+    private val autoCleanOldCommandHistory = AtomicReference(true)
+    private val oldCommandHistoryRetentionHours = AtomicInteger(DefaultOldCommandHistoryRetentionHours)
+    private val lastManagedBashRunPruneAtMillis = AtomicLong(0L)
 
     fun setEnvironmentVariables(variables: List<TermuxEnvironmentVariable>) {
         environmentVariables.set(normalizeTermuxEnvironmentVariables(variables))
+    }
+
+    fun setManagedBashRunCleanupPolicy(
+        enabled: Boolean,
+        retentionHours: Int,
+    ) {
+        autoCleanOldCommandHistory.set(enabled)
+        oldCommandHistoryRetentionHours.set(
+            retentionHours.coerceIn(
+                minimumValue = MinOldCommandHistoryRetentionHours,
+                maximumValue = MaxOldCommandHistoryRetentionHours,
+            )
+        )
     }
 
     @Suppress("UNUSED_PARAMETER")
@@ -151,6 +172,7 @@ class TermuxBashTool(
                 stderr = raw.optString("stderr"),
             )
         }
+        maybePruneExpiredManagedBashRuns()
         try {
             val startedAtMillis = System.currentTimeMillis()
             val initialResult = executeManagedScript(
@@ -173,6 +195,58 @@ class TermuxBashTool(
         } catch (cancellationException: CancellationException) {
             runCatching { killExecutionByRunId(runId) }
             throw cancellationException
+        }
+    }
+
+
+    private suspend fun maybePruneExpiredManagedBashRuns() {
+        if (!autoCleanOldCommandHistory.get()) return
+        val nowMillis = System.currentTimeMillis()
+        val previousPruneMillis = lastManagedBashRunPruneAtMillis.get()
+        if (nowMillis - previousPruneMillis < ManagedBashRunPruneThrottleMillis) return
+        if (!lastManagedBashRunPruneAtMillis.compareAndSet(previousPruneMillis, nowMillis)) return
+
+        val retentionMillis = oldCommandHistoryRetentionHours.get() * 60L * 60L * 1000L
+        val raw = runCatching {
+            JSONObject(
+                dispatchCommand(
+                    command = buildPruneExpiredManagedBashRunsScript(retentionMillis),
+                    workingDirectory = TermuxContract.HomeDirectory,
+                    awaitTimeoutMillis = InternalCommandTimeoutMillis,
+                )
+            )
+        }.getOrElse { throwable ->
+            lastManagedBashRunPruneAtMillis.set(0L)
+            diagnosticLogger.exception(
+                category = "storage",
+                event = "old_command_history_cleanup_failed",
+                throwable = throwable,
+                level = "warn",
+            )
+            return
+        }
+
+        if (raw.optBoolean("ok")) {
+            val values = parseKeyValueOutput(raw.optString("stdout"))
+            diagnosticLogger.event(
+                category = "storage",
+                event = "old_command_history_cleanup_completed",
+                details = mapOf(
+                    "deleted_count" to (values["expired_bash_runs_deleted"] ?: "0"),
+                    "retention_hours" to oldCommandHistoryRetentionHours.get(),
+                ),
+            )
+        } else {
+            lastManagedBashRunPruneAtMillis.set(0L)
+            diagnosticLogger.event(
+                category = "storage",
+                event = "old_command_history_cleanup_failed",
+                level = "warn",
+                details = mapOf(
+                    "message" to raw.optString("errmsg").ifBlank { raw.optString("stderr") },
+                    "retention_hours" to oldCommandHistoryRetentionHours.get(),
+                ),
+            )
         }
     }
 
@@ -706,6 +780,46 @@ class TermuxBashTool(
             put("hint", hint)
         }
     }.toString()
+
+
+    private fun buildPruneExpiredManagedBashRunsScript(retentionMillis: Long): String = buildString {
+        appendManagedShellPreamble(this)
+        appendLine("read_trimmed_file() {")
+        appendLine("  local file_path=\"\$1\"")
+        appendLine("  if [ ! -f \"\$file_path\" ]; then")
+        appendLine("    printf ''")
+        appendLine("    return 0")
+        appendLine("  fi")
+        appendLine("  tr -d '[:space:]' < \"\$file_path\"")
+        appendLine("}")
+        appendLine("bash_runs_dir='${escapeForSingleQuoted(TermuxContract.ManagedCommandsDirectory)}'")
+        appendLine("bash_runs_deleted=0")
+        appendLine("bash_runs_retention_ms=${retentionMillis.coerceAtLeast(1L)}")
+        appendLine("now_ms=\"\$(date +%s%3N)\"")
+        appendLine("if [ -d \"\$bash_runs_dir\" ]; then")
+        appendLine("  for run_dir in \"\$bash_runs_dir\"/*; do")
+        appendLine("    [ -d \"\$run_dir\" ] || continue")
+        appendLine("    state=\"\$(read_trimmed_file \"\$run_dir/state\")\"")
+        appendLine("    case \"\$state\" in")
+        appendLine("      completed|failed|cancelled|killed) ;;")
+        appendLine("      *) continue ;;")
+        appendLine("    esac")
+        appendLine("    finished_at=\"\$(read_trimmed_file \"\$run_dir/finished_at\")\"")
+        appendLine("    case \"\$finished_at\" in")
+        appendLine("      ''|*[!0-9]*)")
+        appendLine("        modified_seconds=\"\$(stat -c %Y \"\$run_dir\" 2>/dev/null || printf '0')\"")
+        appendLine("        finished_at=\$((modified_seconds * 1000))")
+        appendLine("        ;;")
+        appendLine("    esac")
+        appendLine("    age_ms=\$((now_ms - finished_at))")
+        appendLine("    if [ \"\$age_ms\" -ge \"\$bash_runs_retention_ms\" ]; then")
+        appendLine("      rm -rf -- \"\$run_dir\"")
+        appendLine("      bash_runs_deleted=\$((bash_runs_deleted + 1))")
+        appendLine("    fi")
+        appendLine("  done")
+        appendLine("fi")
+        appendLine("emit_kv expired_bash_runs_deleted \"\$bash_runs_deleted\"")
+    }
 
     private fun buildLaunchManagedCommandScript(
         runId: String,

--- a/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
@@ -696,6 +696,10 @@ private fun AetherAppContent(
                     keepTasksRunningInBackground = uiState.settings.keepTasksRunningInBackground,
                     notifyOnTaskCompletion = uiState.settings.notifyOnTaskCompletion,
                     agentWorkspaceMode = uiState.settings.agentWorkspaceMode,
+                    autoCleanOldCommandHistory =
+                        uiState.settings.autoCleanOldCommandHistory,
+                    oldCommandHistoryRetentionHours =
+                        uiState.settings.oldCommandHistoryRetentionHours,
                     termuxLiveOutputEnabled = uiState.settings.termuxLiveOutputEnabled,
                     termuxEnvironmentVariables = uiState.settings.termuxEnvironmentVariables,
                     agentModeAuthorizationEnabled = uiState.settings.agentModeAuthorizationEnabled,

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -32,6 +32,7 @@ import com.zhousl.aether.data.McpServerConfig
 import com.zhousl.aether.data.McpServerTestOperation
 import com.zhousl.aether.data.normalizeSelectableModelKey
 import com.zhousl.aether.data.normalizeLlmInactivityReconnectTimeoutSeconds
+import com.zhousl.aether.data.normalizeOldCommandHistoryRetentionHours
 import com.zhousl.aether.data.normalizeTavilyBaseUrl
 import com.zhousl.aether.data.OnboardingStarterPrompt
 import com.zhousl.aether.data.OpenAiCompatibleClient
@@ -160,6 +161,10 @@ class AetherViewModel(
                 }
                 syncTermuxSettings()
                 bashTool.setEnvironmentVariables(settings.termuxEnvironmentVariables)
+                bashTool.setManagedBashRunCleanupPolicy(
+                    enabled = settings.autoCleanOldCommandHistory,
+                    retentionHours = settings.oldCommandHistoryRetentionHours,
+                )
                 runtime.alpineRuntime.setEnvironmentVariables(settings.alpineEnvironmentVariables)
                 if (!didEvaluateStartupUpdateCheck && settings.privacyPolicyAccepted) {
                     didEvaluateStartupUpdateCheck = true
@@ -1087,7 +1092,10 @@ class AetherViewModel(
         }
 
         var didUpdate = false
+        var sharedWorkspaceFilePaths = emptyList<String>()
         _uiState.update { current ->
+            val session = current.sessions.firstOrNull { it.id == sessionId } ?: return@update current
+            sharedWorkspaceFilePaths = session.workspaceFilePathsForCleanup()
             val updatedSessions = current.sessions.filterNot { it.id == sessionId }
             if (updatedSessions.size == current.sessions.size) return@update current
             didUpdate = true
@@ -1104,7 +1112,10 @@ class AetherViewModel(
             )
         }
         if (didUpdate) {
-            persistDeleteSession(sessionId)
+            persistDeleteSession(
+                sessionId = sessionId,
+                sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+            )
             captureAnalyticsEvent(event = "conversation deleted")
         }
     }
@@ -1282,6 +1293,7 @@ class AetherViewModel(
         var didUpdate = false
         var updatedSessionForPersistence: ChatSession? = null
         var removedSessionForPersistence = false
+        var sharedWorkspaceFilePaths = emptyList<String>()
 
         _uiState.update { current ->
             val sessionIndex = current.sessions.indexOfFirst { it.id == sessionId }
@@ -1296,11 +1308,14 @@ class AetherViewModel(
             val updatedSessions = current.sessions.toMutableList().apply {
                 removeAt(sessionIndex)
                 if (trimmedMessages.isNotEmpty()) {
+                    val removedMessages = session.messages.drop(trimFromIndex)
                     val updatedSession = session.withMessages(trimmedMessages)
                     updatedSessionForPersistence = updatedSession
+                    sharedWorkspaceFilePaths = session.copy(messages = removedMessages).workspaceFilePathsForCleanup()
                     add(sessionIndex.coerceAtMost(size), updatedSession)
                 } else {
                     removedSessionForPersistence = true
+                    sharedWorkspaceFilePaths = session.workspaceFilePathsForCleanup()
                 }
             }
 
@@ -1345,8 +1360,15 @@ class AetherViewModel(
 
         if (didUpdate) {
             if (removedSessionForPersistence) {
-                persistDeleteSession(sessionId)
+                persistDeleteSession(
+                    sessionId = sessionId,
+                    sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+                )
             } else {
+                cleanupSharedWorkspaceFilesIfUnreferenced(
+                    sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+                    excludedSessionIds = emptySet(),
+                )
                 updatedSessionForPersistence?.let(::persistSessionSnapshot)
             }
         }
@@ -1542,6 +1564,8 @@ class AetherViewModel(
         keepTasksRunningInBackground: Boolean,
         notifyOnTaskCompletion: Boolean,
         agentWorkspaceMode: AgentWorkspaceMode,
+        autoCleanOldCommandHistory: Boolean,
+        oldCommandHistoryRetentionHours: Int,
         termuxLiveOutputEnabled: Boolean,
         termuxEnvironmentVariables: List<TermuxEnvironmentVariable>,
         agentModeAuthorizationEnabled: Boolean,
@@ -1590,6 +1614,10 @@ class AetherViewModel(
                     keepTasksRunningInBackground = keepTasksRunningInBackground,
                     notifyOnTaskCompletion = notifyOnTaskCompletion,
                     agentWorkspaceMode = agentWorkspaceMode,
+                    autoCleanOldCommandHistory = autoCleanOldCommandHistory,
+                    oldCommandHistoryRetentionHours = normalizeOldCommandHistoryRetentionHours(
+                        oldCommandHistoryRetentionHours
+                    ),
                     termuxLiveOutputEnabled = termuxLiveOutputEnabled,
                     termuxEnvironmentVariables = normalizeTermuxEnvironmentVariables(termuxEnvironmentVariables),
                     agentModeAuthorizationEnabled = agentModeAuthorizationEnabled,
@@ -2659,8 +2687,22 @@ class AetherViewModel(
         }
     }
 
-    private fun persistDeleteSession(sessionId: String) {
+    private fun ChatSession.workspaceFilePathsForCleanup(): List<String> = messages
+        .flatMap { message -> message.attachments }
+        .map { attachment -> attachment.workspacePath.trim() }
+        .filter(String::isNotEmpty)
+        .distinct()
+
+    private fun persistDeleteSession(
+        sessionId: String,
+        sharedWorkspaceFilePaths: Collection<String> = emptyList(),
+    ) {
+        var unreferencedSharedWorkspaceFilePaths = emptyList<String>()
         chatStateStore.update { persisted ->
+            unreferencedSharedWorkspaceFilePaths = sharedWorkspaceFilePaths.unreferencedWorkspaceFilePaths(
+                sessions = persisted.sessions,
+                excludedSessionIds = setOf(sessionId),
+            )
             val updatedSessions = persisted.sessions.filterNot { it.id == sessionId }
             persisted.copy(
                 sessions = updatedSessions,
@@ -2670,6 +2712,89 @@ class AetherViewModel(
                     persisted.currentSessionId
                 },
             )
+        }
+        scheduleSessionRuntimeDataCleanup(
+            sessionIds = listOf(sessionId),
+            sharedWorkspaceFilePaths = unreferencedSharedWorkspaceFilePaths,
+            mode = _uiState.value.settings.agentWorkspaceMode,
+        )
+    }
+
+    private fun cleanupSharedWorkspaceFilesIfUnreferenced(
+        sharedWorkspaceFilePaths: Collection<String>,
+        excludedSessionIds: Set<String>,
+    ) {
+        val unreferencedSharedWorkspaceFilePaths = sharedWorkspaceFilePaths.unreferencedWorkspaceFilePaths(
+            sessions = _uiState.value.sessions,
+            excludedSessionIds = excludedSessionIds,
+        )
+        if (unreferencedSharedWorkspaceFilePaths.isEmpty()) return
+        scheduleSessionRuntimeDataCleanup(
+            sessionIds = emptyList(),
+            sharedWorkspaceFilePaths = unreferencedSharedWorkspaceFilePaths,
+            mode = _uiState.value.settings.agentWorkspaceMode,
+        )
+    }
+
+    private fun Collection<String>.unreferencedWorkspaceFilePaths(
+        sessions: Collection<ChatSession>,
+        excludedSessionIds: Set<String>,
+    ): List<String> {
+        val candidatePaths = map(String::trim)
+            .filter(String::isNotEmpty)
+            .distinct()
+        if (candidatePaths.isEmpty()) return emptyList()
+
+        val referencedPaths = sessions
+            .asSequence()
+            .filterNot { session -> session.id in excludedSessionIds }
+            .flatMap { session -> session.workspaceFilePathsForCleanup().asSequence() }
+            .toSet()
+        return candidatePaths.filterNot(referencedPaths::contains)
+    }
+
+    private fun scheduleSessionRuntimeDataCleanup(
+        sessionIds: Collection<String>,
+        sharedWorkspaceFilePaths: Collection<String>,
+        mode: AgentWorkspaceMode,
+    ) {
+        val cleanupSessionIds = sessionIds
+            .filter { it.isNotBlank() && it != DraftSessionId }
+            .distinct()
+        val sharedWorkspaceFileCount = sharedWorkspaceFilePaths.distinct().size
+        if (cleanupSessionIds.isEmpty() && sharedWorkspaceFileCount == 0) return
+
+        viewModelScope.launch {
+            workspaceFileBridge.deleteSessionsRuntimeData(
+                sessionIds = cleanupSessionIds,
+                sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+            )
+                .onSuccess {
+                    diagnosticLogger.event(
+                        category = "storage",
+                        event = "deleted_session_runtime_cleanup_completed",
+                        sessionId = cleanupSessionIds.singleOrNull(),
+                        details = mapOf(
+                            "session_count" to cleanupSessionIds.size,
+                            "shared_workspace_file_count" to sharedWorkspaceFileCount,
+                            "settings_workspace_mode" to mode.storageValue,
+                        ),
+                    )
+                }
+                .onFailure { throwable ->
+                    diagnosticLogger.exception(
+                        category = "storage",
+                        event = "deleted_session_runtime_cleanup_failed",
+                        throwable = throwable,
+                        level = "warn",
+                        sessionId = cleanupSessionIds.singleOrNull(),
+                        details = mapOf(
+                            "session_count" to cleanupSessionIds.size,
+                            "shared_workspace_file_count" to sharedWorkspaceFileCount,
+                            "settings_workspace_mode" to mode.storageValue,
+                        ),
+                    )
+                }
         }
     }
 
@@ -4098,6 +4223,8 @@ class AetherViewModel(
                 }
             },
         )
+        put("autoCleanOldCommandHistory", autoCleanOldCommandHistory)
+        put("oldCommandHistoryRetentionHours", oldCommandHistoryRetentionHours)
         put("agentModeAuthorizationEnabled", agentModeAuthorizationEnabled)
         put("agentModeAuthorizationMethod", agentModeAuthorizationMethod.storageValue)
         put("language", language.storageValue)
@@ -4161,6 +4288,16 @@ class AetherViewModel(
             termuxLiveOutputEnabled = json.optBoolean(
                 "termuxLiveOutputEnabled",
                 defaults.termuxLiveOutputEnabled,
+            ),
+            autoCleanOldCommandHistory = json.optBoolean(
+                "autoCleanOldCommandHistory",
+                defaults.autoCleanOldCommandHistory,
+            ),
+            oldCommandHistoryRetentionHours = normalizeOldCommandHistoryRetentionHours(
+                json.optInt(
+                    "oldCommandHistoryRetentionHours",
+                    defaults.oldCommandHistoryRetentionHours,
+                )
             ),
             enabledRuntimeIds = parseImportedRuntimeIds(json.optJSONArray("enabledRuntimeIds")),
             defaultRuntimeId = LocalRuntimeId.fromStorage(json.optString("defaultRuntimeId")),

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -2687,11 +2687,20 @@ class AetherViewModel(
         }
     }
 
-    private fun ChatSession.workspaceFilePathsForCleanup(): List<String> = messages
-        .flatMap { message -> message.attachments }
-        .map { attachment -> attachment.workspacePath.trim() }
-        .filter(String::isNotEmpty)
-        .distinct()
+    private fun ChatSession.workspaceFilePathsForCleanup(): List<String> =
+        messages.collectWorkspaceFilePathsForCleanup().distinct()
+
+    private fun List<ChatMessage>.collectWorkspaceFilePathsForCleanup(): List<String> =
+        flatMap { message -> message.collectWorkspaceFilePathsForCleanup() }
+
+    private fun ChatMessage.collectWorkspaceFilePathsForCleanup(): List<String> =
+        attachments
+            .map { attachment -> attachment.workspacePath.trim() }
+            .filter(String::isNotEmpty) +
+            branchGroup
+                ?.branches
+                .orEmpty()
+                .flatMap { branch -> branch.collectWorkspaceFilePathsForCleanup() }
 
     private fun persistDeleteSession(
         sessionId: String,

--- a/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
@@ -97,6 +98,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -113,7 +115,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
@@ -157,6 +158,7 @@ import com.zhousl.aether.data.availableModels
 import com.zhousl.aether.data.enabledModels
 import com.zhousl.aether.data.findModelOption
 import com.zhousl.aether.data.normalizeLlmInactivityReconnectTimeoutSeconds
+import com.zhousl.aether.data.normalizeOldCommandHistoryRetentionHours
 import com.zhousl.aether.data.normalizeTavilyBaseUrl
 import com.zhousl.aether.data.quickActionLabel
 import com.zhousl.aether.data.resolveAutomaticModelKey
@@ -388,6 +390,8 @@ fun SettingsScreen(
     keepTasksRunningInBackground: Boolean,
     notifyOnTaskCompletion: Boolean,
     agentWorkspaceMode: AgentWorkspaceMode,
+    autoCleanOldCommandHistory: Boolean,
+    oldCommandHistoryRetentionHours: Int,
     termuxLiveOutputEnabled: Boolean,
     termuxEnvironmentVariables: List<TermuxEnvironmentVariable>,
     agentModeAuthorizationEnabled: Boolean,
@@ -427,6 +431,8 @@ fun SettingsScreen(
         Boolean,
         Boolean,
         AgentWorkspaceMode,
+        Boolean,
+        Int,
         Boolean,
         List<TermuxEnvironmentVariable>,
         Boolean,
@@ -515,6 +521,12 @@ fun SettingsScreen(
     var agentWorkspaceModeValue by rememberSaveable {
         mutableStateOf(agentWorkspaceMode)
     }
+    var autoCleanOldCommandHistoryValue by rememberSaveable {
+        mutableStateOf(autoCleanOldCommandHistory)
+    }
+    var oldCommandHistoryRetentionHoursValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(oldCommandHistoryRetentionHours.toString()))
+    }
     var termuxLiveOutputEnabledValue by rememberSaveable {
         mutableStateOf(termuxLiveOutputEnabled)
     }
@@ -532,6 +544,13 @@ fun SettingsScreen(
     }
     var themeModeValue by rememberSaveable {
         mutableStateOf(themeMode)
+    }
+    LaunchedEffect(
+        autoCleanOldCommandHistory,
+        oldCommandHistoryRetentionHours,
+    ) {
+        autoCleanOldCommandHistoryValue = autoCleanOldCommandHistory
+        oldCommandHistoryRetentionHoursValue = TextFieldValue(oldCommandHistoryRetentionHours.toString())
     }
     LaunchedEffect(language) {
         languageValue = language
@@ -576,6 +595,10 @@ fun SettingsScreen(
             keepTasksRunningInBackgroundValue,
             notifyOnTaskCompletionValue,
             agentWorkspaceModeValue,
+            autoCleanOldCommandHistoryValue,
+            normalizeOldCommandHistoryRetentionHours(
+                oldCommandHistoryRetentionHoursValue.text.trim().toIntOrNull()
+            ),
             termuxLiveOutputEnabledValue,
             termuxEnvironmentVariablesValue,
             agentModeAuthorizationEnabledValue,
@@ -606,6 +629,10 @@ fun SettingsScreen(
             keepTasksRunningInBackgroundValue,
             notifyOnTaskCompletionValue,
             agentWorkspaceModeValue,
+            autoCleanOldCommandHistoryValue,
+            normalizeOldCommandHistoryRetentionHours(
+                oldCommandHistoryRetentionHoursValue.text.trim().toIntOrNull()
+            ),
             termuxLiveOutputEnabledValue,
             termuxEnvironmentVariablesValue,
             agentModeAuthorizationEnabledValue,
@@ -636,6 +663,10 @@ fun SettingsScreen(
             keepTasksRunningInBackgroundValue,
             notifyOnTaskCompletionValue,
             agentWorkspaceModeValue,
+            autoCleanOldCommandHistoryValue,
+            normalizeOldCommandHistoryRetentionHours(
+                oldCommandHistoryRetentionHoursValue.text.trim().toIntOrNull()
+            ),
             termuxLiveOutputEnabledValue,
             termuxEnvironmentVariablesValue,
             agentModeAuthorizationEnabledValue,
@@ -1133,6 +1164,10 @@ fun SettingsScreen(
                 onExportAppData = onExportAppData,
                 onExportLogs = onExportLogs,
                 onForceUpdateCheckForTesting = onForceUpdateCheckForTesting,
+                autoCleanOldCommandHistory = autoCleanOldCommandHistoryValue,
+                oldCommandHistoryRetentionHours = oldCommandHistoryRetentionHoursValue,
+                onAutoCleanOldCommandHistoryChanged = { autoCleanOldCommandHistoryValue = it },
+                onOldCommandHistoryRetentionHoursChanged = { oldCommandHistoryRetentionHoursValue = it },
                 termuxReadyForTesting = developerTermuxReadyOverride ?: termuxSetupState.isReady,
                 onTermuxReadyForTestingChanged = onSetDeveloperTermuxReadyOverride,
                 onBack = { currentPage = SettingsPage.Hub.name },
@@ -3983,6 +4018,45 @@ private fun TermuxSettingsPage(
 }
 
 @Composable
+private fun RuntimeCleanupDeveloperSettingsSection(
+    autoCleanOldCommandHistory: Boolean,
+    oldCommandHistoryRetentionHours: TextFieldValue,
+    onAutoCleanOldCommandHistoryChanged: (Boolean) -> Unit,
+    onOldCommandHistoryRetentionHoursChanged: (TextFieldValue) -> Unit,
+) {
+    SettingsCardGroup {
+        Column(modifier = Modifier.padding(16.dp)) {
+            SettingsToggleRow(
+                title = stringResource(R.string.settings_old_command_history_retention_hours),
+                subtitle = stringResource(R.string.settings_old_command_history_retention_hours_description),
+                checked = autoCleanOldCommandHistory,
+                onCheckedChange = onAutoCleanOldCommandHistoryChanged,
+            )
+            AnimatedVisibility(visible = autoCleanOldCommandHistory) {
+                Column {
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = oldCommandHistoryRetentionHours,
+                        onValueChange = { value ->
+                            onOldCommandHistoryRetentionHoursChanged(
+                                value.copy(text = value.text.filter(Char::isDigit)),
+                            )
+                        },
+                        label = { Text(stringResource(R.string.settings_old_command_history_retention_hours_value)) },
+                        supportingText = {
+                            Text(stringResource(R.string.settings_old_command_history_retention_hours_value_description))
+                        },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun TermuxLiveOutputSettingsSection(
     liveOutputEnabled: Boolean,
     onLiveOutputEnabledChanged: (Boolean) -> Unit,
@@ -5060,6 +5134,10 @@ private fun DeveloperSettingsPage(
     onExportAppData: () -> Unit,
     onExportLogs: () -> Unit,
     onForceUpdateCheckForTesting: () -> Unit,
+    autoCleanOldCommandHistory: Boolean,
+    oldCommandHistoryRetentionHours: TextFieldValue,
+    onAutoCleanOldCommandHistoryChanged: (Boolean) -> Unit,
+    onOldCommandHistoryRetentionHoursChanged: (TextFieldValue) -> Unit,
     termuxReadyForTesting: Boolean,
     onTermuxReadyForTestingChanged: (Boolean) -> Unit,
     onBack: () -> Unit,
@@ -5149,6 +5227,15 @@ private fun DeveloperSettingsPage(
                 )
             }
         }
+
+        Spacer(Modifier.height(14.dp))
+
+        RuntimeCleanupDeveloperSettingsSection(
+            autoCleanOldCommandHistory = autoCleanOldCommandHistory,
+            oldCommandHistoryRetentionHours = oldCommandHistoryRetentionHours,
+            onAutoCleanOldCommandHistoryChanged = onAutoCleanOldCommandHistoryChanged,
+            onOldCommandHistoryRetentionHoursChanged = onOldCommandHistoryRetentionHoursChanged,
+        )
 
         Spacer(Modifier.height(14.dp))
 

--- a/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
@@ -74,7 +74,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
@@ -4035,20 +4034,22 @@ private fun RuntimeCleanupDeveloperSettingsSection(
             AnimatedVisibility(visible = autoCleanOldCommandHistory) {
                 Column {
                     Spacer(Modifier.height(12.dp))
-                    OutlinedTextField(
+                    ChatGptTextField(
                         value = oldCommandHistoryRetentionHours,
                         onValueChange = { value ->
                             onOldCommandHistoryRetentionHoursChanged(
                                 value.copy(text = value.text.filter(Char::isDigit)),
                             )
                         },
-                        label = { Text(stringResource(R.string.settings_old_command_history_retention_hours_value)) },
-                        supportingText = {
-                            Text(stringResource(R.string.settings_old_command_history_retention_hours_value_description))
-                        },
-                        singleLine = true,
+                        label = stringResource(R.string.settings_old_command_history_retention_hours_value),
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(R.string.settings_old_command_history_retention_hours_value_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = AetherOnSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp),
                     )
                 }
             }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -760,4 +760,8 @@
     <string name="onboarding_alpine_status_missing_assets">当前构建尚未包含 Alpine 运行环境资源。</string>
     <string name="onboarding_alpine_status_failed">Alpine 未能启动。之后可以在设置里重试。</string>
     <string name="onboarding_alpine_status_not_ready">Alpine 尚未就绪。</string>
+    <string name="settings_old_command_history_retention_hours">清理旧命令输出</string>
+    <string name="settings_old_command_history_retention_hours_description">运行新的 bash 命令时，会清理过期的已结束输出。运行中的命令不受影响。</string>
+    <string name="settings_old_command_history_retention_hours_value">输出保留时长</string>
+    <string name="settings_old_command_history_retention_hours_value_description">默认 6 小时，范围 1–168。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -781,4 +781,8 @@
     <string name="onboarding_alpine_status_missing_assets">This build does not include the Alpine runtime assets yet.</string>
     <string name="onboarding_alpine_status_failed">Alpine could not start. You can retry later from Settings.</string>
     <string name="onboarding_alpine_status_not_ready">Alpine is not ready yet.</string>
+    <string name="settings_old_command_history_retention_hours">Clean up old command output</string>
+    <string name="settings_old_command_history_retention_hours_description">Expired completed output is cleaned up when starting new bash commands. Running commands are unaffected.</string>
+    <string name="settings_old_command_history_retention_hours_value">Keep output for</string>
+    <string name="settings_old_command_history_retention_hours_value_description">Default: 6 hours. Range: 1–168.</string>
 </resources>


### PR DESCRIPTION
### Summary

This PR adds runtime cleanup for deleted chats and old command output.

- Delete per-session workspaces when chats are removed.
- Clean unreferenced shared workspace uploads for Single Workspace mode.
- Preserve shared uploads that are still referenced by other chats.
- Add old command output cleanup for completed bash runs.
- Add Developer settings for command history cleanup and retention.
- Suppress the intentional `targetSdk 28` lint warning for local runtime support.

### Details

#### Chat runtime cleanup

When a chat is deleted, Aether now cleans up its associated runtime files:

- Independent Workspace:
  - deletes the corresponding session workspace under:
    `~/.aether/workspaces/<sessionId>`

- Single Workspace:
  - deletes only unreferenced uploaded files under:
    `~/.aether/workspace/uploads/`
  - keeps files that are still referenced by other chats.

Deletion uses canonical path checks to avoid removing shared workspace roots, unrelated `.aether` data, or files outside the allowed cleanup roots.

#### Bash command output cleanup

Aether now prunes expired completed bash command output when starting new bash commands.

- Default retention: 6 hours
- Allowed range: 1–168 hours
- Running commands are not affected
- Cleanup is configurable from Developer settings

#### Build

Adds a lint suppression for `ExpiredTargetSdkVersion` because `targetSdk = 28` is intentionally retained for local runtime execution.

### Validation
- Tested on a physical Android device.
- Verified the affected cleanup flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new developer setting to automatically clean up old command history.
  * Users can now choose how long completed command output is kept, with a configurable retention period.

* **Bug Fixes**
  * Improved cleanup of session-related runtime files and shared workspace files when chats or messages are deleted.
  * Added safer deletion handling to reduce the risk of removing files outside the intended workspace.

* **Documentation**
  * Added new on-screen text for the cleanup setting in English and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->