### PR TITLE
fix(history): index chat workspace file refs

### DIFF
--- a/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/2.json
+++ b/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/2.json
@@ -1,0 +1,317 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "f4fe3071a2ca1a43e45eef590ab873be",
+    "entities": [
+      {
+        "tableName": "chat_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `preview` TEXT NOT NULL, `hasCustomTitle` INTEGER NOT NULL, `selectedSkillIdsJson` TEXT NOT NULL, `activeSkillsJson` TEXT NOT NULL, `activeMcpServerIdsJson` TEXT NOT NULL, `agentModeEnabled` INTEGER NOT NULL, `selectedModelKey` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomTitle",
+            "columnName": "hasCustomTitle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSkillIdsJson",
+            "columnName": "selectedSkillIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeSkillsJson",
+            "columnName": "activeSkillsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeMcpServerIdsJson",
+            "columnName": "activeMcpServerIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentModeEnabled",
+            "columnName": "agentModeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedModelKey",
+            "columnName": "selectedModelKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `id` TEXT NOT NULL, `position` INTEGER NOT NULL, `messageJson` TEXT NOT NULL, `author` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAtMillis` INTEGER, `responseGroupId` TEXT, `displayKind` TEXT, `messageSchemaVersion` INTEGER NOT NULL, PRIMARY KEY(`sessionId`, `id`), FOREIGN KEY(`sessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageJson",
+            "columnName": "messageJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "responseGroupId",
+            "columnName": "responseGroupId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayKind",
+            "columnName": "displayKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "messageSchemaVersion",
+            "columnName": "messageSchemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_sessionId_position",
+            "unique": true,
+            "columnNames": [
+              "sessionId",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chat_messages_sessionId_position` ON `${TABLE_NAME}` (`sessionId`, `position`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_responseGroupId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "responseGroupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_responseGroupId` ON `${TABLE_NAME}` (`sessionId`, `responseGroupId`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_author",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "author"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_author` ON `${TABLE_NAME}` (`sessionId`, `author`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_workspace_file_refs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `messageId` TEXT NOT NULL, `path` TEXT NOT NULL, PRIMARY KEY(`sessionId`, `messageId`, `path`), FOREIGN KEY(`sessionId`, `messageId`) REFERENCES `chat_messages`(`sessionId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "messageId",
+            "path"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_workspace_file_refs_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId",
+              "messageId"
+            ],
+            "referencedColumns": [
+              "sessionId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_state_meta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `currentSessionId` TEXT, `roomMigrationComplete` INTEGER NOT NULL, `workspaceFileRefsComplete` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`currentSessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentSessionId",
+            "columnName": "currentSessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roomMigrationComplete",
+            "columnName": "roomMigrationComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workspaceFileRefsComplete",
+            "columnName": "workspaceFileRefsComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_state_meta_currentSessionId",
+            "unique": false,
+            "columnNames": [
+              "currentSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_state_meta_currentSessionId` ON `${TABLE_NAME}` (`currentSessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "currentSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f4fe3071a2ca1a43e45eef590ab873be')"
+    ]
+  }
+}

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -13,6 +13,7 @@ import com.zhousl.aether.data.chatdb.ChatMessageSummaryEntity
 import com.zhousl.aether.data.chatdb.ChatSessionEntity
 import com.zhousl.aether.data.chatdb.ChatSessionSnapshot
 import com.zhousl.aether.data.chatdb.ChatStateMetaEntity
+import com.zhousl.aether.data.chatdb.ChatWorkspaceFileRefEntity
 
 import com.zhousl.aether.ui.AttachmentKind
 import com.zhousl.aether.ui.AttachmentWorkspaceState
@@ -45,6 +46,7 @@ import org.json.JSONObject
 
 private const val DraftSessionId = "draft"
 private const val MessageJsonChunkSize = 64 * 1024
+private const val WorkspaceFileRefQueryChunkSize = 500
 
 
 private val Context.chatDataStore by preferencesDataStore(name = "aether_chats")
@@ -155,12 +157,15 @@ class ChatRepository(
         migrateLegacyChatStateIfNeeded()
         invalidateRestoredMessage(sessionId = sessionId, messageId = message.id)
         database.withTransaction {
-            chatHistoryDao.upsertMessage(
-                ChatMessageEntityMapper.toEntity(
-                    sessionId = sessionId,
-                    position = position,
-                    message = message,
-                )
+            val messageEntity = ChatMessageEntityMapper.toEntity(
+                sessionId = sessionId,
+                position = position,
+                message = message,
+            )
+            chatHistoryDao.upsertMessage(messageEntity)
+            replaceWorkspaceFileRefsForMessagesInTransaction(
+                sessionId = sessionId,
+                messages = listOf(message),
             )
         }
     }
@@ -173,6 +178,55 @@ class ChatRepository(
             val meta = chatHistoryDao.getMeta()
             if (meta?.currentSessionId == sessionId) {
                 chatHistoryDao.upsertMeta(meta.copy(currentSessionId = null))
+            }
+        }
+    }
+
+    suspend fun getUnreferencedWorkspaceFilePathsForDeletedSession(sessionId: String): List<String> {
+        migrateLegacyChatStateIfNeeded()
+        return database.withTransaction {
+            if (chatHistoryDao.getMeta()?.workspaceFileRefsComplete != true) {
+                return@withTransaction emptyList()
+            }
+            val candidatePaths = chatHistoryDao.getWorkspaceFilePathsForSession(sessionId).normalizedWorkspaceFilePaths()
+            if (candidatePaths.isEmpty()) {
+                emptyList()
+            } else {
+                val referencedPaths = getWorkspaceFileRefsForPathsChunked(candidatePaths)
+                    .asSequence()
+                    .filterNot { ref -> ref.sessionId == sessionId }
+                    .map { ref -> ref.path }
+                    .toSet()
+                candidatePaths.filterNot(referencedPaths::contains)
+            }
+        }
+    }
+
+    suspend fun getUnreferencedWorkspaceFilePathsForDeletedMessages(
+        sessionId: String,
+        messageIds: List<String>,
+    ): List<String> {
+        migrateLegacyChatStateIfNeeded()
+        val safeMessageIds = messageIds.map(String::trim).filter(String::isNotEmpty).distinct()
+        if (safeMessageIds.isEmpty()) return emptyList()
+        val safeMessageIdSet = safeMessageIds.toSet()
+        return database.withTransaction {
+            if (chatHistoryDao.getMeta()?.workspaceFileRefsComplete != true) {
+                return@withTransaction emptyList()
+            }
+            val candidatePaths = getWorkspaceFilePathsForMessagesChunked(
+                sessionId = sessionId,
+                messageIds = safeMessageIds,
+            ).normalizedWorkspaceFilePaths()
+            if (candidatePaths.isEmpty()) {
+                emptyList()
+            } else {
+                val referencedPaths = getWorkspaceFileRefsForPathsChunked(candidatePaths)
+                    .asSequence()
+                    .filterNot { ref -> ref.sessionId == sessionId && ref.messageId in safeMessageIdSet }
+                    .map { ref -> ref.path }
+                    .toSet()
+                candidatePaths.filterNot(referencedPaths::contains)
             }
         }
     }
@@ -195,16 +249,20 @@ class ChatRepository(
         fromPosition: Int,
         messages: List<ChatMessage>,
     ) {
+        chatHistoryDao.deleteWorkspaceFileRefsFromPosition(sessionId, fromPosition)
         chatHistoryDao.deleteMessagesFromPosition(sessionId, fromPosition)
         if (messages.isNotEmpty()) {
-            chatHistoryDao.upsertMessages(
-                messages.mapIndexed { index, message ->
-                    ChatMessageEntityMapper.toEntity(
-                        sessionId = sessionId,
-                        position = fromPosition + index,
-                        message = message,
-                    )
-                }
+            val messageEntities = messages.mapIndexed { index, message ->
+                ChatMessageEntityMapper.toEntity(
+                    sessionId = sessionId,
+                    position = fromPosition + index,
+                    message = message,
+                )
+            }
+            chatHistoryDao.upsertMessages(messageEntities)
+            replaceWorkspaceFileRefsForMessagesInTransaction(
+                sessionId = sessionId,
+                messages = messages,
             )
         }
     }
@@ -229,8 +287,10 @@ class ChatRepository(
                     ChatStateMetaEntity(
                         currentSessionId = null,
                         roomMigrationComplete = migrationComplete,
+                        workspaceFileRefsComplete = true,
                     )
                 )
+                chatHistoryDao.deleteAllWorkspaceFileRefs()
                 chatHistoryDao.deleteAllMessages()
                 chatHistoryDao.deleteAllSessions()
                 return@withTransaction
@@ -239,23 +299,59 @@ class ChatRepository(
             val sessionEntities = sessions.map { it.session }
             val sessionIds = sessionEntities.map { it.id }
             chatHistoryDao.upsertSessions(sessionEntities)
+            chatHistoryDao.deleteWorkspaceFileRefsExceptSessions(sessionIds)
             chatHistoryDao.deleteSessionsExcept(sessionIds)
             chatHistoryDao.deleteMessagesExceptSessions(sessionIds)
+            val existingWorkspaceFileRefsComplete = chatHistoryDao.getMeta()?.workspaceFileRefsComplete ?: true
             chatHistoryDao.upsertMeta(
                 ChatStateMetaEntity(
                     currentSessionId = safeCurrentSessionId.toStoredCurrentSessionId(),
                     roomMigrationComplete = migrationComplete,
+                    workspaceFileRefsComplete = existingWorkspaceFileRefsComplete,
                 )
             )
 
             sessions.forEach { snapshot ->
+                chatHistoryDao.deleteWorkspaceFileRefsForSession(snapshot.session.id)
                 chatHistoryDao.deleteMessagesForSession(snapshot.session.id)
                 if (snapshot.messages.isNotEmpty()) {
                     chatHistoryDao.upsertMessages(snapshot.messages)
+                    if (snapshot.workspaceFileRefs.isNotEmpty()) {
+                        chatHistoryDao.upsertWorkspaceFileRefs(snapshot.workspaceFileRefs)
+                    }
                 }
             }
         }
     }
+
+    private suspend fun replaceWorkspaceFileRefsForMessagesInTransaction(
+        sessionId: String,
+        messages: List<ChatMessage>,
+    ) {
+        if (messages.isEmpty()) return
+        messages.forEach { message ->
+            chatHistoryDao.deleteWorkspaceFileRefsForMessage(sessionId, message.id)
+        }
+        val refs = messages.toWorkspaceFileRefs(sessionId)
+        if (refs.isNotEmpty()) {
+            chatHistoryDao.upsertWorkspaceFileRefs(refs)
+        }
+    }
+
+    private suspend fun getWorkspaceFilePathsForMessagesChunked(
+        sessionId: String,
+        messageIds: List<String>,
+    ): List<String> = messageIds.chunked(WorkspaceFileRefQueryChunkSize).flatMap { chunk ->
+        chatHistoryDao.getWorkspaceFilePathsForMessages(sessionId = sessionId, messageIds = chunk)
+    }
+
+    private suspend fun getWorkspaceFileRefsForPathsChunked(paths: List<String>): List<ChatWorkspaceFileRefEntity> =
+        paths.chunked(WorkspaceFileRefQueryChunkSize).flatMap { chunk ->
+            chatHistoryDao.getWorkspaceFileRefsForPaths(chunk)
+        }
+
+    private fun Collection<String>.normalizedWorkspaceFilePaths(): List<String> =
+        map(String::trim).filter(String::isNotEmpty).distinct().sorted()
 
     // TODO(Room v2): remove legacy DataStore chat import.
     private suspend fun migrateLegacyChatStateIfNeeded() = migrationMutex.withLock {
@@ -338,6 +434,7 @@ class ChatRepository(
                 ChatStateMetaEntity(
                     currentSessionId = currentSessionId,
                     roomMigrationComplete = true,
+                    workspaceFileRefsComplete = existingMeta?.workspaceFileRefsComplete ?: existingSessions.isEmpty(),
                 )
             )
         }
@@ -535,16 +632,42 @@ private fun ChatSession.toSessionEntity(sortOrder: Long): ChatSessionEntity = Ch
     sortOrder = sortOrder,
 )
 
-private fun ChatSession.toSnapshot(index: Int): ChatSessionSnapshot = ChatSessionSnapshot(
-    session = toSessionEntity(index.toLong()),
-    messages = syncActiveBranches(messages).mapIndexed { messageIndex, message ->
-        ChatMessageEntityMapper.toEntity(
-            sessionId = id,
-            position = messageIndex,
-            message = message,
-        )
-    },
-)
+private fun List<ChatMessage>.toWorkspaceFileRefs(sessionId: String): List<ChatWorkspaceFileRefEntity> =
+    flatMap { message ->
+        message.collectWorkspaceFilePathsForIndex()
+            .map { path ->
+                ChatWorkspaceFileRefEntity(
+                    sessionId = sessionId,
+                    messageId = message.id,
+                    path = path,
+                )
+            }
+    }.distinctBy { ref -> Triple(ref.sessionId, ref.messageId, ref.path) }
+
+private fun ChatMessage.collectWorkspaceFilePathsForIndex(): List<String> =
+    (attachments
+        .map { attachment -> attachment.workspacePath.trim() }
+        .filter(String::isNotEmpty) +
+        branchGroup
+            ?.branches
+            .orEmpty()
+            .flatMap { branch -> branch.flatMap { it.collectWorkspaceFilePathsForIndex() } })
+        .distinct()
+
+private fun ChatSession.toSnapshot(index: Int): ChatSessionSnapshot {
+    val syncedMessages = syncActiveBranches(messages)
+    return ChatSessionSnapshot(
+        session = toSessionEntity(index.toLong()),
+        messages = syncedMessages.mapIndexed { messageIndex, message ->
+            ChatMessageEntityMapper.toEntity(
+                sessionId = id,
+                position = messageIndex,
+                message = message,
+            )
+        },
+        workspaceFileRefs = syncedMessages.toWorkspaceFileRefs(id),
+    )
+}
 
 private fun ChatSessionEntity.toChatSession(messages: List<LoadedChatMessage>): ChatSession {
     val orderedMessages = messages.sortedBy { it.position }.map { it.message }

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -57,6 +57,33 @@ interface ChatHistoryDao {
         length: Int,
     ): String?
 
+    @Query("""
+        SELECT DISTINCT path
+        FROM chat_workspace_file_refs
+        WHERE sessionId = :sessionId
+        ORDER BY path ASC
+    """)
+    suspend fun getWorkspaceFilePathsForSession(sessionId: String): List<String>
+
+    @Query("""
+        SELECT DISTINCT path
+        FROM chat_workspace_file_refs
+        WHERE sessionId = :sessionId AND messageId IN (:messageIds)
+        ORDER BY path ASC
+    """)
+    suspend fun getWorkspaceFilePathsForMessages(
+        sessionId: String,
+        messageIds: List<String>,
+    ): List<String>
+
+    @Query("""
+        SELECT sessionId, messageId, path
+        FROM chat_workspace_file_refs
+        WHERE path IN (:paths)
+        ORDER BY path ASC
+    """)
+    suspend fun getWorkspaceFileRefsForPaths(paths: List<String>): List<ChatWorkspaceFileRefEntity>
+
     @Upsert
     suspend fun upsertMeta(meta: ChatStateMetaEntity)
 
@@ -71,6 +98,24 @@ interface ChatHistoryDao {
 
     @Upsert
     suspend fun upsertMessages(messages: List<ChatMessageEntity>)
+
+    @Upsert
+    suspend fun upsertWorkspaceFileRefs(refs: List<ChatWorkspaceFileRefEntity>)
+
+    @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId = :messageId")
+    suspend fun deleteWorkspaceFileRefsForMessage(sessionId: String, messageId: String)
+
+    @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId IN (SELECT id FROM chat_messages WHERE sessionId = :sessionId AND position >= :fromPosition)")
+    suspend fun deleteWorkspaceFileRefsFromPosition(sessionId: String, fromPosition: Int)
+
+    @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId")
+    suspend fun deleteWorkspaceFileRefsForSession(sessionId: String)
+
+    @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId NOT IN (:sessionIds)")
+    suspend fun deleteWorkspaceFileRefsExceptSessions(sessionIds: List<String>)
+
+    @Query("DELETE FROM chat_workspace_file_refs")
+    suspend fun deleteAllWorkspaceFileRefs()
 
     @Query("DELETE FROM chat_messages WHERE sessionId = :sessionId AND position >= :fromPosition")
     suspend fun deleteMessagesFromPosition(sessionId: String, fromPosition: Int)

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
@@ -4,14 +4,17 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [
         ChatSessionEntity::class,
         ChatMessageEntity::class,
+        ChatWorkspaceFileRefEntity::class,
         ChatStateMetaEntity::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = true,
 )
 abstract class ChatHistoryDatabase : RoomDatabase() {
@@ -26,7 +29,31 @@ abstract class ChatHistoryDatabase : RoomDatabase() {
                 context.applicationContext,
                 ChatHistoryDatabase::class.java,
                 "aether_chat_history.db",
-            ).build().also { instance = it }
+            ).addMigrations(Migration1To2)
+                .build()
+                .also { instance = it }
         }
+    }
+}
+
+internal object Migration1To2 : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chat_workspace_file_refs` (
+                `sessionId` TEXT NOT NULL,
+                `messageId` TEXT NOT NULL,
+                `path` TEXT NOT NULL,
+                PRIMARY KEY(`sessionId`, `messageId`, `path`),
+                FOREIGN KEY(`sessionId`, `messageId`) REFERENCES `chat_messages`(`sessionId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `chat_workspace_file_refs` (`path`)",
+        )
+        db.execSQL(
+            "ALTER TABLE `chat_state_meta` ADD COLUMN `workspaceFileRefsComplete` INTEGER NOT NULL DEFAULT 0",
+        )
     }
 }

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import org.json.JSONObject
 
 @Database(
     entities = [
@@ -52,8 +53,79 @@ internal object Migration1To2 : Migration(1, 2) {
         db.execSQL(
             "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `chat_workspace_file_refs` (`path`)",
         )
+        val workspaceFileRefsBackfilled = backfillWorkspaceFileRefs(db)
         db.execSQL(
             "ALTER TABLE `chat_state_meta` ADD COLUMN `workspaceFileRefsComplete` INTEGER NOT NULL DEFAULT 0",
         )
+        if (workspaceFileRefsBackfilled) {
+            db.execSQL(
+                """
+                INSERT OR IGNORE INTO `chat_state_meta` (
+                    `id`,
+                    `currentSessionId`,
+                    `roomMigrationComplete`,
+                    `workspaceFileRefsComplete`
+                ) VALUES (?, NULL, 0, 1)
+                """.trimIndent(),
+                arrayOf(ChatStateMetaEntityId),
+            )
+            db.execSQL("UPDATE `chat_state_meta` SET `workspaceFileRefsComplete` = 1")
+        }
+    }
+
+    private fun backfillWorkspaceFileRefs(db: SupportSQLiteDatabase): Boolean {
+        var complete = true
+        db.query("SELECT `sessionId`, `id`, `messageJson` FROM `chat_messages`").use { cursor ->
+            while (cursor.moveToNext()) {
+                val sessionId = cursor.getString(0)
+                val messageId = cursor.getString(1)
+                val messageJson = cursor.getString(2)
+                val paths = runCatching { collectWorkspaceFilePaths(JSONObject(messageJson)) }
+                    .getOrElse {
+                        complete = false
+                        emptySet()
+                    }
+                paths.forEach { path ->
+                    db.execSQL(
+                        """
+                        INSERT OR IGNORE INTO `chat_workspace_file_refs` (`sessionId`, `messageId`, `path`)
+                        VALUES (?, ?, ?)
+                        """.trimIndent(),
+                        arrayOf(sessionId, messageId, path),
+                    )
+                }
+            }
+        }
+        return complete
+    }
+
+    private fun collectWorkspaceFilePaths(message: JSONObject): Set<String> = buildSet {
+        collectWorkspaceFilePaths(message, this)
+    }
+
+    private fun collectWorkspaceFilePaths(
+        message: JSONObject,
+        paths: MutableSet<String>,
+    ) {
+        val attachments = message.optJSONArray("attachments")
+        if (attachments != null) {
+            for (index in 0 until attachments.length()) {
+                attachments.optJSONObject(index)
+                    ?.optString("workspacePath")
+                    ?.trim()
+                    ?.takeIf(String::isNotEmpty)
+                    ?.let(paths::add)
+            }
+        }
+
+        val branches = message.optJSONObject("branchGroup")?.optJSONArray("branches") ?: return
+        for (branchIndex in 0 until branches.length()) {
+            val branch = branches.optJSONArray(branchIndex) ?: continue
+            for (messageIndex in 0 until branch.length()) {
+                branch.optJSONObject(messageIndex)?.let { branchMessage ->
+                    collectWorkspaceFilePaths(branchMessage, paths)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -64,6 +64,25 @@ data class ChatMessageSummaryEntity(
 )
 
 @Entity(
+    tableName = "chat_workspace_file_refs",
+    primaryKeys = ["sessionId", "messageId", "path"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatMessageEntity::class,
+            parentColumns = ["sessionId", "id"],
+            childColumns = ["sessionId", "messageId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["path"])],
+)
+data class ChatWorkspaceFileRefEntity(
+    val sessionId: String,
+    val messageId: String,
+    val path: String,
+)
+
+@Entity(
     tableName = "chat_state_meta",
     foreignKeys = [
         ForeignKey(
@@ -80,6 +99,7 @@ data class ChatStateMetaEntity(
     val id: String = ChatStateMetaEntityId,
     val currentSessionId: String?,
     val roomMigrationComplete: Boolean,
+    val workspaceFileRefsComplete: Boolean,
 )
 
 const val ChatStateMetaEntityId = "default"
@@ -87,4 +107,5 @@ const val ChatStateMetaEntityId = "default"
 data class ChatSessionSnapshot(
     val session: ChatSessionEntity,
     val messages: List<ChatMessageEntity>,
+    val workspaceFileRefs: List<ChatWorkspaceFileRefEntity> = emptyList(),
 )

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -1093,10 +1093,8 @@ class AetherViewModel(
         }
 
         var didUpdate = false
-        var sharedWorkspaceFilePaths = emptyList<String>()
         _uiState.update { current ->
             val session = current.sessions.firstOrNull { it.id == sessionId } ?: return@update current
-            sharedWorkspaceFilePaths = session.workspaceFilePathsForCleanup()
             val updatedSessions = current.sessions.filterNot { it.id == sessionId }
             if (updatedSessions.size == current.sessions.size) return@update current
             didUpdate = true
@@ -1113,11 +1111,28 @@ class AetherViewModel(
             )
         }
         if (didUpdate) {
-            persistDeleteSession(
-                sessionId = sessionId,
-                sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
-            )
-            captureAnalyticsEvent(event = "conversation deleted")
+            viewModelScope.launch {
+                val sharedWorkspaceFilePaths = withContext(Dispatchers.IO) {
+                    runCatching {
+                        runtime.chatRepository.getUnreferencedWorkspaceFilePathsForDeletedSession(sessionId)
+                    }.getOrElse { throwable ->
+                        diagnosticLogger.exception(
+                            category = "storage",
+                            event = "unreferenced_workspace_lookup_failed",
+                            throwable = throwable,
+                            level = "warn",
+                            sessionId = sessionId,
+                            details = mapOf("lookup_scope" to "session"),
+                        )
+                        emptyList()
+                    }
+                }
+                persistDeleteSession(
+                    sessionId = sessionId,
+                    sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+                )
+                captureAnalyticsEvent(event = "conversation deleted")
+            }
         }
     }
 
@@ -1296,7 +1311,7 @@ class AetherViewModel(
         var didUpdate = false
         var updatedSessionForPersistence: ChatSession? = null
         var removedSessionForPersistence = false
-        var sharedWorkspaceFilePaths = emptyList<String>()
+        var removedMessageIds = emptyList<String>()
 
         _uiState.update { current ->
             val sessionIndex = current.sessions.indexOfFirst { it.id == sessionId }
@@ -1308,44 +1323,43 @@ class AetherViewModel(
 
             val trimFromIndex = session.messages.resolveConversationTrimIndex(messageIndex)
             val trimmedMessages = session.messages.take(trimFromIndex)
+            val removedMessages = session.messages.drop(trimFromIndex)
+            removedMessageIds = removedMessages.map { it.id }
             val updatedSessions = current.sessions.toMutableList().apply {
                 removeAt(sessionIndex)
                 if (trimmedMessages.isNotEmpty()) {
-                    val removedMessages = session.messages.drop(trimFromIndex)
                     val updatedSession = session.withMessages(trimmedMessages)
                     updatedSessionForPersistence = updatedSession
-                    sharedWorkspaceFilePaths = session.copy(messages = removedMessages).workspaceFilePathsForCleanup()
                     add(sessionIndex.coerceAtMost(size), updatedSession)
                 } else {
                     removedSessionForPersistence = true
-                    sharedWorkspaceFilePaths = session.workspaceFilePathsForCleanup()
                 }
             }
 
             didUpdate = true
-                current.copy(
-                    sessions = updatedSessions,
-                    currentSessionId = when {
-                        trimmedMessages.isEmpty() && current.currentSessionId == sessionId -> DraftSessionId
-                        else -> current.currentSessionId
-                    },
-                    draftSelectedSkillIds = if (
-                        trimmedMessages.isEmpty() && current.currentSessionId == sessionId
-                    ) {
-                        emptyList()
-                    } else {
-                        current.draftSelectedSkillIds
-                    },
-                    draftSelectedMcpServerIds = if (
-                        trimmedMessages.isEmpty() && current.currentSessionId == sessionId
-                    ) {
-                        emptyList()
-                    } else {
-                        current.draftSelectedMcpServerIds
-                    },
-                    draftInput = if (current.editingSessionId == sessionId) "" else current.draftInput,
-                    draftAttachments = if (current.editingSessionId == sessionId) {
-                        emptyList()
+            current.copy(
+                sessions = updatedSessions,
+                currentSessionId = when {
+                    trimmedMessages.isEmpty() && current.currentSessionId == sessionId -> DraftSessionId
+                    else -> current.currentSessionId
+                },
+                draftSelectedSkillIds = if (
+                    trimmedMessages.isEmpty() && current.currentSessionId == sessionId
+                ) {
+                    emptyList()
+                } else {
+                    current.draftSelectedSkillIds
+                },
+                draftSelectedMcpServerIds = if (
+                    trimmedMessages.isEmpty() && current.currentSessionId == sessionId
+                ) {
+                    emptyList()
+                } else {
+                    current.draftSelectedMcpServerIds
+                },
+                draftInput = if (current.editingSessionId == sessionId) "" else current.draftInput,
+                draftAttachments = if (current.editingSessionId == sessionId) {
+                    emptyList()
                 } else {
                     current.draftAttachments
                 },
@@ -1362,17 +1376,43 @@ class AetherViewModel(
         }
 
         if (didUpdate) {
-            if (removedSessionForPersistence) {
-                persistDeleteSession(
-                    sessionId = sessionId,
-                    sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
-                )
-            } else {
-                cleanupSharedWorkspaceFilesIfUnreferenced(
-                    sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
-                    excludedSessionIds = emptySet(),
-                )
-                updatedSessionForPersistence?.let(::persistSessionSnapshot)
+            viewModelScope.launch {
+                val sharedWorkspaceFilePaths = withContext(Dispatchers.IO) {
+                    runCatching {
+                        runtime.chatRepository.getUnreferencedWorkspaceFilePathsForDeletedMessages(
+                            sessionId = sessionId,
+                            messageIds = removedMessageIds,
+                        )
+                    }.getOrElse { throwable ->
+                        diagnosticLogger.exception(
+                            category = "storage",
+                            event = "unreferenced_workspace_lookup_failed",
+                            throwable = throwable,
+                            level = "warn",
+                            sessionId = sessionId,
+                            details = mapOf(
+                                "lookup_scope" to "messages",
+                                "message_count" to removedMessageIds.size,
+                            ),
+                        )
+                        emptyList()
+                    }
+                }
+                if (removedSessionForPersistence) {
+                    persistDeleteSession(
+                        sessionId = sessionId,
+                        sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+                    )
+                } else {
+                    updatedSessionForPersistence?.let { persistSessionSnapshotAndFlush(it) }
+                    if (sharedWorkspaceFilePaths.isNotEmpty()) {
+                        scheduleSessionRuntimeDataCleanup(
+                            sessionIds = emptyList(),
+                            sharedWorkspaceFilePaths = sharedWorkspaceFilePaths,
+                            mode = _uiState.value.settings.agentWorkspaceMode,
+                        )
+                    }
+                }
             }
         }
     }
@@ -2675,6 +2715,31 @@ class AetherViewModel(
         }
     }
 
+    private suspend fun persistSessionSnapshotAndFlush(
+        session: ChatSession,
+        moveToFront: Boolean = false,
+        currentSessionId: String? = null,
+    ) {
+        chatStateStore.updateAndFlush { persisted ->
+            val currentIndex = persisted.sessions.indexOfFirst { it.id == session.id }
+            val updatedSessions = persisted.sessions.toMutableList().apply {
+                if (currentIndex >= 0) {
+                    removeAt(currentIndex)
+                }
+                val insertIndex = when {
+                    moveToFront -> 0
+                    currentIndex >= 0 -> currentIndex.coerceAtMost(size)
+                    else -> 0
+                }
+                add(insertIndex, session)
+            }
+            persisted.copy(
+                sessions = updatedSessions,
+                currentSessionId = currentSessionId ?: persisted.currentSessionId,
+            )
+        }
+    }
+
     private fun persistSessionMutation(
         sessionId: String,
         transform: (ChatSession) -> ChatSession?,
@@ -2690,33 +2755,17 @@ class AetherViewModel(
         }
     }
 
-    private fun ChatSession.workspaceFilePathsForCleanup(): List<String> =
-        messages.collectWorkspaceFilePathsForCleanup().distinct()
-
-    private fun List<ChatMessage>.collectWorkspaceFilePathsForCleanup(): List<String> =
-        flatMap { message -> message.collectWorkspaceFilePathsForCleanup() }
-
-    private fun ChatMessage.collectWorkspaceFilePathsForCleanup(): List<String> =
-        attachments
-            .map { attachment -> attachment.workspacePath.trim() }
-            .filter(String::isNotEmpty) +
-            branchGroup
-                ?.branches
-                .orEmpty()
-                .flatMap { branch -> branch.collectWorkspaceFilePathsForCleanup() }
-
-    private fun persistDeleteSession(
+    private suspend fun persistDeleteSession(
         sessionId: String,
         sharedWorkspaceFilePaths: Collection<String> = emptyList(),
     ) {
-        var unreferencedSharedWorkspaceFilePaths = emptyList<String>()
-        chatStateStore.update(
+        val unreferencedSharedWorkspaceFilePaths = sharedWorkspaceFilePaths
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .distinct()
+        chatStateStore.updateAndFlush(
             writeIntent = PersistedChatWriteIntent.DeleteSession,
         ) { persisted ->
-            unreferencedSharedWorkspaceFilePaths = sharedWorkspaceFilePaths.unreferencedWorkspaceFilePaths(
-                sessions = persisted.sessions,
-                excludedSessionIds = setOf(sessionId),
-            )
             val updatedSessions = persisted.sessions.filterNot { it.id == sessionId }
             persisted.copy(
                 sessions = updatedSessions,
@@ -2732,39 +2781,6 @@ class AetherViewModel(
             sharedWorkspaceFilePaths = unreferencedSharedWorkspaceFilePaths,
             mode = _uiState.value.settings.agentWorkspaceMode,
         )
-    }
-
-    private fun cleanupSharedWorkspaceFilesIfUnreferenced(
-        sharedWorkspaceFilePaths: Collection<String>,
-        excludedSessionIds: Set<String>,
-    ) {
-        val unreferencedSharedWorkspaceFilePaths = sharedWorkspaceFilePaths.unreferencedWorkspaceFilePaths(
-            sessions = _uiState.value.sessions,
-            excludedSessionIds = excludedSessionIds,
-        )
-        if (unreferencedSharedWorkspaceFilePaths.isEmpty()) return
-        scheduleSessionRuntimeDataCleanup(
-            sessionIds = emptyList(),
-            sharedWorkspaceFilePaths = unreferencedSharedWorkspaceFilePaths,
-            mode = _uiState.value.settings.agentWorkspaceMode,
-        )
-    }
-
-    private fun Collection<String>.unreferencedWorkspaceFilePaths(
-        sessions: Collection<ChatSession>,
-        excludedSessionIds: Set<String>,
-    ): List<String> {
-        val candidatePaths = map(String::trim)
-            .filter(String::isNotEmpty)
-            .distinct()
-        if (candidatePaths.isEmpty()) return emptyList()
-
-        val referencedPaths = sessions
-            .asSequence()
-            .filterNot { session -> session.id in excludedSessionIds }
-            .flatMap { session -> session.workspaceFilePathsForCleanup().asSequence() }
-            .toSet()
-        return candidatePaths.filterNot(referencedPaths::contains)
     }
 
     private fun scheduleSessionRuntimeDataCleanup(

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -1112,6 +1112,7 @@ class AetherViewModel(
         }
         if (didUpdate) {
             viewModelScope.launch {
+                chatStateStore.flush()
                 val sharedWorkspaceFilePaths = withContext(Dispatchers.IO) {
                     runCatching {
                         runtime.chatRepository.getUnreferencedWorkspaceFilePathsForDeletedSession(sessionId)
@@ -1377,6 +1378,7 @@ class AetherViewModel(
 
         if (didUpdate) {
             viewModelScope.launch {
+                chatStateStore.flush()
                 val sharedWorkspaceFilePaths = withContext(Dispatchers.IO) {
                     runCatching {
                         runtime.chatRepository.getUnreferencedWorkspaceFilePathsForDeletedMessages(


### PR DESCRIPTION
- Track workspace file references in Room for chat messages
- Use indexed refs when cleaning deleted session and message files
- Add a Room v2 migration and exported schema for the ref table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat history now tracks workspace file references per session and message, and restores these links when loading conversations.
  * Added detection of workspace files that become unreferenced after deleting a session or specific messages.
* **Bug Fixes**
  * Deleting sessions or messages more accurately removes only workspace files no longer referenced elsewhere.
  * When replacing or trimming messages, workspace file links are updated to stay synchronized and avoid stale references.
  * Improves upgrade/migration completion so workspace file reference tracking remains consistent across versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->