### PR TITLE
fix(history): preserve and cache Room chat messages

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -27,6 +27,7 @@ import com.zhousl.aether.ui.MessageDisplayKind
 import com.zhousl.aether.ui.ReasoningSummaryChunk
 import com.zhousl.aether.ui.ReasoningTrace
 import com.zhousl.aether.ui.syncActiveBranches
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -36,12 +37,14 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.json.JSONArray
 import org.json.JSONObject
 
 private const val DraftSessionId = "draft"
+private const val MessageJsonChunkSize = 64 * 1024
 
 
 private val Context.chatDataStore by preferencesDataStore(name = "aether_chats")
@@ -50,6 +53,12 @@ data class PersistedChatState(
     val sessions: List<ChatSession> = emptyList(),
     val currentSessionId: String = DraftSessionId,
 )
+
+enum class PersistedChatWriteIntent {
+    SyncSnapshot,
+    DeleteSession,
+    ReplaceFromImport,
+}
 
 class ChatRepository(
     private val context: Context,
@@ -60,6 +69,7 @@ class ChatRepository(
     @OptIn(ExperimentalCoroutinesApi::class)
     val chatState: Flow<PersistedChatState> = flow {
         migrateLegacyChatStateIfNeeded()
+        val restoredMessageCache = mutableMapOf<ChatMessageCacheKey, LoadedChatMessage>()
         emitAll(
             combine(
                 chatHistoryDao.observeSessions(),
@@ -76,9 +86,18 @@ class ChatRepository(
             }.flatMapLatest { state ->
                 val sessionIds = state.rows.map { it.id }
                 val messagesFlow = if (sessionIds.isEmpty()) {
+                    restoredMessageCache.clear()
                     flowOf(emptyList())
                 } else {
-                    chatHistoryDao.observeMessagesForSessions(sessionIds)
+                    chatHistoryDao.observeMessageSummariesForSessions(sessionIds).mapLatest { summaries ->
+                        restoredMessageCache.keys.retainAll(summaries.mapTo(mutableSetOf()) { it.cacheKey })
+                        database.withTransaction {
+                            chatHistoryDao.getMessagesForSummariesSafely(
+                                summaries = summaries,
+                                restoredMessageCache = restoredMessageCache,
+                            )
+                        }
+                    }
                 }
                 messagesFlow.map { messages ->
                     val messagesBySessionId = messages.groupBy { it.sessionId }
@@ -97,12 +116,14 @@ class ChatRepository(
     suspend fun updateChatState(
         sessions: List<ChatSession>,
         currentSessionId: String,
+        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
     ) {
         migrateLegacyChatStateIfNeeded()
         replaceChatState(
             sessions = sessions.mapIndexed { index, session -> session.toSnapshot(index) },
             currentSessionId = currentSessionId,
             migrationComplete = true,
+            writeIntent = writeIntent,
         )
         context.chatDataStore.edit { preferences ->
             preferences.remove(SESSIONS_JSON)
@@ -186,6 +207,7 @@ class ChatRepository(
         sessions: List<ChatSessionSnapshot>,
         currentSessionId: String,
         migrationComplete: Boolean,
+        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
     ) {
         database.withTransaction {
             val safeCurrentSessionId = currentSessionId
@@ -193,6 +215,9 @@ class ChatRepository(
                 ?: sessions.firstOrNull()?.session?.id
                 ?: DraftSessionId
             if (sessions.isEmpty()) {
+                if (writeIntent == PersistedChatWriteIntent.SyncSnapshot && chatHistoryDao.getSessions().isNotEmpty()) {
+                    return@withTransaction
+                }
                 chatHistoryDao.upsertMeta(
                     ChatStateMetaEntity(
                         currentSessionId = null,
@@ -235,47 +260,29 @@ class ChatRepository(
 
         if (roomMeta?.roomMigrationComplete == true) {
             if (legacySessionsJson.isNotBlank() || preferences[CURRENT_SESSION_ID] != null) {
-                context.chatDataStore.edit { data ->
-                    data.remove(SESSIONS_JSON)
-                    data.remove(CURRENT_SESSION_ID)
-                    data[ROOM_MIGRATION_COMPLETE] = true
-                }
+                clearLegacyChatState()
             }
             return@withLock
         }
 
         if (legacyMigrationComplete && legacySessionsJson.isBlank()) {
-            database.withTransaction {
-                chatHistoryDao.upsertMeta(
-                    ChatStateMetaEntity(
-                        currentSessionId = null,
-                        roomMigrationComplete = true,
-                    )
-                )
-            }
+            markRoomMigrationCompletePreservingExistingState()
             if (preferences[CURRENT_SESSION_ID] != null) {
-                context.chatDataStore.edit { data ->
-                    data.remove(CURRENT_SESSION_ID)
-                    data[ROOM_MIGRATION_COMPLETE] = true
-                }
+                clearLegacyChatState()
             }
             return@withLock
         }
 
         if (legacySessionsJson.isBlank()) {
-            database.withTransaction {
-                chatHistoryDao.upsertMeta(
-                    ChatStateMetaEntity(
-                        currentSessionId = null,
-                        roomMigrationComplete = true,
-                    )
-                )
-            }
-            context.chatDataStore.edit { data ->
-                data.remove(SESSIONS_JSON)
-                data.remove(CURRENT_SESSION_ID)
-                data[ROOM_MIGRATION_COMPLETE] = true
-            }
+            markRoomMigrationCompletePreservingExistingState()
+            clearLegacyChatState()
+            return@withLock
+        }
+
+        val existingSessions = chatHistoryDao.getSessions()
+        if (existingSessions.isNotEmpty()) {
+            markRoomMigrationCompletePreservingExistingState()
+            clearLegacyChatState()
             return@withLock
         }
 
@@ -291,11 +298,7 @@ class ChatRepository(
                 ),
                 migrationComplete = true,
             )
-            context.chatDataStore.edit { data ->
-                data.remove(SESSIONS_JSON)
-                data.remove(CURRENT_SESSION_ID)
-                data[ROOM_MIGRATION_COMPLETE] = true
-            }
+            clearLegacyChatState()
             return@withLock
         }
         if (legacySessions.isNotEmpty()) {
@@ -307,22 +310,33 @@ class ChatRepository(
                 ),
                 migrationComplete = true,
             )
-            context.chatDataStore.edit { data ->
-                data.remove(SESSIONS_JSON)
-                data.remove(CURRENT_SESSION_ID)
-                data[ROOM_MIGRATION_COMPLETE] = true
-            }
+            clearLegacyChatState()
             return@withLock
         }
+
+        markRoomMigrationCompletePreservingExistingState()
+        clearLegacyChatState()
+    }
+
+    private suspend fun markRoomMigrationCompletePreservingExistingState() {
+        val existingSessions = chatHistoryDao.getSessions()
+        val existingMeta = chatHistoryDao.getMeta()
+        val existingSessionIds = existingSessions.mapTo(mutableSetOf()) { it.id }
+        val currentSessionId = existingMeta
+            ?.currentSessionId
+            ?.takeIf { id -> id in existingSessionIds }
 
         database.withTransaction {
             chatHistoryDao.upsertMeta(
                 ChatStateMetaEntity(
-                    currentSessionId = null,
+                    currentSessionId = currentSessionId,
                     roomMigrationComplete = true,
                 )
             )
         }
+    }
+
+    private suspend fun clearLegacyChatState() {
         context.chatDataStore.edit { data ->
             data.remove(SESSIONS_JSON)
             data.remove(CURRENT_SESSION_ID)
@@ -354,6 +368,105 @@ internal fun resolveLegacyCurrentSessionIdForMigration(
 private fun String?.toStoredCurrentSessionId(): String? = this
     ?.takeUnless { it.isBlank() || it == DraftSessionId }
 
+private suspend fun ChatHistoryDao.getMessagesForSummariesSafely(
+    summaries: List<ChatMessageSummaryEntity>,
+    restoredMessageCache: MutableMap<ChatMessageCacheKey, LoadedChatMessage>,
+): List<LoadedChatMessage> = summaries.map { summary ->
+    val cacheKey = summary.cacheKey
+    restoredMessageCache[cacheKey] ?: run {
+        val message = try {
+            loadMessageEntityInChunks(summary)?.let { entity ->
+                ChatMessageEntityMapper.toChatMessage(entity, entity.position)
+            }
+        } catch (throwable: Exception) {
+            if (throwable is CancellationException) throw throwable
+            null
+        } ?: ChatMessageEntityMapper.summaryToChatMessage(summary)
+
+        LoadedChatMessage(
+            sessionId = summary.sessionId,
+            position = summary.position,
+            message = message,
+        ).also { loadedMessage -> restoredMessageCache[cacheKey] = loadedMessage }
+    }
+}
+
+private suspend fun ChatHistoryDao.loadMessageEntityInChunks(
+    summary: ChatMessageSummaryEntity,
+): ChatMessageEntity? {
+    val jsonLength = getMessageJsonLength(
+        sessionId = summary.sessionId,
+        messageId = summary.id,
+    ) ?: return null
+    if (jsonLength <= 0) {
+        return summary.toMessageEntity(messageJson = "")
+    }
+
+    val builder = StringBuilder(jsonLength)
+    var start = 1
+    while (start <= jsonLength) {
+        val requestedLength = minOf(MessageJsonChunkSize, jsonLength - start + 1)
+        val chunk = getMessageJsonChunk(
+            sessionId = summary.sessionId,
+            messageId = summary.id,
+            start = start,
+            length = requestedLength,
+        ) ?: return null
+        if (chunk.isEmpty()) {
+            return null
+        }
+        builder.append(chunk)
+        start += requestedLength
+    }
+    return summary.toMessageEntity(builder.toString())
+}
+
+private fun ChatMessageSummaryEntity.toMessageEntity(messageJson: String): ChatMessageEntity = ChatMessageEntity(
+    sessionId = sessionId,
+    id = id,
+    position = position,
+    messageJson = messageJson,
+    author = author,
+    text = text,
+    createdAtMillis = createdAtMillis,
+    responseGroupId = responseGroupId,
+    displayKind = displayKind,
+    messageSchemaVersion = messageSchemaVersion,
+)
+
+private val ChatMessageSummaryEntity.cacheKey: ChatMessageCacheKey
+    get() = ChatMessageCacheKey(
+        sessionId = sessionId,
+        id = id,
+        position = position,
+        author = author,
+        text = text,
+        createdAtMillis = createdAtMillis,
+        responseGroupId = responseGroupId,
+        displayKind = displayKind,
+        messageSchemaVersion = messageSchemaVersion,
+        messageJsonLength = messageJsonLength,
+    )
+
+private data class ChatMessageCacheKey(
+    val sessionId: String,
+    val id: String,
+    val position: Int,
+    val author: String,
+    val text: String,
+    val createdAtMillis: Long?,
+    val responseGroupId: String?,
+    val displayKind: String?,
+    val messageSchemaVersion: Int,
+    val messageJsonLength: Int?,
+)
+
+private data class LoadedChatMessage(
+    val sessionId: String,
+    val position: Int,
+    val message: ChatMessage,
+)
+
 private data class SessionListState(
     val rows: List<ChatSessionEntity>,
     val currentSessionId: String,
@@ -383,10 +496,8 @@ private fun ChatSession.toSnapshot(index: Int): ChatSessionSnapshot = ChatSessio
     },
 )
 
-private fun ChatSessionEntity.toChatSession(messages: List<ChatMessageEntity>): ChatSession {
-    val orderedMessages = messages.sortedBy { it.position }.mapIndexed { index, message ->
-        ChatMessageEntityMapper.toChatMessage(message, index)
-    }
+private fun ChatSessionEntity.toChatSession(messages: List<LoadedChatMessage>): ChatSession {
+    val orderedMessages = messages.sortedBy { it.position }.map { it.message }
     val activeSkills = parseActiveSkillContexts(activeSkillsJson)
     return ChatSession(
         id = id,

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -65,11 +65,12 @@ class ChatRepository(
     private val database: ChatHistoryDatabase = ChatHistoryDatabase.getInstance(context),
 ) {
     private val chatHistoryDao: ChatHistoryDao = database.chatHistoryDao()
+    private val restoredMessageCache = mutableMapOf<ChatMessageCacheKey, LoadedChatMessage>()
+    private val restoredMessageCacheMutex = Mutex()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val chatState: Flow<PersistedChatState> = flow {
         migrateLegacyChatStateIfNeeded()
-        val restoredMessageCache = mutableMapOf<ChatMessageCacheKey, LoadedChatMessage>()
         emitAll(
             combine(
                 chatHistoryDao.observeSessions(),
@@ -86,16 +87,18 @@ class ChatRepository(
             }.flatMapLatest { state ->
                 val sessionIds = state.rows.map { it.id }
                 val messagesFlow = if (sessionIds.isEmpty()) {
-                    restoredMessageCache.clear()
+                    clearRestoredMessageCache()
                     flowOf(emptyList())
                 } else {
                     chatHistoryDao.observeMessageSummariesForSessions(sessionIds).mapLatest { summaries ->
-                        restoredMessageCache.keys.retainAll(summaries.mapTo(mutableSetOf()) { it.cacheKey })
-                        database.withTransaction {
-                            chatHistoryDao.getMessagesForSummariesSafely(
-                                summaries = summaries,
-                                restoredMessageCache = restoredMessageCache,
-                            )
+                        restoredMessageCacheMutex.withLock {
+                            restoredMessageCache.keys.retainAll(summaries.mapTo(mutableSetOf()) { it.cacheKey })
+                            database.withTransaction {
+                                chatHistoryDao.getMessagesForSummariesSafely(
+                                    summaries = summaries,
+                                    restoredMessageCache = restoredMessageCache,
+                                )
+                            }
                         }
                     }
                 }
@@ -150,6 +153,7 @@ class ChatRepository(
     ) {
         require(position >= 0) { "position must be non-negative" }
         migrateLegacyChatStateIfNeeded()
+        invalidateRestoredMessage(sessionId = sessionId, messageId = message.id)
         database.withTransaction {
             chatHistoryDao.upsertMessage(
                 ChatMessageEntityMapper.toEntity(
@@ -163,6 +167,7 @@ class ChatRepository(
 
     suspend fun deleteSessionById(sessionId: String) {
         migrateLegacyChatStateIfNeeded()
+        invalidateRestoredSession(sessionId)
         database.withTransaction {
             chatHistoryDao.deleteSession(sessionId)
             val meta = chatHistoryDao.getMeta()
@@ -179,6 +184,7 @@ class ChatRepository(
     ) {
         require(fromPosition >= 0) { "fromPosition must be non-negative" }
         migrateLegacyChatStateIfNeeded()
+        invalidateRestoredMessagesFromPosition(sessionId = sessionId, fromPosition = fromPosition)
         database.withTransaction {
             replaceMessagesFromPositionInTransaction(sessionId, fromPosition, messages)
         }
@@ -209,6 +215,7 @@ class ChatRepository(
         migrationComplete: Boolean,
         writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
     ) {
+        clearRestoredMessageCache()
         database.withTransaction {
             val safeCurrentSessionId = currentSessionId
                 .takeIf { id -> id == DraftSessionId || sessions.any { it.session.id == id } }
@@ -341,6 +348,49 @@ class ChatRepository(
             data.remove(SESSIONS_JSON)
             data.remove(CURRENT_SESSION_ID)
             data[ROOM_MIGRATION_COMPLETE] = true
+        }
+    }
+
+    private suspend fun clearRestoredMessageCache() {
+        restoredMessageCacheMutex.withLock {
+            restoredMessageCache.clear()
+        }
+    }
+
+    private suspend fun invalidateRestoredMessage(
+        sessionId: String,
+        messageId: String,
+    ) {
+        removeRestoredMessagesFromCache { cacheKey ->
+            cacheKey.sessionId == sessionId && cacheKey.id == messageId
+        }
+    }
+
+    private suspend fun invalidateRestoredSession(sessionId: String) {
+        removeRestoredMessagesFromCache { cacheKey ->
+            cacheKey.sessionId == sessionId
+        }
+    }
+
+    private suspend fun invalidateRestoredMessagesFromPosition(
+        sessionId: String,
+        fromPosition: Int,
+    ) {
+        removeRestoredMessagesFromCache { cacheKey ->
+            cacheKey.sessionId == sessionId && cacheKey.position >= fromPosition
+        }
+    }
+
+    private suspend fun removeRestoredMessagesFromCache(
+        shouldRemove: (ChatMessageCacheKey) -> Boolean,
+    ) {
+        restoredMessageCacheMutex.withLock {
+            val iterator = restoredMessageCache.keys.iterator()
+            while (iterator.hasNext()) {
+                if (shouldRemove(iterator.next())) {
+                    iterator.remove()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
@@ -102,10 +102,14 @@ class ChatStateStore(
     }
 
     suspend fun updateAndFlush(
+        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
         transform: (PersistedChatState) -> PersistedChatState,
     ): PersistedChatState {
         repositoryStateReady.await()
-        val updated = update(transform)
+        val updated = update(
+            writeIntent = writeIntent,
+            transform = transform,
+        )
         flushLatestPending(propagateFailure = true)
         return updated
     }
@@ -127,6 +131,7 @@ class ChatStateStore(
                 chatRepository.updateChatState(
                     sessions = pending.state.sessions,
                     currentSessionId = pending.state.currentSessionId,
+                    writeIntent = pending.writeIntent,
                 )
             }.exceptionOrNull()
             if (persistError != null) {
@@ -256,15 +261,25 @@ class ChatStateStore(
     }
 
     fun update(
+        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
         transform: (PersistedChatState) -> PersistedChatState,
     ): PersistedChatState {
         val pending = synchronized(updateLock) {
             val updated = transform(_state.value)
             localGeneration += 1
             _state.value = updated
+            val effectiveWriteIntent = latestPending
+                ?.writeIntent
+                ?.takeIf { pendingIntent ->
+                    writeIntent == PersistedChatWriteIntent.SyncSnapshot &&
+                        updated.sessions.isEmpty() &&
+                        pendingIntent != PersistedChatWriteIntent.SyncSnapshot
+                }
+                ?: writeIntent
             PendingPersistedChatState(
                 generation = localGeneration,
                 state = updated,
+                writeIntent = effectiveWriteIntent,
             ).also {
                 latestPending = it
             }
@@ -279,6 +294,7 @@ class ChatStateStore(
     private data class PendingPersistedChatState(
         val generation: Long,
         val state: PersistedChatState,
+        val writeIntent: PersistedChatWriteIntent,
     )
 
     private companion object {

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -10,6 +10,9 @@ interface ChatHistoryDao {
     @Query("SELECT * FROM chat_sessions ORDER BY sortOrder ASC")
     fun observeSessions(): Flow<List<ChatSessionEntity>>
 
+    @Query("SELECT * FROM chat_sessions ORDER BY sortOrder ASC")
+    suspend fun getSessions(): List<ChatSessionEntity>
+
     @Query("SELECT * FROM chat_state_meta WHERE id = :id")
     fun observeMeta(id: String = ChatStateMetaEntityId): Flow<ChatStateMetaEntity?>
 
@@ -17,7 +20,7 @@ interface ChatHistoryDao {
     suspend fun getMeta(id: String = ChatStateMetaEntityId): ChatStateMetaEntity?
 
     @Query("""
-        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion
+        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength
         FROM chat_messages
         WHERE sessionId = :sessionId
         ORDER BY position ASC
@@ -25,7 +28,7 @@ interface ChatHistoryDao {
     fun observeMessageSummariesForSession(sessionId: String): Flow<List<ChatMessageSummaryEntity>>
 
     @Query("""
-        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion
+        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength
         FROM chat_messages
         WHERE sessionId IN (:sessionIds)
         ORDER BY sessionId ASC, position ASC
@@ -33,13 +36,26 @@ interface ChatHistoryDao {
     fun observeMessageSummariesForSessions(sessionIds: List<String>): Flow<List<ChatMessageSummaryEntity>>
 
     @Query("""
-        SELECT *
+        SELECT length(messageJson)
         FROM chat_messages
-        WHERE sessionId IN (:sessionIds)
-        ORDER BY sessionId ASC, position ASC
+        WHERE sessionId = :sessionId AND id = :messageId
     """)
-    fun observeMessagesForSessions(sessionIds: List<String>): Flow<List<ChatMessageEntity>>
+    suspend fun getMessageJsonLength(
+        sessionId: String,
+        messageId: String,
+    ): Int?
 
+    @Query("""
+        SELECT substr(messageJson, :start, :length)
+        FROM chat_messages
+        WHERE sessionId = :sessionId AND id = :messageId
+    """)
+    suspend fun getMessageJsonChunk(
+        sessionId: String,
+        messageId: String,
+        start: Int,
+        length: Int,
+    ): String?
 
     @Upsert
     suspend fun upsertMeta(meta: ChatStateMetaEntity)

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -60,6 +60,7 @@ data class ChatMessageSummaryEntity(
     val responseGroupId: String? = null,
     val displayKind: String? = null,
     val messageSchemaVersion: Int = 1,
+    val messageJsonLength: Int? = null,
 )
 
 @Entity(

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -26,6 +26,7 @@ import com.zhousl.aether.data.LlmProvider
 import com.zhousl.aether.data.LlmProviderConfig
 import com.zhousl.aether.data.LocalRuntimeId
 import com.zhousl.aether.data.ProviderModelOption
+import com.zhousl.aether.data.PersistedChatWriteIntent
 import com.zhousl.aether.data.availableModelOptions
 import com.zhousl.aether.data.McpClientManager
 import com.zhousl.aether.data.McpServerConfig
@@ -1198,7 +1199,9 @@ class AetherViewModel(
                     )
                     extensionsRepository.updateInstalledSkills(imported.installedSkills)
                     extensionsRepository.updateMcpServers(imported.mcpServers)
-                    chatStateStore.updateAndFlush {
+                    chatStateStore.updateAndFlush(
+                        writeIntent = PersistedChatWriteIntent.ReplaceFromImport,
+                    ) {
                         it.copy(
                             sessions = imported.sessions,
                             currentSessionId = imported.currentSessionId,
@@ -2707,7 +2710,9 @@ class AetherViewModel(
         sharedWorkspaceFilePaths: Collection<String> = emptyList(),
     ) {
         var unreferencedSharedWorkspaceFilePaths = emptyList<String>()
-        chatStateStore.update { persisted ->
+        chatStateStore.update(
+            writeIntent = PersistedChatWriteIntent.DeleteSession,
+        ) { persisted ->
             unreferencedSharedWorkspaceFilePaths = sharedWorkspaceFilePaths.unreferencedWorkspaceFilePaths(
                 sessions = persisted.sessions,
                 excludedSessionIds = setOf(sessionId),


### PR DESCRIPTION
## Summary

- Keep existing Room sessions when legacy migration has already run
- Preserve summary text for fallback message restoration
- Cache restored message bodies across summary emissions

## Testing

- Built and tested on a physical Android device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improves chat history restoration with chunked, lazy reconstruction for smoother loading of large conversations.
* **Bug Fixes**
  * Prevents existing chat data from being cleared during certain sync/empty-state updates.
  * Improves resilience by rebuilding messages from per-session summaries and fetching JSON incrementally when needed.
  * Strengthens cache invalidation so restored messages stay consistent after edits and deletions.
* **Improvements**
  * Makes imports and session deletions more reliable by applying more precise persistence behavior.  
* **Refactor**
  * Refines legacy migration cleanup and recovery handling to preserve existing chat state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->