### PR TITLE
fix: adapt popup surfaces for dark mode

### DIFF
--- a/app/src/main/java/com/zhousl/aether/ui/MarkdownRenderer.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/MarkdownRenderer.kt
@@ -970,8 +970,8 @@ private fun MarkdownMermaidPreviewDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(24.dp))
-                .background(Color.White),
-            backgroundColor = Color.White,
+                .background(AetherSurfaceHigh),
+            backgroundColor = AetherSurfaceHigh,
         )
     }
 }

--- a/app/src/main/java/com/zhousl/aether/ui/MarkdownRenderer.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/MarkdownRenderer.kt
@@ -991,7 +991,7 @@ private fun MarkdownPreviewDialogFrame(
                 .fillMaxWidth()
                 .padding(horizontal = 18.dp, vertical = 24.dp)
                 .clip(RoundedCornerShape(28.dp))
-                .background(Color.White.copy(alpha = 0.98f))
+                .background(AetherSurface.copy(alpha = 0.98f))
                 .padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {

--- a/app/src/main/java/com/zhousl/aether/ui/ProviderConfigForm.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/ProviderConfigForm.kt
@@ -60,6 +60,8 @@ import com.zhousl.aether.data.requiresApiKey
 import com.zhousl.aether.data.sanitizeProviderId
 import com.zhousl.aether.ui.theme.AetherOnSurface
 import com.zhousl.aether.ui.theme.AetherOnSurfaceVariant
+import com.zhousl.aether.ui.theme.AetherPrimary
+import com.zhousl.aether.ui.theme.AetherSurface
 import com.zhousl.aether.ui.theme.AetherSurfaceHigh
 import java.util.UUID
 
@@ -639,13 +641,13 @@ private fun ProviderFormDropdownField(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier.background(Color.White),
+            containerColor = AetherSurface,
         ) {
             options.forEach { option ->
                 DropdownMenuItem(
                     text = { Text(option.displayName, color = AetherOnSurface) },
                     trailingIcon = if (option.displayName == selectedValue) {
-                        { Icon(Icons.Rounded.Check, contentDescription = null, tint = ProviderFormPrimary) }
+                        { Icon(Icons.Rounded.Check, contentDescription = null, tint = AetherPrimary) }
                     } else {
                         null
                     },


### PR DESCRIPTION
## Summary

- Use themed surfaces for provider request format menus
- Match markdown preview dialog frames to dark mode surfaces

## Testing

- Built and tested on a physical Android device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Markdown preview dialog background to use the app’s themed surface color, keeping the same transparency level and overall layout.
  * Refined the provider dropdown menu to use themed surface styling instead of a hardcoded background.
  * Changed the selected-provider check/icon tint to the primary theme color for better visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->