### PR TITLE
feat(history): store chat history in Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.posthog.android)
 }
@@ -132,6 +133,16 @@ android {
         // targetSdk is intentionally capped at API 28 for local runtime execution.
         disable += "ExpiredTargetSdkVersion"
     }
+
+    sourceSets {
+        getByName("androidTest").assets.srcDir("$projectDir/schemas")
+    }
+}
+
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+    arg("room.incremental", "true")
+    arg("room.generateKotlin", "true")
 }
 
 kotlin {
@@ -150,6 +161,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
@@ -172,9 +186,11 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.squareup.okhttp.mockwebserver)
     testImplementation(libs.json)
-
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation(libs.junit4)
+    androidTestImplementation(libs.androidx.room.testing)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.ext.junit)
 }
 
 tasks.withType<PostHogCliExecTask>().configureEach {

--- a/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/1.json
+++ b/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/1.json
@@ -1,0 +1,253 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "1dcf1f4b4f0ca914011d1c9c3e30378d",
+    "entities": [
+      {
+        "tableName": "chat_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `preview` TEXT NOT NULL, `hasCustomTitle` INTEGER NOT NULL, `selectedSkillIdsJson` TEXT NOT NULL, `activeSkillsJson` TEXT NOT NULL, `activeMcpServerIdsJson` TEXT NOT NULL, `agentModeEnabled` INTEGER NOT NULL, `selectedModelKey` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomTitle",
+            "columnName": "hasCustomTitle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSkillIdsJson",
+            "columnName": "selectedSkillIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeSkillsJson",
+            "columnName": "activeSkillsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeMcpServerIdsJson",
+            "columnName": "activeMcpServerIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentModeEnabled",
+            "columnName": "agentModeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedModelKey",
+            "columnName": "selectedModelKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `id` TEXT NOT NULL, `position` INTEGER NOT NULL, `messageJson` TEXT NOT NULL, `author` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAtMillis` INTEGER, `responseGroupId` TEXT, `displayKind` TEXT, `messageSchemaVersion` INTEGER NOT NULL, PRIMARY KEY(`sessionId`, `id`), FOREIGN KEY(`sessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageJson",
+            "columnName": "messageJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "responseGroupId",
+            "columnName": "responseGroupId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayKind",
+            "columnName": "displayKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "messageSchemaVersion",
+            "columnName": "messageSchemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_sessionId_position",
+            "unique": true,
+            "columnNames": [
+              "sessionId",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chat_messages_sessionId_position` ON `${TABLE_NAME}` (`sessionId`, `position`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_responseGroupId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "responseGroupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_responseGroupId` ON `${TABLE_NAME}` (`sessionId`, `responseGroupId`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_author",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "author"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_author` ON `${TABLE_NAME}` (`sessionId`, `author`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_state_meta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `currentSessionId` TEXT, `roomMigrationComplete` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`currentSessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentSessionId",
+            "columnName": "currentSessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roomMigrationComplete",
+            "columnName": "roomMigrationComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_state_meta_currentSessionId",
+            "unique": false,
+            "columnNames": [
+              "currentSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_state_meta_currentSessionId` ON `${TABLE_NAME}` (`currentSessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "currentSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1dcf1f4b4f0ca914011d1c9c3e30378d')"
+    ]
+  }
+}

--- a/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
@@ -1,0 +1,53 @@
+package com.zhousl.aether.data
+
+import com.zhousl.aether.data.chatdb.ChatMessageEntity
+import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.MessageAuthor
+import com.zhousl.aether.ui.MessageDisplayKind
+import org.json.JSONObject
+
+internal const val CurrentMessageSchemaVersion = 2
+
+internal object ChatMessageEntityMapper {
+    fun toEntity(
+        sessionId: String,
+        position: Int,
+        message: ChatMessage,
+    ): ChatMessageEntity {
+        val messageJson = message.toJson().toString()
+        return ChatMessageEntity(
+            sessionId = sessionId,
+            id = message.id,
+            position = position,
+            messageJson = messageJson,
+            author = message.author.name,
+            text = message.text,
+            createdAtMillis = message.createdAtMillis.takeIf { it > 0L },
+            responseGroupId = message.responseGroupId,
+            displayKind = message.displayKind.name,
+            messageSchemaVersion = CurrentMessageSchemaVersion,
+        )
+    }
+
+    fun toChatMessage(
+        entity: ChatMessageEntity,
+        messageIndex: Int,
+    ): ChatMessage = runCatching {
+        // Keep messageJson as the compatibility source of truth during the typed-column transition.
+        parseMessage(JSONObject(entity.messageJson), messageIndex)
+    }.getOrElse { throwable ->
+        ChatMessage(
+            id = entity.id,
+            author = MessageAuthor.entries.firstOrNull { it.name == entity.author } ?: MessageAuthor.Agent,
+            text = entity.text.ifBlank {
+                "Aether could not render a stored message (${throwable.javaClass.simpleName}). " +
+                    "The raw stored JSON is attached to the message payload for recovery."
+            },
+            createdAtMillis = entity.createdAtMillis ?: timestampFromMessageId(entity.id),
+            responseGroupId = entity.responseGroupId,
+            providerPayloadJson = entity.messageJson,
+            displayKind = MessageDisplayKind.entries.firstOrNull { it.name == entity.displayKind }
+                ?: MessageDisplayKind.Standard,
+        )
+    }
+}

--- a/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
@@ -1,6 +1,7 @@
 package com.zhousl.aether.data
 
 import com.zhousl.aether.data.chatdb.ChatMessageEntity
+import com.zhousl.aether.data.chatdb.ChatMessageSummaryEntity
 import com.zhousl.aether.ui.ChatMessage
 import com.zhousl.aether.ui.MessageAuthor
 import com.zhousl.aether.ui.MessageDisplayKind
@@ -46,8 +47,19 @@ internal object ChatMessageEntityMapper {
             createdAtMillis = entity.createdAtMillis ?: timestampFromMessageId(entity.id),
             responseGroupId = entity.responseGroupId,
             providerPayloadJson = entity.messageJson,
-            displayKind = MessageDisplayKind.entries.firstOrNull { it.name == entity.displayKind }
-                ?: MessageDisplayKind.Standard,
+            displayKind = entity.displayKind.toMessageDisplayKind(),
         )
     }
+
+    fun summaryToChatMessage(entity: ChatMessageSummaryEntity): ChatMessage = ChatMessage(
+        id = entity.id,
+        author = MessageAuthor.entries.firstOrNull { it.name == entity.author } ?: MessageAuthor.Agent,
+        text = entity.text,
+        createdAtMillis = entity.createdAtMillis ?: timestampFromMessageId(entity.id),
+        responseGroupId = entity.responseGroupId,
+        displayKind = entity.displayKind.toMessageDisplayKind(),
+    )
+
+    private fun String?.toMessageDisplayKind(): MessageDisplayKind =
+        MessageDisplayKind.entries.firstOrNull { it.name == this } ?: MessageDisplayKind.Standard
 }

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -126,6 +126,7 @@ class ChatRepository(
         message: ChatMessage,
         position: Int,
     ) {
+        require(position >= 0) { "position must be non-negative" }
         migrateLegacyChatStateIfNeeded()
         database.withTransaction {
             chatHistoryDao.upsertMessage(
@@ -144,7 +145,7 @@ class ChatRepository(
             chatHistoryDao.deleteSession(sessionId)
             val meta = chatHistoryDao.getMeta()
             if (meta?.currentSessionId == sessionId) {
-                chatHistoryDao.upsertMeta(meta.copy(currentSessionId = DraftSessionId))
+                chatHistoryDao.upsertMeta(meta.copy(currentSessionId = null))
             }
         }
     }
@@ -154,6 +155,7 @@ class ChatRepository(
         fromPosition: Int,
         messages: List<ChatMessage>,
     ) {
+        require(fromPosition >= 0) { "fromPosition must be non-negative" }
         migrateLegacyChatStateIfNeeded()
         database.withTransaction {
             replaceMessagesFromPositionInTransaction(sessionId, fromPosition, messages)
@@ -189,13 +191,13 @@ class ChatRepository(
                 .takeIf { id -> id == DraftSessionId || sessions.any { it.session.id == id } }
                 ?: sessions.firstOrNull()?.session?.id
                 ?: DraftSessionId
-            chatHistoryDao.upsertMeta(
-                ChatStateMetaEntity(
-                    currentSessionId = safeCurrentSessionId,
-                    roomMigrationComplete = migrationComplete,
-                )
-            )
             if (sessions.isEmpty()) {
+                chatHistoryDao.upsertMeta(
+                    ChatStateMetaEntity(
+                        currentSessionId = null,
+                        roomMigrationComplete = migrationComplete,
+                    )
+                )
                 chatHistoryDao.deleteAllMessages()
                 chatHistoryDao.deleteAllSessions()
                 return@withTransaction
@@ -206,6 +208,12 @@ class ChatRepository(
             chatHistoryDao.upsertSessions(sessionEntities)
             chatHistoryDao.deleteSessionsExcept(sessionIds)
             chatHistoryDao.deleteMessagesExceptSessions(sessionIds)
+            chatHistoryDao.upsertMeta(
+                ChatStateMetaEntity(
+                    currentSessionId = safeCurrentSessionId.toStoredCurrentSessionId(),
+                    roomMigrationComplete = migrationComplete,
+                )
+            )
 
             sessions.forEach { snapshot ->
                 chatHistoryDao.deleteMessagesForSession(snapshot.session.id)
@@ -239,7 +247,7 @@ class ChatRepository(
             database.withTransaction {
                 chatHistoryDao.upsertMeta(
                     ChatStateMetaEntity(
-                        currentSessionId = legacyCurrentSessionId ?: DraftSessionId,
+                        currentSessionId = null,
                         roomMigrationComplete = true,
                     )
                 )
@@ -257,7 +265,7 @@ class ChatRepository(
             database.withTransaction {
                 chatHistoryDao.upsertMeta(
                     ChatStateMetaEntity(
-                        currentSessionId = legacyCurrentSessionId ?: DraftSessionId,
+                        currentSessionId = null,
                         roomMigrationComplete = true,
                     )
                 )
@@ -309,7 +317,7 @@ class ChatRepository(
         database.withTransaction {
             chatHistoryDao.upsertMeta(
                 ChatStateMetaEntity(
-                    currentSessionId = legacyCurrentSessionId ?: DraftSessionId,
+                    currentSessionId = null,
                     roomMigrationComplete = true,
                 )
             )
@@ -341,6 +349,9 @@ internal fun resolveLegacyCurrentSessionIdForMigration(
         ?: firstSessionId.takeIf { it.isNotBlank() }
         ?: DraftSessionId
 }
+
+private fun String?.toStoredCurrentSessionId(): String? = this
+    ?.takeUnless { it.isBlank() || it == DraftSessionId }
 
 private data class SessionListState(
     val rows: List<ChatSessionEntity>,
@@ -411,14 +422,16 @@ internal fun parseChatSessionsForMigration(rawValue: String): LegacyChatSessions
         LegacyChatSessionsParseResult(
             sessions = buildList {
                 for (sessionIndex in 0 until sessions.length()) {
-                    val session = sessions.optJSONObject(sessionIndex) ?: continue
+                    val session = checkNotNull(sessions.optJSONObject(sessionIndex)) {
+                        "Invalid chat session at index $sessionIndex"
+                    }
                     add(
                         ChatSession(
                             id = session.optString("id").ifBlank { "session-$sessionIndex" },
                             title = session.optString("title"),
                             preview = session.optString("preview"),
                             hasCustomTitle = session.optBoolean("hasCustomTitle", false),
-                            messages = parseMessages(session.optJSONArray("messages")),
+                            messages = parseMessages(session.optJSONArrayOrThrow("messages", sessionIndex)),
                             selectedSkillIds = parseStringList(session.optJSONArray("selectedSkillIds")).ifEmpty {
                                 parseActiveSkillContexts(session.optString("activeSkillsJson")).map { it.skillId }
                             },
@@ -455,6 +468,7 @@ private fun corruptedChatStateSession(
             text = "Aether could not read the stored chat history (${throwable.javaClass.simpleName}). " +
                 "The app is showing this recovery placeholder instead of hiding the conversation list.",
             createdAtMillis = 0L,
+            providerPayloadJson = rawValue,
         )
     ),
 )
@@ -486,7 +500,9 @@ private fun parseMessages(messages: JSONArray?): List<ChatMessage> {
 
     return buildList {
         for (messageIndex in 0 until messages.length()) {
-            val message = messages.optJSONObject(messageIndex) ?: continue
+            val message = checkNotNull(messages.optJSONObject(messageIndex)) {
+                "Invalid chat message at index $messageIndex"
+            }
             add(parseMessage(message, messageIndex))
         }
     }
@@ -765,6 +781,19 @@ private fun ChatToolInvocation.toJson(): JSONObject = JSONObject().apply {
 private fun parseStringList(rawValue: String): List<String> = runCatching {
     parseStringList(JSONArray(rawValue))
 }.getOrDefault(emptyList())
+
+
+private fun JSONObject.optJSONArrayOrThrow(
+    key: String,
+    sessionIndex: Int,
+): JSONArray? {
+    if (!has(key) || isNull(key)) {
+        return null
+    }
+    return checkNotNull(optJSONArray(key)) {
+        "Invalid $key array for chat session at index $sessionIndex"
+    }
+}
 
 private fun parseStringList(array: JSONArray?): List<String> {
     if (array == null) return emptyList()

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -9,6 +9,7 @@ import androidx.room.withTransaction
 import com.zhousl.aether.data.chatdb.ChatHistoryDao
 import com.zhousl.aether.data.chatdb.ChatHistoryDatabase
 import com.zhousl.aether.data.chatdb.ChatMessageEntity
+import com.zhousl.aether.data.chatdb.ChatMessageSummaryEntity
 import com.zhousl.aether.data.chatdb.ChatSessionEntity
 import com.zhousl.aether.data.chatdb.ChatSessionSnapshot
 import com.zhousl.aether.data.chatdb.ChatStateMetaEntity

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -1,9 +1,18 @@
 package com.zhousl.aether.data
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import androidx.room.withTransaction
+import com.zhousl.aether.data.chatdb.ChatHistoryDao
+import com.zhousl.aether.data.chatdb.ChatHistoryDatabase
+import com.zhousl.aether.data.chatdb.ChatMessageEntity
+import com.zhousl.aether.data.chatdb.ChatSessionEntity
+import com.zhousl.aether.data.chatdb.ChatSessionSnapshot
+import com.zhousl.aether.data.chatdb.ChatStateMetaEntity
+
 import com.zhousl.aether.ui.AttachmentKind
 import com.zhousl.aether.ui.AttachmentWorkspaceState
 import com.zhousl.aether.ui.ChatAttachment
@@ -17,18 +26,22 @@ import com.zhousl.aether.ui.MessageDisplayKind
 import com.zhousl.aether.ui.ReasoningSummaryChunk
 import com.zhousl.aether.ui.ReasoningTrace
 import com.zhousl.aether.ui.syncActiveBranches
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.json.JSONArray
 import org.json.JSONObject
 
 private const val DraftSessionId = "draft"
-private const val PersistedReasoningRawTextMaxChars = 12_000
-private const val PersistedProviderPayloadJsonMaxChars = 120_000
-private const val PersistedToolArgumentsJsonMaxChars = 24_000
-private const val PersistedToolOutputJsonMaxChars = 72_000
-private const val PersistedReasoningSummaryRawTextMaxChars = 4_000
-private const val PersistedJsonStringValueMaxChars = 16_000
+
 
 private val Context.chatDataStore by preferencesDataStore(name = "aether_chats")
 
@@ -39,16 +52,44 @@ data class PersistedChatState(
 
 class ChatRepository(
     private val context: Context,
+    private val database: ChatHistoryDatabase = ChatHistoryDatabase.getInstance(context),
 ) {
-    val chatState: Flow<PersistedChatState> = context.chatDataStore.data.map { preferences ->
-        val sessions = parseChatSessions(preferences[SESSIONS_JSON].orEmpty())
-        val storedSessionId = preferences[CURRENT_SESSION_ID] ?: DraftSessionId
-        PersistedChatState(
-            sessions = sessions,
-            currentSessionId = storedSessionId
-                .takeIf { id -> id == DraftSessionId || sessions.any { it.id == id } }
-                ?: sessions.firstOrNull()?.id
-                ?: DraftSessionId,
+    private val chatHistoryDao: ChatHistoryDao = database.chatHistoryDao()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val chatState: Flow<PersistedChatState> = flow {
+        migrateLegacyChatStateIfNeeded()
+        emitAll(
+            combine(
+                chatHistoryDao.observeSessions(),
+                chatHistoryDao.observeMeta(),
+            ) { sessionRows, meta ->
+                val currentSessionId = meta?.currentSessionId ?: DraftSessionId
+                SessionListState(
+                    rows = sessionRows,
+                    currentSessionId = currentSessionId
+                        .takeIf { id -> id == DraftSessionId || sessionRows.any { it.id == id } }
+                        ?: sessionRows.firstOrNull()?.id
+                        ?: DraftSessionId,
+                )
+            }.flatMapLatest { state ->
+                val sessionIds = state.rows.map { it.id }
+                val messagesFlow = if (sessionIds.isEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    chatHistoryDao.observeMessagesForSessions(sessionIds)
+                }
+                messagesFlow.map { messages ->
+                    val messagesBySessionId = messages.groupBy { it.sessionId }
+                    val sessions = state.rows.map { session ->
+                        session.toChatSession(messagesBySessionId[session.id].orEmpty())
+                    }
+                    PersistedChatState(
+                        sessions = sessions,
+                        currentSessionId = state.currentSessionId,
+                    )
+                }
+            }
         )
     }
 
@@ -56,46 +97,346 @@ class ChatRepository(
         sessions: List<ChatSession>,
         currentSessionId: String,
     ) {
-        context.chatDataStore.edit {
-            it[SESSIONS_JSON] = serializeChatSessions(sessions)
-            it[CURRENT_SESSION_ID] = currentSessionId
+        migrateLegacyChatStateIfNeeded()
+        replaceChatState(
+            sessions = sessions.mapIndexed { index, session -> session.toSnapshot(index) },
+            currentSessionId = currentSessionId,
+            migrationComplete = true,
+        )
+        context.chatDataStore.edit { preferences ->
+            preferences.remove(SESSIONS_JSON)
+            preferences.remove(CURRENT_SESSION_ID)
+            preferences[ROOM_MIGRATION_COMPLETE] = true
         }
     }
+
+
+    suspend fun upsertSessionSnapshot(
+        session: ChatSession,
+        sortOrder: Long,
+    ) {
+        migrateLegacyChatStateIfNeeded()
+        database.withTransaction {
+            chatHistoryDao.upsertSession(session.toSessionEntity(sortOrder))
+        }
+    }
+
+    suspend fun upsertMessageSnapshot(
+        sessionId: String,
+        message: ChatMessage,
+        position: Int,
+    ) {
+        migrateLegacyChatStateIfNeeded()
+        database.withTransaction {
+            chatHistoryDao.upsertMessage(
+                ChatMessageEntityMapper.toEntity(
+                    sessionId = sessionId,
+                    position = position,
+                    message = message,
+                )
+            )
+        }
+    }
+
+    suspend fun deleteSessionById(sessionId: String) {
+        migrateLegacyChatStateIfNeeded()
+        database.withTransaction {
+            chatHistoryDao.deleteSession(sessionId)
+            val meta = chatHistoryDao.getMeta()
+            if (meta?.currentSessionId == sessionId) {
+                chatHistoryDao.upsertMeta(meta.copy(currentSessionId = DraftSessionId))
+            }
+        }
+    }
+
+    suspend fun replaceMessagesFromPosition(
+        sessionId: String,
+        fromPosition: Int,
+        messages: List<ChatMessage>,
+    ) {
+        migrateLegacyChatStateIfNeeded()
+        database.withTransaction {
+            replaceMessagesFromPositionInTransaction(sessionId, fromPosition, messages)
+        }
+    }
+
+    private suspend fun replaceMessagesFromPositionInTransaction(
+        sessionId: String,
+        fromPosition: Int,
+        messages: List<ChatMessage>,
+    ) {
+        chatHistoryDao.deleteMessagesFromPosition(sessionId, fromPosition)
+        if (messages.isNotEmpty()) {
+            chatHistoryDao.upsertMessages(
+                messages.mapIndexed { index, message ->
+                    ChatMessageEntityMapper.toEntity(
+                        sessionId = sessionId,
+                        position = fromPosition + index,
+                        message = message,
+                    )
+                }
+            )
+        }
+    }
+
+    private suspend fun replaceChatState(
+        sessions: List<ChatSessionSnapshot>,
+        currentSessionId: String,
+        migrationComplete: Boolean,
+    ) {
+        database.withTransaction {
+            val safeCurrentSessionId = currentSessionId
+                .takeIf { id -> id == DraftSessionId || sessions.any { it.session.id == id } }
+                ?: sessions.firstOrNull()?.session?.id
+                ?: DraftSessionId
+            chatHistoryDao.upsertMeta(
+                ChatStateMetaEntity(
+                    currentSessionId = safeCurrentSessionId,
+                    roomMigrationComplete = migrationComplete,
+                )
+            )
+            if (sessions.isEmpty()) {
+                chatHistoryDao.deleteAllMessages()
+                chatHistoryDao.deleteAllSessions()
+                return@withTransaction
+            }
+
+            val sessionEntities = sessions.map { it.session }
+            val sessionIds = sessionEntities.map { it.id }
+            chatHistoryDao.upsertSessions(sessionEntities)
+            chatHistoryDao.deleteSessionsExcept(sessionIds)
+            chatHistoryDao.deleteMessagesExceptSessions(sessionIds)
+
+            sessions.forEach { snapshot ->
+                chatHistoryDao.deleteMessagesForSession(snapshot.session.id)
+                if (snapshot.messages.isNotEmpty()) {
+                    chatHistoryDao.upsertMessages(snapshot.messages)
+                }
+            }
+        }
+    }
+
+    // TODO(Room v2): remove legacy DataStore chat import.
+    private suspend fun migrateLegacyChatStateIfNeeded() = migrationMutex.withLock {
+        val preferences = context.chatDataStore.data.first()
+        val legacySessionsJson = preferences[SESSIONS_JSON].orEmpty()
+        val legacyMigrationComplete = preferences[ROOM_MIGRATION_COMPLETE] == true
+        val legacyCurrentSessionId = preferences[CURRENT_SESSION_ID] ?: DraftSessionId
+        val roomMeta = chatHistoryDao.getMeta()
+
+        if (roomMeta?.roomMigrationComplete == true) {
+            if (legacySessionsJson.isNotBlank() || preferences[CURRENT_SESSION_ID] != null) {
+                context.chatDataStore.edit { data ->
+                    data.remove(SESSIONS_JSON)
+                    data.remove(CURRENT_SESSION_ID)
+                    data[ROOM_MIGRATION_COMPLETE] = true
+                }
+            }
+            return@withLock
+        }
+
+        if (legacyMigrationComplete && legacySessionsJson.isBlank()) {
+            database.withTransaction {
+                chatHistoryDao.upsertMeta(
+                    ChatStateMetaEntity(
+                        currentSessionId = legacyCurrentSessionId,
+                        roomMigrationComplete = true,
+                    )
+                )
+            }
+            if (preferences[CURRENT_SESSION_ID] != null) {
+                context.chatDataStore.edit { data ->
+                    data.remove(CURRENT_SESSION_ID)
+                    data[ROOM_MIGRATION_COMPLETE] = true
+                }
+            }
+            return@withLock
+        }
+
+        if (legacySessionsJson.isBlank()) {
+            database.withTransaction {
+                chatHistoryDao.upsertMeta(
+                    ChatStateMetaEntity(
+                        currentSessionId = legacyCurrentSessionId,
+                        roomMigrationComplete = true,
+                    )
+                )
+            }
+            context.chatDataStore.edit { data ->
+                data.remove(SESSIONS_JSON)
+                data.remove(CURRENT_SESSION_ID)
+                data[ROOM_MIGRATION_COMPLETE] = true
+            }
+            return@withLock
+        }
+
+        val legacyParseResult = parseChatSessionsForMigration(legacySessionsJson)
+        val legacySessions = legacyParseResult.sessions
+        if (legacyParseResult.recoveredFromCorruption) {
+            // TODO(Room v2): remove with legacy DataStore chat import.
+            replaceChatState(
+                sessions = legacySessions.mapIndexed { index, session -> session.toSnapshot(index) },
+                currentSessionId = resolveLegacyCurrentSessionIdForMigration(
+                    legacyCurrentSessionId = legacyCurrentSessionId,
+                    legacySessions = legacySessions,
+                ),
+                migrationComplete = true,
+            )
+            context.chatDataStore.edit { data ->
+                data.remove(SESSIONS_JSON)
+                data.remove(CURRENT_SESSION_ID)
+                data[ROOM_MIGRATION_COMPLETE] = true
+            }
+            return@withLock
+        }
+        if (legacySessions.isNotEmpty()) {
+            replaceChatState(
+                sessions = legacySessions.mapIndexed { index, session -> session.toSnapshot(index) },
+                currentSessionId = resolveLegacyCurrentSessionIdForMigration(
+                    legacyCurrentSessionId = legacyCurrentSessionId,
+                    legacySessions = legacySessions,
+                ),
+                migrationComplete = true,
+            )
+            context.chatDataStore.edit { data ->
+                data.remove(SESSIONS_JSON)
+                data.remove(CURRENT_SESSION_ID)
+                data[ROOM_MIGRATION_COMPLETE] = true
+            }
+            return@withLock
+        }
+
+        database.withTransaction {
+            chatHistoryDao.upsertMeta(
+                ChatStateMetaEntity(
+                    currentSessionId = legacyCurrentSessionId,
+                    roomMigrationComplete = true,
+                )
+            )
+        }
+        context.chatDataStore.edit { data ->
+            data.remove(SESSIONS_JSON)
+            data.remove(CURRENT_SESSION_ID)
+            data[ROOM_MIGRATION_COMPLETE] = true
+        }
+    }
+
 
     private companion object {
         val SESSIONS_JSON = stringPreferencesKey("sessions_json")
         val CURRENT_SESSION_ID = stringPreferencesKey("current_session_id")
+        val ROOM_MIGRATION_COMPLETE = booleanPreferencesKey("room_migration_complete")
+        val migrationMutex = Mutex()
     }
 }
 
-internal fun parseChatSessions(rawValue: String): List<ChatSession> {
-    if (rawValue.isBlank()) return emptyList()
+internal fun resolveLegacyCurrentSessionIdForMigration(
+    legacyCurrentSessionId: String,
+    legacySessions: List<ChatSession>,
+): String {
+    if (legacySessions.isEmpty()) return DraftSessionId
+    val firstSessionId = legacySessions.first().id
+    return legacyCurrentSessionId
+        .takeIf { id -> id == DraftSessionId || legacySessions.any { it.id == id } }
+        ?: firstSessionId.takeIf { it.isNotBlank() }
+        ?: DraftSessionId
+}
+
+private data class SessionListState(
+    val rows: List<ChatSessionEntity>,
+    val currentSessionId: String,
+)
+
+private fun ChatSession.toSessionEntity(sortOrder: Long): ChatSessionEntity = ChatSessionEntity(
+    id = id,
+    title = title,
+    preview = preview,
+    hasCustomTitle = hasCustomTitle,
+    selectedSkillIdsJson = JSONArray().apply { selectedSkillIds.forEach(::put) }.toString(),
+    activeSkillsJson = serializeActiveSkillContexts(activeSkills),
+    activeMcpServerIdsJson = JSONArray().apply { activeMcpServerIds.forEach(::put) }.toString(),
+    agentModeEnabled = agentModeEnabled,
+    selectedModelKey = selectedModelKey,
+    sortOrder = sortOrder,
+)
+
+private fun ChatSession.toSnapshot(index: Int): ChatSessionSnapshot = ChatSessionSnapshot(
+    session = toSessionEntity(index.toLong()),
+    messages = syncActiveBranches(messages).mapIndexed { messageIndex, message ->
+        ChatMessageEntityMapper.toEntity(
+            sessionId = id,
+            position = messageIndex,
+            message = message,
+        )
+    },
+)
+
+private fun ChatSessionEntity.toChatSession(messages: List<ChatMessageEntity>): ChatSession {
+    val orderedMessages = messages.sortedBy { it.position }.mapIndexed { index, message ->
+        ChatMessageEntityMapper.toChatMessage(message, index)
+    }
+    val activeSkills = parseActiveSkillContexts(activeSkillsJson)
+    return ChatSession(
+        id = id,
+        title = title,
+        preview = preview,
+        hasCustomTitle = hasCustomTitle,
+        messages = orderedMessages,
+        selectedSkillIds = parseStringList(selectedSkillIdsJson).ifEmpty { activeSkills.map { it.skillId } },
+        activeSkills = activeSkills,
+        activeMcpServerIds = parseStringList(activeMcpServerIdsJson),
+        agentModeEnabled = agentModeEnabled,
+        selectedModelKey = selectedModelKey,
+    )
+}
+
+internal fun parseChatSessions(rawValue: String): List<ChatSession> =
+    parseChatSessionsForMigration(rawValue).sessions
+
+internal data class LegacyChatSessionsParseResult(
+    val sessions: List<ChatSession>,
+    val recoveredFromCorruption: Boolean,
+)
+
+internal fun parseChatSessionsForMigration(rawValue: String): LegacyChatSessionsParseResult {
+    if (rawValue.isBlank()) {
+        return LegacyChatSessionsParseResult(
+            sessions = emptyList(),
+            recoveredFromCorruption = false,
+        )
+    }
 
     return runCatching {
         val sessions = JSONArray(rawValue)
-        buildList {
-            for (sessionIndex in 0 until sessions.length()) {
-                val session = sessions.optJSONObject(sessionIndex) ?: continue
-                add(
-                    ChatSession(
-                        id = session.optString("id").ifBlank { "session-$sessionIndex" },
-                        title = session.optString("title"),
-                        preview = session.optString("preview"),
-                        hasCustomTitle = session.optBoolean("hasCustomTitle", false),
-                        messages = parseMessages(session.optJSONArray("messages")),
-                        selectedSkillIds = parseStringList(session.optJSONArray("selectedSkillIds")).ifEmpty {
-                            parseActiveSkillContexts(session.optString("activeSkillsJson")).map { it.skillId }
-                        },
-                        activeSkills = parseActiveSkillContexts(session.optString("activeSkillsJson")),
-                        activeMcpServerIds = parseStringList(session.optJSONArray("activeMcpServerIds")),
-                        agentModeEnabled = session.optBoolean("agentModeEnabled", false),
-                        selectedModelKey = session.optString("selectedModelKey"),
+        LegacyChatSessionsParseResult(
+            sessions = buildList {
+                for (sessionIndex in 0 until sessions.length()) {
+                    val session = sessions.optJSONObject(sessionIndex) ?: continue
+                    add(
+                        ChatSession(
+                            id = session.optString("id").ifBlank { "session-$sessionIndex" },
+                            title = session.optString("title"),
+                            preview = session.optString("preview"),
+                            hasCustomTitle = session.optBoolean("hasCustomTitle", false),
+                            messages = parseMessages(session.optJSONArray("messages")),
+                            selectedSkillIds = parseStringList(session.optJSONArray("selectedSkillIds")).ifEmpty {
+                                parseActiveSkillContexts(session.optString("activeSkillsJson")).map { it.skillId }
+                            },
+                            activeSkills = parseActiveSkillContexts(session.optString("activeSkillsJson")),
+                            activeMcpServerIds = parseStringList(session.optJSONArray("activeMcpServerIds")),
+                            agentModeEnabled = session.optBoolean("agentModeEnabled", false),
+                            selectedModelKey = session.optString("selectedModelKey"),
+                        )
                     )
-                )
-            }
-        }
+                }
+            },
+            recoveredFromCorruption = false,
+        )
     }.getOrElse { throwable ->
-        listOf(corruptedChatStateSession(rawValue, throwable))
+        LegacyChatSessionsParseResult(
+            sessions = listOf(corruptedChatStateSession(rawValue, throwable)),
+            recoveredFromCorruption = true,
+        )
     }
 }
 
@@ -118,12 +459,14 @@ private fun corruptedChatStateSession(
     ),
 )
 
-internal fun serializeChatSessions(sessions: List<ChatSession>): String =
-    JSONArray().apply {
-        sessions.forEach { session ->
-            put(session.toJson())
-        }
-    }.toString()
+internal fun serializeChatSessions(sessions: List<ChatSession>): String = buildString {
+    append('[')
+    sessions.forEachIndexed { index, session ->
+        if (index > 0) append(',')
+        append(session.toJson().toString())
+    }
+    append(']')
+}
 
 internal fun ChatSession.toJson(): JSONObject = JSONObject().apply {
     put("id", id)
@@ -144,40 +487,41 @@ private fun parseMessages(messages: JSONArray?): List<ChatMessage> {
     return buildList {
         for (messageIndex in 0 until messages.length()) {
             val message = messages.optJSONObject(messageIndex) ?: continue
-            add(
-                ChatMessage(
-                    id = message.optString("id").ifBlank { "message-$messageIndex" },
-                    author = if (message.optString("author") == MessageAuthor.User.name) {
-                        MessageAuthor.User
-                    } else {
-                        MessageAuthor.Agent
-                    },
-                    text = message.optString("text"),
-                    createdAtMillis = message.optLong("createdAtMillis").takeIf { it > 0L }
-                        ?: timestampFromMessageId(message.optString("id")),
-                    attachments = parseAttachments(message.optJSONArray("attachments")),
-                    toolInvocations = parseToolInvocations(message.optJSONArray("toolInvocations")),
-                    thoughtDurationMillis = if (message.has("thoughtDurationMillis")) {
-                        message.optLong("thoughtDurationMillis")
-                    } else {
-                        null
-                    },
-                    reasoningTrace = parseReasoningTrace(message.optJSONObject("reasoningTrace")),
-                    branchGroup = parseBranchGroup(message.optJSONObject("branchGroup")),
-                    responseGroupId = message.optString("responseGroupId").ifBlank { null },
-                    assistantActionsHidden = message.optBoolean("assistantActionsHidden"),
-                    providerPayloadJson = message.optString("providerPayloadJson"),
-                    displayKind = MessageDisplayKind.entries.firstOrNull {
-                        it.name == message.optString("displayKind")
-                    } ?: MessageDisplayKind.Standard,
-                    usageStatistics = parseUsageStatistics(message.optJSONObject("usageStatistics")),
-                )
-            )
+            add(parseMessage(message, messageIndex))
         }
     }
 }
 
-private fun ChatMessage.toJson(): JSONObject = JSONObject().apply {
+internal fun parseMessage(message: JSONObject, messageIndex: Int): ChatMessage = ChatMessage(
+    id = message.optString("id").ifBlank { "message-$messageIndex" },
+    author = if (message.optString("author") == MessageAuthor.User.name) {
+        MessageAuthor.User
+    } else {
+        MessageAuthor.Agent
+    },
+    text = message.optString("text"),
+    createdAtMillis = message.optLong("createdAtMillis").takeIf { it > 0L }
+        ?: timestampFromMessageId(message.optString("id")),
+    attachments = parseAttachments(message.optJSONArray("attachments")),
+    toolInvocations = parseToolInvocations(message.optJSONArray("toolInvocations")),
+    thoughtDurationMillis = if (message.has("thoughtDurationMillis")) {
+        message.optLong("thoughtDurationMillis")
+    } else {
+        null
+    },
+    reasoningTrace = parseReasoningTrace(message.optJSONObject("reasoningTrace")),
+    branchGroup = parseBranchGroup(message.optJSONObject("branchGroup")),
+    responseGroupId = message.optString("responseGroupId").ifBlank { null },
+    assistantActionsHidden = message.optBoolean("assistantActionsHidden"),
+    providerPayloadJson = message.optString("providerPayloadJson"),
+    displayKind = parseMessageDisplayKind(message.optString("displayKind")),
+    usageStatistics = parseUsageStatistics(message.optJSONObject("usageStatistics")),
+)
+
+private fun parseMessageDisplayKind(value: String): MessageDisplayKind =
+    MessageDisplayKind.entries.firstOrNull { it.name == value } ?: MessageDisplayKind.Standard
+
+internal fun ChatMessage.toJson(): JSONObject = JSONObject().apply {
     put("id", id)
     put("author", author.name)
     put("text", text)
@@ -191,9 +535,9 @@ private fun ChatMessage.toJson(): JSONObject = JSONObject().apply {
     if (assistantActionsHidden) {
         put("assistantActionsHidden", true)
     }
-    truncatePersistedText(providerPayloadJson, PersistedProviderPayloadJsonMaxChars)
-        .takeIf { it.isNotBlank() }
-        ?.let { put("providerPayloadJson", it) }
+    providerPayloadJson.takeIf { it.isNotBlank() }?.let {
+        put("providerPayloadJson", it)
+    }
     if (displayKind != MessageDisplayKind.Standard) {
         put("displayKind", displayKind.name)
     }
@@ -307,6 +651,9 @@ private fun ChatAttachment.toJson(): JSONObject = JSONObject().apply {
     put("kind", kind.name)
     put("workspacePath", workspacePath)
     sizeBytes?.let { put("sizeBytes", it) }
+    inlineBase64.takeIf { it.isNotBlank() }?.let {
+        put("inlineBase64", it)
+    }
 }
 
 private fun parseReasoningTrace(json: JSONObject?): ReasoningTrace? {
@@ -329,7 +676,7 @@ private fun parseReasoningTrace(json: JSONObject?): ReasoningTrace? {
 
 private fun ReasoningTrace.toJson(): JSONObject = JSONObject().apply {
     put("id", id)
-    put("rawText", if (hasSummary) "" else truncatePersistedText(rawText, PersistedReasoningRawTextMaxChars))
+    put("rawText", if (hasSummary) "" else rawText)
     put("latestStatusText", latestStatusText)
     put("startedAtMillis", startedAtMillis)
     completedAtMillis?.let { put("completedAtMillis", it) }
@@ -363,11 +710,7 @@ private fun ReasoningSummaryChunk.toJson(): JSONObject = JSONObject().apply {
     put("detail", detail)
     put(
         "rawText",
-        if (title.isNotBlank() || detail.isNotBlank()) {
-            ""
-        } else {
-            truncatePersistedText(rawText, PersistedReasoningSummaryRawTextMaxChars)
-        },
+        if (title.isNotBlank() || detail.isNotBlank()) "" else rawText,
     )
     put("isPending", isPending)
     put("createdAtMillis", createdAtMillis)
@@ -409,8 +752,8 @@ private fun parseToolInvocations(toolInvocations: JSONArray?): List<ChatToolInvo
 private fun ChatToolInvocation.toJson(): JSONObject = JSONObject().apply {
     put("id", id)
     put("toolName", toolName)
-    put("argumentsJson", truncatePersistedJson(argumentsJson, PersistedToolArgumentsJsonMaxChars))
-    put("outputJson", truncatePersistedJson(outputJson, PersistedToolOutputJsonMaxChars))
+    put("argumentsJson", argumentsJson)
+    put("outputJson", outputJson)
     put("isRunning", isRunning)
     put("startedAtUptimeMillis", startedAtUptimeMillis)
     completedAtUptimeMillis?.let { put("completedAtUptimeMillis", it) }
@@ -418,6 +761,10 @@ private fun ChatToolInvocation.toJson(): JSONObject = JSONObject().apply {
     completedAtMillis?.let { put("completedAtMillis", it) }
     put("timelineOrder", timelineOrder)
 }
+
+private fun parseStringList(rawValue: String): List<String> = runCatching {
+    parseStringList(JSONArray(rawValue))
+}.getOrDefault(emptyList())
 
 private fun parseStringList(array: JSONArray?): List<String> {
     if (array == null) return emptyList()
@@ -431,50 +778,7 @@ private fun parseStringList(array: JSONArray?): List<String> {
     }
 }
 
-private fun timestampFromMessageId(messageId: String): Long {
+internal fun timestampFromMessageId(messageId: String): Long {
     val timestamp = messageId.substringAfterLast('-', missingDelimiterValue = "")
     return timestamp.toLongOrNull()?.takeIf { it > 0L } ?: 0L
-}
-
-private fun truncatePersistedText(
-    value: String,
-    maxChars: Int,
-): String {
-    if (value.length <= maxChars) return value
-    val omittedChars = value.length - maxChars
-    return value.take(maxChars) + "\n\n[... $omittedChars characters omitted from persisted chat storage]"
-}
-
-private fun truncatePersistedJson(
-    value: String,
-    maxChars: Int,
-): String {
-    if (value.length <= maxChars) return value
-    val parsed = runCatching { JSONObject(value) }.getOrNull()
-    if (parsed != null) {
-        val compactedText = compactPersistedJsonObject(parsed).toString()
-        if (compactedText.length <= maxChars) return compactedText
-    }
-    return JSONObject().apply {
-        put("ok", false)
-        put("truncated", true)
-        put("text", truncatePersistedText(value, maxChars))
-    }.toString()
-}
-
-private fun compactPersistedJsonObject(json: JSONObject): JSONObject {
-    val compacted = JSONObject()
-    json.keys().forEach { key ->
-        val value = json.opt(key)
-        compacted.put(
-            key,
-            if (value is String) {
-                truncatePersistedText(value, PersistedJsonStringValueMaxChars)
-            } else {
-                value
-            },
-        )
-    }
-    compacted.put("aetherPersistedOutputTruncated", true)
-    return compacted
 }

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -221,7 +221,7 @@ class ChatRepository(
         val preferences = context.chatDataStore.data.first()
         val legacySessionsJson = preferences[SESSIONS_JSON].orEmpty()
         val legacyMigrationComplete = preferences[ROOM_MIGRATION_COMPLETE] == true
-        val legacyCurrentSessionId = preferences[CURRENT_SESSION_ID] ?: DraftSessionId
+        val legacyCurrentSessionId = preferences[CURRENT_SESSION_ID]
         val roomMeta = chatHistoryDao.getMeta()
 
         if (roomMeta?.roomMigrationComplete == true) {
@@ -239,7 +239,7 @@ class ChatRepository(
             database.withTransaction {
                 chatHistoryDao.upsertMeta(
                     ChatStateMetaEntity(
-                        currentSessionId = legacyCurrentSessionId,
+                        currentSessionId = legacyCurrentSessionId ?: DraftSessionId,
                         roomMigrationComplete = true,
                     )
                 )
@@ -257,7 +257,7 @@ class ChatRepository(
             database.withTransaction {
                 chatHistoryDao.upsertMeta(
                     ChatStateMetaEntity(
-                        currentSessionId = legacyCurrentSessionId,
+                        currentSessionId = legacyCurrentSessionId ?: DraftSessionId,
                         roomMigrationComplete = true,
                     )
                 )
@@ -309,7 +309,7 @@ class ChatRepository(
         database.withTransaction {
             chatHistoryDao.upsertMeta(
                 ChatStateMetaEntity(
-                    currentSessionId = legacyCurrentSessionId,
+                    currentSessionId = legacyCurrentSessionId ?: DraftSessionId,
                     roomMigrationComplete = true,
                 )
             )
@@ -331,13 +331,13 @@ class ChatRepository(
 }
 
 internal fun resolveLegacyCurrentSessionIdForMigration(
-    legacyCurrentSessionId: String,
+    legacyCurrentSessionId: String?,
     legacySessions: List<ChatSession>,
 ): String {
-    if (legacySessions.isEmpty()) return DraftSessionId
+    if (legacySessions.isEmpty()) return legacyCurrentSessionId ?: DraftSessionId
     val firstSessionId = legacySessions.first().id
     return legacyCurrentSessionId
-        .takeIf { id -> id == DraftSessionId || legacySessions.any { it.id == id } }
+        ?.takeIf { id -> id == DraftSessionId || legacySessions.any { it.id == id } }
         ?: firstSessionId.takeIf { it.isNotBlank() }
         ?: DraftSessionId
 }

--- a/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
@@ -1,8 +1,14 @@
 package com.zhousl.aether.data
 
+import android.util.Log
+import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.ChatSession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,6 +17,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+
+private const val DraftSessionId = "draft"
+private const val ChatStateStoreLogTag = "ChatStateStore"
 
 class ChatStateStore(
     private val scope: CoroutineScope,
@@ -23,17 +32,52 @@ class ChatStateStore(
     private var localGeneration = 0L
     private var persistedGeneration = 0L
     private var latestPending: PendingPersistedChatState? = null
+    private var repositoryStateLoaded = false
+    private val repositoryStateReady = CompletableDeferred<Unit>()
 
     val state: StateFlow<PersistedChatState> = _state.asStateFlow()
 
     init {
         scope.launch {
-            chatRepository.chatState.collect { persisted ->
-                synchronized(updateLock) {
-                    if (localGeneration == persistedGeneration) {
-                        _state.value = persisted
+            try {
+                chatRepository.chatState.collect { persisted ->
+                    val pendingAfterInitialLoad = synchronized(updateLock) {
+                        if (!repositoryStateLoaded) {
+                            repositoryStateLoaded = true
+                            if (localGeneration == persistedGeneration) {
+                                _state.value = persisted
+                                null
+                            } else {
+                                val merged = mergeRepositoryStateWithLocalUpdates(
+                                    repositoryState = persisted,
+                                    localState = _state.value,
+                                )
+                                _state.value = merged
+                                latestPending = latestPending?.copy(state = merged)
+                                latestPending
+                            }
+                        } else {
+                            if (localGeneration == persistedGeneration) {
+                                _state.value = persisted
+                            }
+                            null
+                        }
+                    }
+                    if (!repositoryStateReady.isCompleted) {
+                        repositoryStateReady.complete(Unit)
+                    }
+                    if (pendingAfterInitialLoad != null) {
+                        persistWithoutQueue(pendingAfterInitialLoad)
                     }
                 }
+            } catch (throwable: Throwable) {
+                if (throwable is CancellationException) {
+                    throw throwable
+                }
+                if (!repositoryStateReady.isCompleted) {
+                    repositoryStateReady.completeExceptionally(throwable)
+                }
+                Log.e(ChatStateStoreLogTag, "Failed to load chat state", throwable)
             }
         }
         scope.launch {
@@ -43,34 +87,65 @@ class ChatStateStore(
                 }
             } finally {
                 withContext(NonCancellable) {
-                    flushLatestPending()
+                    runCatching { flushLatestPending() }
+                        .onFailure { throwable ->
+                            Log.e(ChatStateStoreLogTag, "Failed to flush pending chat state", throwable)
+                        }
                 }
             }
         }
     }
 
     suspend fun flush() {
-        flushLatestPending()
+        repositoryStateReady.await()
+        flushLatestPending(propagateFailure = true)
     }
 
     suspend fun updateAndFlush(
         transform: (PersistedChatState) -> PersistedChatState,
     ): PersistedChatState {
+        repositoryStateReady.await()
         val updated = update(transform)
-        flushLatestPending()
+        flushLatestPending(propagateFailure = true)
         return updated
     }
 
-    private suspend fun persistPending(pending: PendingPersistedChatState) {
+    private suspend fun persistPending(
+        pending: PendingPersistedChatState,
+        propagateFailure: Boolean = false,
+    ) {
         persistMutex.withLock {
+            if (synchronized(updateLock) { !repositoryStateLoaded }) {
+                return@withLock
+            }
+
             if (synchronized(updateLock) { pending.generation <= persistedGeneration }) {
                 return@withLock
             }
 
-            chatRepository.updateChatState(
-                sessions = pending.state.sessions,
-                currentSessionId = pending.state.currentSessionId,
-            )
+            val persistError = runCatching {
+                chatRepository.updateChatState(
+                    sessions = pending.state.sessions,
+                    currentSessionId = pending.state.currentSessionId,
+                )
+            }.exceptionOrNull()
+            if (persistError != null) {
+                if (persistError is CancellationException) {
+                    throw persistError
+                }
+                synchronized(updateLock) {
+                    if (latestPending == null || pending.generation >= latestPending!!.generation) {
+                        latestPending = pending
+                    }
+                }
+                Log.e(ChatStateStoreLogTag, "Failed to persist chat state", persistError)
+                scheduleRetry(pending)
+                if (propagateFailure) {
+                    throw persistError
+                }
+                return@withLock
+            }
+
             synchronized(updateLock) {
                 if (pending.generation > persistedGeneration) {
                     persistedGeneration = pending.generation
@@ -83,17 +158,99 @@ class ChatStateStore(
         }
     }
 
-    private suspend fun flushLatestPending() {
+    private suspend fun flushLatestPending(propagateFailure: Boolean = false) {
         val pending = synchronized(updateLock) {
             latestPending?.takeIf { it.generation > persistedGeneration }
         } ?: return
-        persistPending(pending)
+        persistPending(pending, propagateFailure)
     }
 
     private fun persistWithoutQueue(pending: PendingPersistedChatState) {
-        scope.launch(Dispatchers.IO + NonCancellable) {
+        scope.launch(Dispatchers.IO) {
             runCatching {
                 persistPending(pending)
+            }.onFailure { throwable ->
+                if (throwable is CancellationException) {
+                    throw throwable
+                }
+                Log.e(ChatStateStoreLogTag, "Failed to persist merged chat state", throwable)
+                scheduleRetry(pending)
+            }
+        }
+    }
+
+    private fun scheduleRetry(pending: PendingPersistedChatState) {
+        scope.launch {
+            delay(PersistRetryDelayMillis)
+            val shouldRetry = synchronized(updateLock) {
+                latestPending?.generation == pending.generation &&
+                    pending.generation > persistedGeneration
+            }
+            if (!shouldRetry) return@launch
+            val sendResult = persistenceQueue.trySend(pending)
+            if (sendResult.isFailure) {
+                persistWithoutQueue(pending)
+            }
+        }
+    }
+
+    private fun mergeRepositoryStateWithLocalUpdates(
+        repositoryState: PersistedChatState,
+        localState: PersistedChatState,
+    ): PersistedChatState {
+        val localSessionsById = localState.sessions.associateBy { it.id }
+        val repositorySessionIds = repositoryState.sessions.mapTo(mutableSetOf()) { it.id }
+        val mergedSessions = buildList(repositoryState.sessions.size + localState.sessions.size) {
+            repositoryState.sessions.forEach { repositorySession ->
+                val localSession = localSessionsById[repositorySession.id]
+                add(
+                    if (localSession == null) {
+                        repositorySession
+                    } else {
+                        localSession.withDerivedMessages(
+                            mergeMessages(
+                                repositoryMessages = repositorySession.messages,
+                                localMessages = localSession.messages,
+                            ),
+                        )
+                    }
+                )
+            }
+            localState.sessions.forEach { localSession ->
+                if (localSession.id !in repositorySessionIds) {
+                    add(localSession)
+                }
+            }
+        }
+        val currentSessionId = localState.currentSessionId
+            .takeIf { id -> id != DraftSessionId && mergedSessions.any { it.id == id } }
+            ?: repositoryState.currentSessionId
+                .takeIf { id -> id != DraftSessionId && mergedSessions.any { it.id == id } }
+            ?: mergedSessions.firstOrNull()?.id
+            ?: DraftSessionId
+        return PersistedChatState(
+            sessions = mergedSessions,
+            currentSessionId = currentSessionId,
+        )
+    }
+
+    private fun mergeMessages(
+        repositoryMessages: List<ChatMessage>,
+        localMessages: List<ChatMessage>,
+    ): List<ChatMessage> {
+        if (repositoryMessages.isEmpty()) return localMessages
+        if (localMessages.isEmpty()) return repositoryMessages
+
+        val localMessagesById = localMessages.associateBy { it.id }
+        val repositoryMessageIds = repositoryMessages.mapTo(mutableSetOf()) { it.id }
+        return buildList(repositoryMessages.size + localMessages.size) {
+            repositoryMessages.forEach { repositoryMessage ->
+                add(localMessagesById[repositoryMessage.id] ?: repositoryMessage)
+            }
+            localMessages.forEach { localMessage ->
+                if (localMessage.id !in repositoryMessageIds) {
+                    add(localMessage)
+                }
             }
         }
     }
@@ -123,4 +280,8 @@ class ChatStateStore(
         val generation: Long,
         val state: PersistedChatState,
     )
+
+    private companion object {
+        const val PersistRetryDelayMillis = 1_000L
+    }
 }

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -1,0 +1,63 @@
+package com.zhousl.aether.data.chatdb
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ChatHistoryDao {
+    @Query("SELECT * FROM chat_sessions ORDER BY sortOrder ASC")
+    fun observeSessions(): Flow<List<ChatSessionEntity>>
+
+    @Query("SELECT * FROM chat_state_meta WHERE id = :id")
+    fun observeMeta(id: String = ChatStateMetaEntityId): Flow<ChatStateMetaEntity?>
+
+    @Query("SELECT * FROM chat_state_meta WHERE id = :id")
+    suspend fun getMeta(id: String = ChatStateMetaEntityId): ChatStateMetaEntity?
+
+    @Query("SELECT * FROM chat_messages WHERE sessionId = :sessionId ORDER BY position ASC")
+    fun observeMessagesForSession(sessionId: String): Flow<List<ChatMessageEntity>>
+
+    @Query("SELECT * FROM chat_messages WHERE sessionId IN (:sessionIds) ORDER BY sessionId ASC, position ASC")
+    fun observeMessagesForSessions(sessionIds: List<String>): Flow<List<ChatMessageEntity>>
+
+    @Query("SELECT * FROM chat_messages WHERE sessionId IN (:sessionIds) ORDER BY sessionId ASC, position ASC")
+    suspend fun getMessagesForSessions(sessionIds: List<String>): List<ChatMessageEntity>
+
+    @Upsert
+    suspend fun upsertMeta(meta: ChatStateMetaEntity)
+
+    @Upsert
+    suspend fun upsertSession(session: ChatSessionEntity)
+
+    @Upsert
+    suspend fun upsertSessions(sessions: List<ChatSessionEntity>)
+
+    @Upsert
+    suspend fun upsertMessage(message: ChatMessageEntity)
+
+    @Upsert
+    suspend fun upsertMessages(messages: List<ChatMessageEntity>)
+
+    @Query("DELETE FROM chat_messages WHERE sessionId = :sessionId AND position >= :fromPosition")
+    suspend fun deleteMessagesFromPosition(sessionId: String, fromPosition: Int)
+
+    @Query("DELETE FROM chat_sessions WHERE id = :sessionId")
+    suspend fun deleteSession(sessionId: String)
+
+    @Query("DELETE FROM chat_sessions WHERE id NOT IN (:sessionIds)")
+    suspend fun deleteSessionsExcept(sessionIds: List<String>)
+
+    @Query("DELETE FROM chat_messages WHERE sessionId = :sessionId")
+    suspend fun deleteMessagesForSession(sessionId: String)
+
+    @Query("DELETE FROM chat_messages WHERE sessionId NOT IN (:sessionIds)")
+    suspend fun deleteMessagesExceptSessions(sessionIds: List<String>)
+
+    @Query("DELETE FROM chat_messages")
+    suspend fun deleteAllMessages()
+
+    @Query("DELETE FROM chat_sessions")
+    suspend fun deleteAllSessions()
+}

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -16,14 +16,30 @@ interface ChatHistoryDao {
     @Query("SELECT * FROM chat_state_meta WHERE id = :id")
     suspend fun getMeta(id: String = ChatStateMetaEntityId): ChatStateMetaEntity?
 
-    @Query("SELECT * FROM chat_messages WHERE sessionId = :sessionId ORDER BY position ASC")
-    fun observeMessagesForSession(sessionId: String): Flow<List<ChatMessageEntity>>
+    @Query("""
+        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion
+        FROM chat_messages
+        WHERE sessionId = :sessionId
+        ORDER BY position ASC
+    """)
+    fun observeMessageSummariesForSession(sessionId: String): Flow<List<ChatMessageSummaryEntity>>
 
-    @Query("SELECT * FROM chat_messages WHERE sessionId IN (:sessionIds) ORDER BY sessionId ASC, position ASC")
+    @Query("""
+        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion
+        FROM chat_messages
+        WHERE sessionId IN (:sessionIds)
+        ORDER BY sessionId ASC, position ASC
+    """)
+    fun observeMessageSummariesForSessions(sessionIds: List<String>): Flow<List<ChatMessageSummaryEntity>>
+
+    @Query("""
+        SELECT *
+        FROM chat_messages
+        WHERE sessionId IN (:sessionIds)
+        ORDER BY sessionId ASC, position ASC
+    """)
     fun observeMessagesForSessions(sessionIds: List<String>): Flow<List<ChatMessageEntity>>
 
-    @Query("SELECT * FROM chat_messages WHERE sessionId IN (:sessionIds) ORDER BY sessionId ASC, position ASC")
-    suspend fun getMessagesForSessions(sessionIds: List<String>): List<ChatMessageEntity>
 
     @Upsert
     suspend fun upsertMeta(meta: ChatStateMetaEntity)

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
@@ -1,0 +1,32 @@
+package com.zhousl.aether.data.chatdb
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [
+        ChatSessionEntity::class,
+        ChatMessageEntity::class,
+        ChatStateMetaEntity::class,
+    ],
+    version = 1,
+    exportSchema = true,
+)
+abstract class ChatHistoryDatabase : RoomDatabase() {
+    abstract fun chatHistoryDao(): ChatHistoryDao
+
+    companion object {
+        @Volatile
+        private var instance: ChatHistoryDatabase? = null
+
+        fun getInstance(context: Context): ChatHistoryDatabase = instance ?: synchronized(this) {
+            instance ?: Room.databaseBuilder(
+                context.applicationContext,
+                ChatHistoryDatabase::class.java,
+                "aether_chat_history.db",
+            ).build().also { instance = it }
+        }
+    }
+}

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -1,0 +1,66 @@
+package com.zhousl.aether.data.chatdb
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "chat_sessions")
+data class ChatSessionEntity(
+    @PrimaryKey
+    val id: String,
+    val title: String,
+    val preview: String,
+    val hasCustomTitle: Boolean,
+    val selectedSkillIdsJson: String,
+    val activeSkillsJson: String,
+    val activeMcpServerIdsJson: String,
+    val agentModeEnabled: Boolean,
+    val selectedModelKey: String,
+    val sortOrder: Long,
+)
+
+@Entity(
+    tableName = "chat_messages",
+    primaryKeys = ["sessionId", "id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatSessionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sessionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index(value = ["sessionId", "position"]),
+        Index(value = ["sessionId", "responseGroupId"]),
+        Index(value = ["sessionId", "author"]),
+    ],
+)
+data class ChatMessageEntity(
+    val sessionId: String,
+    val id: String,
+    val position: Int,
+    val messageJson: String,
+    val author: String = "UNKNOWN",
+    val text: String = "",
+    val createdAtMillis: Long? = null,
+    val responseGroupId: String? = null,
+    val displayKind: String? = null,
+    val messageSchemaVersion: Int = 1,
+)
+
+@Entity(tableName = "chat_state_meta")
+data class ChatStateMetaEntity(
+    @PrimaryKey
+    val id: String = ChatStateMetaEntityId,
+    val currentSessionId: String,
+    val roomMigrationComplete: Boolean,
+)
+
+const val ChatStateMetaEntityId = "default"
+
+data class ChatSessionSnapshot(
+    val session: ChatSessionEntity,
+    val messages: List<ChatMessageEntity>,
+)

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -50,6 +50,18 @@ data class ChatMessageEntity(
     val messageSchemaVersion: Int = 1,
 )
 
+data class ChatMessageSummaryEntity(
+    val sessionId: String,
+    val id: String,
+    val position: Int,
+    val author: String = "UNKNOWN",
+    val text: String = "",
+    val createdAtMillis: Long? = null,
+    val responseGroupId: String? = null,
+    val displayKind: String? = null,
+    val messageSchemaVersion: Int = 1,
+)
+
 @Entity(
     tableName = "chat_state_meta",
     foreignKeys = [

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -32,7 +32,7 @@ data class ChatSessionEntity(
         ),
     ],
     indices = [
-        Index(value = ["sessionId", "position"]),
+        Index(value = ["sessionId", "position"], unique = true),
         Index(value = ["sessionId", "responseGroupId"]),
         Index(value = ["sessionId", "author"]),
     ],
@@ -50,11 +50,22 @@ data class ChatMessageEntity(
     val messageSchemaVersion: Int = 1,
 )
 
-@Entity(tableName = "chat_state_meta")
+@Entity(
+    tableName = "chat_state_meta",
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatSessionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["currentSessionId"],
+            onDelete = ForeignKey.SET_NULL,
+        ),
+    ],
+    indices = [Index(value = ["currentSessionId"])],
+)
 data class ChatStateMetaEntity(
     @PrimaryKey
     val id: String = ChatStateMetaEntityId,
-    val currentSessionId: String,
+    val currentSessionId: String?,
     val roomMigrationComplete: Boolean,
 )
 

--- a/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
@@ -1,5 +1,6 @@
 package com.zhousl.aether.data
 
+import com.zhousl.aether.data.chatdb.ChatMessageSummaryEntity
 import com.zhousl.aether.ui.AttachmentKind
 import com.zhousl.aether.ui.ChatAttachment
 import com.zhousl.aether.ui.ChatMessage
@@ -99,6 +100,27 @@ class ChatRepositorySerializationTest {
 
         assertTrue(output.getBoolean("ok"))
         assertEquals("x".repeat(140_000), output.getString("stdout"))
+    }
+
+    @Test
+    fun summaryMappingDoesNotReadLegacyMessageJsonPayload() {
+        val message = ChatMessageEntityMapper.summaryToChatMessage(
+            ChatMessageSummaryEntity(
+                sessionId = "session-1",
+                id = "agent-1",
+                position = 0,
+                author = MessageAuthor.Agent.name,
+                text = "Recovered from typed columns",
+                createdAtMillis = 123L,
+            )
+        )
+
+        assertEquals("agent-1", message.id)
+        assertEquals(MessageAuthor.Agent, message.author)
+        assertEquals("Recovered from typed columns", message.text)
+        assertEquals(123L, message.createdAtMillis)
+        assertTrue(message.toolInvocations.isEmpty())
+        assertTrue(message.providerPayloadJson.isNullOrBlank())
     }
 
     @Test

--- a/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 
 class ChatRepositorySerializationTest {
     @Test
-    fun serializationDropsInlineImageBytesButKeepsWorkspacePath() {
+    fun serializationKeepsInlineImageBytesAndWorkspacePath() {
         val serialized = serializeChatSessions(
             listOf(
                 ChatSession(
@@ -52,12 +52,12 @@ class ChatRepositorySerializationTest {
             .getJSONArray("attachments")
             .getJSONObject(0)
 
-        assertFalse(attachment.has("inlineBase64"))
+        assertEquals("a".repeat(120_000), attachment.getString("inlineBase64"))
         assertEquals("/workspace/image.png", attachment.getString("workspacePath"))
     }
 
     @Test
-    fun serializationCompactsLargeToolOutputJson() {
+    fun serializationKeepsLargeToolOutputJson() {
         val serialized = serializeChatSessions(
             listOf(
                 ChatSession(
@@ -97,7 +97,58 @@ class ChatRepositorySerializationTest {
             .getString("outputJson")
         val output = JSONObject(outputJson)
 
-        assertTrue(output.getBoolean("aetherPersistedOutputTruncated"))
-        assertTrue(output.getString("stdout").length < 40_000)
+        assertTrue(output.getBoolean("ok"))
+        assertEquals("x".repeat(140_000), output.getString("stdout"))
+    }
+
+    @Test
+    fun migrationParseResultMarksCorruptedJsonAsRecoverable() {
+        val result = parseChatSessionsForMigration("{not-valid-json")
+
+        assertTrue(result.recoveredFromCorruption)
+        assertEquals(1, result.sessions.size)
+        assertTrue(result.sessions.first().id.startsWith("corrupt-chat-state-"))
+    }
+
+    @Test
+    fun migrationParseResultKeepsValidJsonSuccessful() {
+        val result = parseChatSessionsForMigration(
+            """
+                [{"id":"session-1","title":"First","preview":"First","messages":[]}]
+            """.trimIndent()
+        )
+
+        assertFalse(result.recoveredFromCorruption)
+        assertEquals("session-1", result.sessions.single().id)
+    }
+
+    @Test
+    fun migrationKeepsLegacyCurrentSessionWhenItExists() {
+        val sessions = listOf(
+            ChatSession(id = "session-1", title = "First", preview = "First", messages = emptyList()),
+            ChatSession(id = "session-2", title = "Second", preview = "Second", messages = emptyList()),
+        )
+
+        val currentSessionId = resolveLegacyCurrentSessionIdForMigration(
+            legacyCurrentSessionId = "session-2",
+            legacySessions = sessions,
+        )
+
+        assertEquals("session-2", currentSessionId)
+    }
+
+    @Test
+    fun migrationFallsBackToFirstSessionWhenLegacyCurrentSessionIsMissing() {
+        val sessions = listOf(
+            ChatSession(id = "session-1", title = "First", preview = "First", messages = emptyList()),
+            ChatSession(id = "session-2", title = "Second", preview = "Second", messages = emptyList()),
+        )
+
+        val currentSessionId = resolveLegacyCurrentSessionIdForMigration(
+            legacyCurrentSessionId = "missing-session",
+            legacySessions = sessions,
+        )
+
+        assertEquals("session-1", currentSessionId)
     }
 }

--- a/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
@@ -138,6 +138,21 @@ class ChatRepositorySerializationTest {
     }
 
     @Test
+    fun migrationFallsBackToFirstSessionWhenLegacyCurrentSessionIsAbsent() {
+        val sessions = listOf(
+            ChatSession(id = "session-1", title = "First", preview = "First", messages = emptyList()),
+            ChatSession(id = "session-2", title = "Second", preview = "Second", messages = emptyList()),
+        )
+
+        val currentSessionId = resolveLegacyCurrentSessionIdForMigration(
+            legacyCurrentSessionId = null,
+            legacySessions = sessions,
+        )
+
+        assertEquals("session-1", currentSessionId)
+    }
+
+    @Test
     fun migrationFallsBackToFirstSessionWhenLegacyCurrentSessionIsMissing() {
         val sessions = listOf(
             ChatSession(id = "session-1", title = "First", preview = "First", messages = emptyList()),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,10 @@ shizuku = "13.1.5"
 androidAppProcess = "1.4.3"
 posthogAndroid = "3.43.1"
 posthogAndroidGradlePlugin = "1.1.0"
+androidxTestCore = "1.6.1"
+androidxTestExtJunit = "1.2.1"
+room = "2.8.4"
+ksp = "2.3.9"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -48,10 +52,18 @@ shizuku-api = { group = "dev.rikka.shizuku", name = "api", version.ref = "shizuk
 shizuku-provider = { group = "dev.rikka.shizuku", name = "provider", version.ref = "shizuku" }
 android-app-process = { group = "io.github.iamr0s", name = "AndroidAppProcess", version.ref = "androidAppProcess" }
 posthog-android = { group = "com.posthog", name = "posthog-android", version.ref = "posthogAndroid" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestCore" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 posthog-android = { id = "com.posthog.android", version.ref = "posthogAndroidGradlePlugin" }


### PR DESCRIPTION
## Summary

Implements part of #15 by moving chat history persistence from the legacy DataStore JSON snapshot into Room.

Room is introduced as the primary storage for chat sessions, messages, and current session metadata. App settings remain in DataStore.

## Details

- Add Room dependencies and schema export setup
- Add Room entities, DAO, and database for chat history
- Map existing chat messages to Room-backed records
- Migrate legacy DataStore chat history snapshots into Room on first load
- Keep migration idempotent by preserving legacy data until migration succeeds
- Preserve `messageJson` as a compatibility fallback for exported/imported chat data
- Store `currentSessionId` in Room metadata

## Validation

- Added mapper serialization coverage for Room-backed chat messages
- Verified legacy chat snapshots migrate into Room
- Verified exported data preserves session/message structure in tested samples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Added Room-based local chat history persistence with session, message, and metadata observation plus upsert/delete operations.
  * Added message schema versioning for smoother stored data transitions.

* **Bug Fixes**
  * Improved recovery from corrupted legacy chat data with a recoverable fallback.
  * Preserved full inline image and large tool output payloads (and relaxed truncation for other stored payload fields).
  * Enhanced legacy “current session” resolution and more robust chat state/message merging.

* **Tests**
  * Updated and expanded serialization, migration, and mapping tests to validate the new persistence and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->