### PR TITLE
feat: replace debug APK workflow with nightly build

### DIFF
--- a/.github/workflows/build-nightly-apk.yml
+++ b/.github/workflows/build-nightly-apk.yml
@@ -1,30 +1,51 @@
-name: Build Debug APK
+name: Build Nightly APK
 
 on:
   workflow_dispatch:
   push:
-    branches: [ main, master, aether-null-workdir-fix ]
+    branches: [ main ]
+    paths:
+      - 'app/**'
+      - 'third_party/termux/terminal-emulator/**'
+      - 'third_party/termux/terminal-view/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'gradlew'
+      - '.github/workflows/build-nightly-apk.yml'
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: enhanced
+          cache-read-only: false
+
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Make Gradle executable
         run: chmod +x ./gradlew
 
-      - name: Prepare nightly metadata
+      - name: Prepare Nightly Metadata
         id: nightly
         shell: bash
         run: |
@@ -32,7 +53,7 @@ jobs:
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
           echo "version_name=Nightly $short_sha" >> "$GITHUB_OUTPUT"
 
-      - name: Restore nightly signing key
+      - name: Restore Nightly Signing Key
         shell: bash
         env:
           NIGHTLY_KEYSTORE_BASE64: ${{ secrets.NIGHTLY_KEYSTORE_BASE64 }}
@@ -40,22 +61,25 @@ jobs:
           mkdir -p "$RUNNER_TEMP/aether-signing"
           echo "$NIGHTLY_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/aether-signing/aether-nightly.jks"
 
-      - name: Build nightly APK
+      - name: Build Nightly APK
         env:
           NIGHTLY_KEYSTORE_FILE: ${{ runner.temp }}/aether-signing/aether-nightly.jks
           NIGHTLY_KEYSTORE_PASSWORD: ${{ secrets.NIGHTLY_KEYSTORE_PASSWORD }}
           NIGHTLY_KEY_ALIAS: ${{ secrets.NIGHTLY_KEY_ALIAS }}
           NIGHTLY_KEY_PASSWORD: ${{ secrets.NIGHTLY_KEY_PASSWORD }}
-        run: ./gradlew :app:assembleNightly --stacktrace -Paether.versionName="${{ steps.nightly.outputs.version_name }}"
+          VERSION_NAME: ${{ steps.nightly.outputs.version_name }}
+        run: ./gradlew :app:assembleNightly --stacktrace -Paether.versionName="$VERSION_NAME"
 
-      - name: Rename nightly APK
+      - name: Rename Nightly APK
         shell: bash
+        env:
+          SHORT_SHA: ${{ steps.nightly.outputs.short_sha }}
         run: |
           mkdir -p dist/nightly
-          cp app/build/outputs/apk/nightly/app-nightly.apk "dist/nightly/Aether-nightly-${{ steps.nightly.outputs.short_sha }}.apk"
+          cp app/build/outputs/apk/nightly/app-nightly.apk "dist/nightly/Aether-nightly-${SHORT_SHA}.apk"
 
-      - name: Upload nightly APK
-        uses: actions/upload-artifact@v4
+      - name: Upload Nightly APK
+        uses: actions/upload-artifact@v7
         with:
           name: Aether-nightly
           path: dist/nightly/*.apk

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Aether's UI and interactions are heavily inspired by excellent, mature applicati
 - Optional: [Termux](https://termux.dev/) installed
 
 ### Installation
-1. Download the latest [Release APK](https://github.com/Zhou-Shilin/Aether/releases) or [Nightly APK artifact](https://nightly.link/Zhou-Shilin/Aether/workflows/build-debug-apk.yml/main/Aether-nightly.zip).
+1. Download the latest [Release APK](https://github.com/Zhou-Shilin/Aether/releases) or [Nightly APK artifact](https://nightly.link/Zhou-Shilin/Aether/workflows/build-nightly-apk.yml/main/Aether-nightly.zip).
 2. Follow the "Get Started" tour to configure the app.
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,7 +85,7 @@ Aether 的 UI 和交互大量参考了 ChatGPT、Codex CLI/App、Gemini、Poco A
 - 可选：已安装 [Termux](https://termux.dev/)
 
 ### 安装步骤
-1. 下载最新的 [Release APK](https://github.com/Zhou-Shilin/Aether/releases) 或 [Nightly APK artifact](https://nightly.link/Zhou-Shilin/Aether/workflows/build-debug-apk.yml/main/Aether-nightly.zip)。
+1. 下载最新的 [Release APK](https://github.com/Zhou-Shilin/Aether/releases) 或 [Nightly APK artifact](https://nightly.link/Zhou-Shilin/Aether/workflows/build-nightly-apk.yml/main/Aether-nightly.zip)。
 2. 根据 Get Started Tour 指引配置。
 
 ---

--- a/app/src/main/java/com/zhousl/aether/data/AppUpdateManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AppUpdateManager.kt
@@ -13,9 +13,9 @@ import org.json.JSONObject
 private const val GithubLatestReleaseUrl =
     "https://api.github.com/repos/Zhou-Shilin/Aether/releases/latest"
 private const val GithubLatestNightlyRunUrl =
-    "https://api.github.com/repos/Zhou-Shilin/Aether/actions/workflows/build-debug-apk.yml/runs?branch=main&status=success&per_page=1"
+    "https://api.github.com/repos/Zhou-Shilin/Aether/actions/workflows/build-nightly-apk.yml/runs?branch=main&status=success&per_page=1"
 private const val NightlyArtifactDownloadUrl =
-    "https://nightly.link/Zhou-Shilin/Aether/workflows/build-debug-apk.yml/main/Aether-nightly.zip"
+    "https://nightly.link/Zhou-Shilin/Aether/workflows/build-nightly-apk.yml/main/Aether-nightly.zip"
 private const val ApkMimeType = "application/vnd.android.package-archive"
 private const val ZipMimeType = "application/zip"
 


### PR DESCRIPTION
- Run nightly builds only on main and APK-related changes
- Add Gradle enhanced caching for CI builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the nightly Android APK build pipeline with updated CI tooling and better Gradle caching.
  * Tightened build workflow permissions and standardized nightly versioning and signing preparation.
  * Limited nightly builds to relevant changes on the main branch.
  * Continued publishing the nightly APK artifact to the nightly distribution.
  * Updated installation instructions and the app’s nightly update download source to use the nightly APK artifact link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->