### PR TITLE
[codex] Add model capability compatibility table

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/AppSettings.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AppSettings.kt
@@ -268,6 +268,7 @@ fun AppSettings.parallelToolCallSupportKey(): String {
 
 fun AppSettings.supportsParallelToolCalls(): Boolean =
     !basicFunctionCallingCompatibilityMode &&
+        modelCapabilities().supportsParallelToolCalls &&
         parallelToolCallSupportKey() !in unsupportedParallelToolCallProviderKeys
 
 fun isProviderSetupValid(

--- a/app/src/main/java/com/zhousl/aether/data/ModelCapabilities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ModelCapabilities.kt
@@ -1,0 +1,104 @@
+package com.zhousl.aether.data
+
+import java.net.URI
+import java.util.Locale
+
+internal enum class LlmCompatibilityFamily {
+    Generic,
+    DeepSeek,
+    MiniMax,
+    MiMo,
+    Moonshot,
+    OpenRouter,
+}
+
+internal enum class ReasoningDisableStyle {
+    None,
+    DeepSeekThinkingDisabled,
+    MiniMaxThinkingDisabled,
+    OpenRouterReasoningEffortNone,
+}
+
+internal data class ModelCapabilities(
+    val family: LlmCompatibilityFamily = LlmCompatibilityFamily.Generic,
+    val supportsRequiredToolChoice: Boolean = true,
+    val supportsInlineImageWithTools: Boolean = true,
+    val supportsParallelToolCalls: Boolean = true,
+    val supportsReasoningSplit: Boolean = false,
+    val reasoningDisableStyle: ReasoningDisableStyle = ReasoningDisableStyle.None,
+    val mustPreserveReasoningContentForToolCalls: Boolean = false,
+)
+
+internal object ModelCapabilitiesResolver {
+    fun resolve(settings: AppSettings): ModelCapabilities {
+        if (
+            settings.provider != LlmProvider.OpenAiCompatible &&
+            settings.provider != LlmProvider.OpenAiResponses
+        ) {
+            return ModelCapabilities()
+        }
+
+        val host = settings.normalizedBaseUrlHost()
+        val model = settings.modelId.normalizedCapabilityText()
+
+        return when {
+            isOpenRouter(host, model) -> ModelCapabilities(
+                family = LlmCompatibilityFamily.OpenRouter,
+                reasoningDisableStyle = ReasoningDisableStyle.OpenRouterReasoningEffortNone,
+            )
+
+            isDeepSeek(host, model) -> ModelCapabilities(
+                family = LlmCompatibilityFamily.DeepSeek,
+                reasoningDisableStyle = ReasoningDisableStyle.DeepSeekThinkingDisabled,
+                mustPreserveReasoningContentForToolCalls = true,
+            )
+
+            isMiniMax(host, model) -> ModelCapabilities(
+                family = LlmCompatibilityFamily.MiniMax,
+                reasoningDisableStyle = ReasoningDisableStyle.MiniMaxThinkingDisabled,
+                supportsReasoningSplit = true,
+                mustPreserveReasoningContentForToolCalls = true,
+            )
+
+            isMiMo(host, model) -> ModelCapabilities(
+                family = LlmCompatibilityFamily.MiMo,
+                mustPreserveReasoningContentForToolCalls = true,
+            )
+
+            isMoonshot(host, model) -> ModelCapabilities(
+                family = LlmCompatibilityFamily.Moonshot,
+                supportsRequiredToolChoice = false,
+                supportsInlineImageWithTools = false,
+            )
+
+            else -> ModelCapabilities()
+        }
+    }
+
+    private fun isOpenRouter(host: String, model: String): Boolean =
+        "openrouter" in host || model.startsWith("openrouter/") || model.startsWith("openrouter:")
+
+    private fun isDeepSeek(host: String, model: String): Boolean =
+        "deepseek" in host || "deepseek" in model
+
+    private fun isMiniMax(host: String, model: String): Boolean =
+        "minimax" in host || model.startsWith("minimax-") || model.startsWith("minimax/") ||
+            model.startsWith("abab")
+
+    private fun isMiMo(host: String, model: String): Boolean =
+        "xiaomimimo" in host || "mimo.mi.com" in host || "mimo" in host ||
+            model.startsWith("mimo-") || "/mimo-" in model
+
+    private fun isMoonshot(host: String, model: String): Boolean =
+        "moonshot.cn" in host || model.startsWith("kimi-") || "moonshot" in model
+}
+
+internal fun AppSettings.modelCapabilities(): ModelCapabilities =
+    ModelCapabilitiesResolver.resolve(this)
+
+private fun AppSettings.normalizedBaseUrlHost(): String = runCatching {
+    URI(baseUrl.trim()).host.orEmpty().lowercase(Locale.US)
+}.getOrDefault("")
+
+private fun String.normalizedCapabilityText(): String =
+    trim().lowercase(Locale.US)

--- a/app/src/main/java/com/zhousl/aether/data/OpenAiCompatibleClient.kt
+++ b/app/src/main/java/com/zhousl/aether/data/OpenAiCompatibleClient.kt
@@ -780,15 +780,17 @@ class OpenAiCompatibleClient(
         onReasoningSummaryDelta: suspend (String) -> Unit,
         onStreamActivity: suspend () -> Unit,
     ): ChatCompletionResult {
+        val capabilities = settings.modelCapabilities()
         val accumulator = OpenAiStreamAccumulator(
             onTextDelta = onTextDelta,
             onReasoningDelta = onReasoningDelta,
             onReasoningSummaryDelta = onReasoningSummaryDelta,
-            includeEmptyReasoningContentForToolCalls = shouldIncludeEmptyReasoningContentForToolCalls(settings),
+            includeEmptyReasoningContentForToolCalls = shouldIncludeEmptyReasoningContentForToolCalls(capabilities),
         )
         return executeStreamingRequest(
             request = buildOpenAiRequest(
                 settings = settings,
+                capabilities = capabilities,
                 systemPrompt = systemPrompt,
                 conversation = conversation,
                 tools = tools,
@@ -915,6 +917,7 @@ class OpenAiCompatibleClient(
         if (settings.provider.requiresApiKey(settings.baseUrl) && trimmedApiKey.isBlank()) {
             error("API Key is required for ${settings.provider.displayName}.")
         }
+        val capabilities = settings.modelCapabilities()
         val payload = JSONObject().apply {
             put("model", settings.modelId.trim())
             put("store", false)
@@ -943,7 +946,7 @@ class OpenAiCompatibleClient(
                         }
                     }
                 )
-                put("tool_choice", normalizedOpenAiToolChoice(settings, toolChoice))
+                put("tool_choice", normalizedOpenAiToolChoice(settings, capabilities, toolChoice))
                 if (!settings.basicFunctionCallingCompatibilityMode) {
                     parallelToolCalls?.let { put("parallel_tool_calls", it) }
                 }
@@ -951,7 +954,7 @@ class OpenAiCompatibleClient(
             if (stream) {
                 put("stream", true)
             }
-            putReasoningDisabledIfNeeded(settings, disableReasoning)
+            putReasoningDisabledIfNeeded(capabilities, disableReasoning)
         }
 
         return Request.Builder()
@@ -1008,6 +1011,7 @@ class OpenAiCompatibleClient(
 
     private fun buildOpenAiRequest(
         settings: AppSettings,
+        capabilities: ModelCapabilities = settings.modelCapabilities(),
         systemPrompt: String,
         conversation: List<JSONObject>,
         tools: List<JSONObject>,
@@ -1052,7 +1056,7 @@ class OpenAiCompatibleClient(
                         }
                     }
                 )
-                put("tool_choice", normalizedOpenAiToolChoice(settings, toolChoice))
+                put("tool_choice", normalizedOpenAiToolChoice(settings, capabilities, toolChoice))
                 if (!settings.basicFunctionCallingCompatibilityMode) {
                     parallelToolCalls?.let { put("parallel_tool_calls", it) }
                 }
@@ -1066,8 +1070,8 @@ class OpenAiCompatibleClient(
                     },
                 )
             }
-            putReasoningSplitIfNeeded(settings)
-            putReasoningDisabledIfNeeded(settings, disableReasoning)
+            putReasoningSplitIfNeeded(capabilities)
+            putReasoningDisabledIfNeeded(capabilities, disableReasoning)
         }
 
         return Request.Builder()
@@ -1622,15 +1626,15 @@ class OpenAiCompatibleClient(
         return if (preview.isBlank()) "" else " Response preview: $preview"
     }
 
-    private fun shouldIncludeEmptyReasoningContentForToolCalls(settings: AppSettings): Boolean =
-        settings.modelCapabilities().mustPreserveReasoningContentForToolCalls
+    private fun shouldIncludeEmptyReasoningContentForToolCalls(capabilities: ModelCapabilities): Boolean =
+        capabilities.mustPreserveReasoningContentForToolCalls
 
     private fun JSONObject.putReasoningDisabledIfNeeded(
-        settings: AppSettings,
+        capabilities: ModelCapabilities,
         disableReasoning: Boolean,
     ) {
         if (!disableReasoning) return
-        when (settings.modelCapabilities().reasoningDisableStyle) {
+        when (capabilities.reasoningDisableStyle) {
             ReasoningDisableStyle.OpenRouterReasoningEffortNone -> {
                 put(
                     "reasoning",
@@ -1654,19 +1658,20 @@ class OpenAiCompatibleClient(
         }
     }
 
-    private fun JSONObject.putReasoningSplitIfNeeded(settings: AppSettings) {
-        if (settings.modelCapabilities().supportsReasoningSplit) {
+    private fun JSONObject.putReasoningSplitIfNeeded(capabilities: ModelCapabilities) {
+        if (capabilities.supportsReasoningSplit) {
             put("reasoning_split", true)
         }
     }
 
     private fun normalizedOpenAiToolChoice(
         settings: AppSettings,
+        capabilities: ModelCapabilities,
         toolChoice: String?,
     ): String {
         if (settings.basicFunctionCallingCompatibilityMode) return "auto"
         val requested = toolChoice ?: "auto"
-        return if (requested == "required" && !settings.modelCapabilities().supportsRequiredToolChoice) {
+        return if (requested == "required" && !capabilities.supportsRequiredToolChoice) {
             "auto"
         } else {
             requested

--- a/app/src/main/java/com/zhousl/aether/data/OpenAiCompatibleClient.kt
+++ b/app/src/main/java/com/zhousl/aether/data/OpenAiCompatibleClient.kt
@@ -25,7 +25,6 @@ import okio.BufferedSource
 import org.json.JSONArray
 import org.json.JSONObject
 import org.json.JSONTokener
-import java.net.URI
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.math.roundToLong
@@ -944,7 +943,7 @@ class OpenAiCompatibleClient(
                         }
                     }
                 )
-                put("tool_choice", if (settings.basicFunctionCallingCompatibilityMode) "auto" else toolChoice ?: "auto")
+                put("tool_choice", normalizedOpenAiToolChoice(settings, toolChoice))
                 if (!settings.basicFunctionCallingCompatibilityMode) {
                     parallelToolCalls?.let { put("parallel_tool_calls", it) }
                 }
@@ -1053,7 +1052,7 @@ class OpenAiCompatibleClient(
                         }
                     }
                 )
-                put("tool_choice", if (settings.basicFunctionCallingCompatibilityMode) "auto" else toolChoice ?: "auto")
+                put("tool_choice", normalizedOpenAiToolChoice(settings, toolChoice))
                 if (!settings.basicFunctionCallingCompatibilityMode) {
                     parallelToolCalls?.let { put("parallel_tool_calls", it) }
                 }
@@ -1067,6 +1066,7 @@ class OpenAiCompatibleClient(
                     },
                 )
             }
+            putReasoningSplitIfNeeded(settings)
             putReasoningDisabledIfNeeded(settings, disableReasoning)
         }
 
@@ -1622,28 +1622,16 @@ class OpenAiCompatibleClient(
         return if (preview.isBlank()) "" else " Response preview: $preview"
     }
 
-    private fun shouldIncludeEmptyReasoningContentForToolCalls(settings: AppSettings): Boolean {
-        if (settings.provider != LlmProvider.OpenAiCompatible) return false
-        val host = runCatching {
-            URI(settings.baseUrl.trim()).host.orEmpty().lowercase()
-        }.getOrDefault("")
-        val model = settings.modelId.lowercase()
-        return "deepseek" in host || "deepseek" in model
-    }
+    private fun shouldIncludeEmptyReasoningContentForToolCalls(settings: AppSettings): Boolean =
+        settings.modelCapabilities().mustPreserveReasoningContentForToolCalls
 
     private fun JSONObject.putReasoningDisabledIfNeeded(
         settings: AppSettings,
         disableReasoning: Boolean,
     ) {
         if (!disableReasoning) return
-        if (settings.provider != LlmProvider.OpenAiCompatible && settings.provider != LlmProvider.OpenAiResponses) return
-
-        val host = runCatching {
-            URI(settings.baseUrl.trim()).host.orEmpty().lowercase()
-        }.getOrDefault("")
-        val model = settings.modelId.lowercase()
-        when {
-            "openrouter" in host || "openrouter" in model -> {
+        when (settings.modelCapabilities().reasoningDisableStyle) {
+            ReasoningDisableStyle.OpenRouterReasoningEffortNone -> {
                 put(
                     "reasoning",
                     JSONObject().apply {
@@ -1652,7 +1640,8 @@ class OpenAiCompatibleClient(
                 )
             }
 
-            "deepseek" in host || "deepseek" in model -> {
+            ReasoningDisableStyle.DeepSeekThinkingDisabled,
+            ReasoningDisableStyle.MiniMaxThinkingDisabled -> {
                 put(
                     "thinking",
                     JSONObject().apply {
@@ -1660,6 +1649,27 @@ class OpenAiCompatibleClient(
                     },
                 )
             }
+
+            ReasoningDisableStyle.None -> Unit
+        }
+    }
+
+    private fun JSONObject.putReasoningSplitIfNeeded(settings: AppSettings) {
+        if (settings.modelCapabilities().supportsReasoningSplit) {
+            put("reasoning_split", true)
+        }
+    }
+
+    private fun normalizedOpenAiToolChoice(
+        settings: AppSettings,
+        toolChoice: String?,
+    ): String {
+        if (settings.basicFunctionCallingCompatibilityMode) return "auto"
+        val requested = toolChoice ?: "auto"
+        return if (requested == "required" && !settings.modelCapabilities().supportsRequiredToolChoice) {
+            "auto"
+        } else {
+            requested
         }
     }
 

--- a/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
@@ -547,7 +547,10 @@ class SessionExecutionManager(
 
             val result = agent.runTurn(
                 settings = request.settings,
-                messages = buildRequestMessages(request.requestMessages),
+                messages = buildRequestMessages(
+                    messages = request.requestMessages,
+                    settings = request.settings,
+                ),
                 workspaceDirectory = runtimeWorkspaceDirectory,
                 availableSkills = resolvedAvailableSkills,
                 activeSkills = resolvedActiveSkills,
@@ -633,7 +636,7 @@ class SessionExecutionManager(
                     if (drained.isNotEmpty()) {
                         appendSteerInterruptionMessages(handle, drained)
                     }
-                    drained.map { buildSteerRequestMessage(it.message) }
+                    drained.map { buildSteerRequestMessage(it.message, request.settings) }
                 },
             )
             if (handle.pauseRequested) {
@@ -1343,10 +1346,13 @@ class SessionExecutionManager(
     private fun resolveSessionTitle(sessionId: String): String =
         chatStateStore.state.value.sessions.firstOrNull { it.id == sessionId }?.title.orEmpty()
 
-    private fun buildRequestMessages(messages: List<ChatMessage>): List<LlmMessage> =
+    private fun buildRequestMessages(
+        messages: List<ChatMessage>,
+        settings: AppSettings,
+    ): List<LlmMessage> =
         messages.afterLatestCompactedContext()
             .filter { it.displayKind != MessageDisplayKind.CompactStatus }
-            .map(::buildRequestMessage)
+            .map { message -> buildRequestMessage(message, settings) }
 
     private fun List<ChatMessage>.afterLatestCompactedContext(): List<ChatMessage> {
         val compactContextIndex = indexOfLast { it.displayKind == MessageDisplayKind.HiddenContext }
@@ -1357,13 +1363,16 @@ class SessionExecutionManager(
         }
     }
 
-    private fun buildRequestMessage(message: ChatMessage): LlmMessage {
+    private fun buildRequestMessage(
+        message: ChatMessage,
+        settings: AppSettings,
+    ): LlmMessage {
         val parts = mutableListOf<LlmContentPart>()
         if (message.text.isNotBlank()) {
             parts += LlmTextPart(message.text)
         }
         message.attachments.forEach { attachment ->
-            parts += buildWorkspaceAttachmentParts(attachment)
+            parts += buildWorkspaceAttachmentParts(attachment, settings)
         }
         if (parts.isEmpty()) {
             parts += LlmTextPart("[Empty message]")
@@ -1375,7 +1384,10 @@ class SessionExecutionManager(
         )
     }
 
-    private fun buildSteerRequestMessage(message: ChatMessage): LlmMessage {
+    private fun buildSteerRequestMessage(
+        message: ChatMessage,
+        settings: AppSettings,
+    ): LlmMessage {
         val steerText = buildString {
             append(
                 "The user sent this while you were already working. Treat it as supplemental context for the current task. " +
@@ -1388,11 +1400,12 @@ class SessionExecutionManager(
                 append("\n\nThe user also attached additional files for the current task.")
             }
         }
-        return buildRequestMessage(message.copy(text = steerText))
+        return buildRequestMessage(message.copy(text = steerText), settings)
     }
 
     private fun buildWorkspaceAttachmentParts(
         attachment: ChatAttachment,
+        settings: AppSettings,
     ): List<LlmContentPart> {
         if (attachment.workspacePath.isBlank()) {
             return listOf(LlmTextPart(
@@ -1400,8 +1413,13 @@ class SessionExecutionManager(
             ))
         }
 
+        val shouldInlineImage = shouldInlineWorkspaceImageAttachment(attachment, settings)
         val accessHint = if (attachment.kind == AttachmentKind.Image) {
-            "This image was copied into the workspace and is also inserted into this model request when local bytes are available. Use analyze_image on this path for a focused second pass if needed."
+            if (shouldInlineImage) {
+                "This image was copied into the workspace and is also inserted into this model request when local bytes are available. Use analyze_image on this path for a focused second pass if needed."
+            } else {
+                "This image was copied into the workspace. Call analyze_image on this exact path before answering questions about the image; this model endpoint does not reliably read images in tool-enabled agent requests."
+            }
         } else {
             "Inspect this file through read, grep, find, ls, or bash inside the workspace instead of assuming its contents."
         }
@@ -1418,7 +1436,7 @@ class SessionExecutionManager(
             }
         )
         val imagePart = attachment.takeIf {
-            it.kind == AttachmentKind.Image &&
+            shouldInlineImage &&
                 it.mimeType.startsWith("image/") &&
                 it.inlineBase64.isNotBlank()
         }?.let {
@@ -2546,3 +2564,10 @@ class SessionExecutionManager(
         }
     }
 }
+
+internal fun shouldInlineWorkspaceImageAttachment(
+    attachment: ChatAttachment,
+    settings: AppSettings,
+): Boolean =
+    attachment.kind == AttachmentKind.Image &&
+        settings.modelCapabilities().supportsInlineImageWithTools

--- a/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
@@ -1413,9 +1413,9 @@ class SessionExecutionManager(
             ))
         }
 
-        val shouldInlineImage = shouldInlineWorkspaceImageAttachment(attachment, settings)
-        val accessHint = if (attachment.kind == AttachmentKind.Image) {
-            if (shouldInlineImage) {
+        val canInlineImage = canInlineWorkspaceImageAttachment(attachment, settings)
+        val accessHint = if (isWorkspaceImageAttachment(attachment)) {
+            if (canInlineImage) {
                 "This image was copied into the workspace and is also inserted into this model request when local bytes are available. Use analyze_image on this path for a focused second pass if needed."
             } else {
                 "This image was copied into the workspace. Call analyze_image on this exact path before answering questions about the image; this model endpoint does not reliably read images in tool-enabled agent requests."
@@ -1436,9 +1436,7 @@ class SessionExecutionManager(
             }
         )
         val imagePart = attachment.takeIf {
-            shouldInlineImage &&
-                it.mimeType.startsWith("image/") &&
-                it.inlineBase64.isNotBlank()
+            canInlineImage
         }?.let {
             LlmImagePart(
                 mimeType = it.mimeType,
@@ -2569,5 +2567,16 @@ internal fun shouldInlineWorkspaceImageAttachment(
     attachment: ChatAttachment,
     settings: AppSettings,
 ): Boolean =
-    attachment.kind == AttachmentKind.Image &&
+    isWorkspaceImageAttachment(attachment) &&
         settings.modelCapabilities().supportsInlineImageWithTools
+
+private fun canInlineWorkspaceImageAttachment(
+    attachment: ChatAttachment,
+    settings: AppSettings,
+): Boolean =
+    shouldInlineWorkspaceImageAttachment(attachment, settings) &&
+        attachment.inlineBase64.isNotBlank()
+
+private fun isWorkspaceImageAttachment(attachment: ChatAttachment): Boolean =
+    attachment.kind == AttachmentKind.Image &&
+        attachment.mimeType.startsWith("image/")

--- a/app/src/test/java/com/zhousl/aether/data/OpenAiCompatibleClientProviderFormatsTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/OpenAiCompatibleClientProviderFormatsTest.kt
@@ -539,7 +539,7 @@ class OpenAiCompatibleClientProviderFormatsTest {
                 provider = LlmProvider.OpenAiCompatible,
                 apiKey = "test-key",
                 baseUrl = "http://api.moonshot.cn:${server.port}/v1",
-                modelId = "moonshot-v1-auto",
+                modelId = "custom-model-v1",
             )
 
             client.createChatCompletion(

--- a/app/src/test/java/com/zhousl/aether/data/OpenAiCompatibleClientProviderFormatsTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/OpenAiCompatibleClientProviderFormatsTest.kt
@@ -1,6 +1,10 @@
 package com.zhousl.aether.data
 
 import kotlinx.coroutines.runBlocking
+import com.zhousl.aether.ui.AttachmentKind
+import com.zhousl.aether.ui.ChatAttachment
+import java.net.InetAddress
+import okhttp3.Dns
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.json.JSONObject
@@ -371,6 +375,285 @@ class OpenAiCompatibleClientProviderFormatsTest {
         } finally {
             server.shutdown()
         }
+    }
+
+    @Test
+    fun minimaxRequestsEnableReasoningSplitAndCanDisableThinking() = runBlocking {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "choices": [
+                        {
+                          "message": {
+                            "role": "assistant",
+                            "content": "Title"
+                          }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+        server.start()
+
+        try {
+            val settings = AppSettings(
+                provider = LlmProvider.OpenAiCompatible,
+                apiKey = "test-key",
+                baseUrl = server.url("/v1").toString(),
+                modelId = "MiniMax-M3",
+            )
+
+            client.createChatCompletion(
+                settings = settings,
+                systemPrompt = "",
+                conversation = listOf(
+                    JSONObject().apply {
+                        put("role", "user")
+                        put("content", "Summarize")
+                    }
+                ),
+                disableReasoning = true,
+            ).getOrThrow()
+
+            val payload = JSONObject(server.takeRequest().body.readUtf8())
+            assertEquals(true, payload.getBoolean("reasoning_split"))
+            assertEquals("disabled", payload.getJSONObject("thinking").getString("type"))
+            assertFalse(payload.has("reasoning"))
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun moonshotKimiDowngradesRequiredToolChoiceToAuto() = runBlocking {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "choices": [
+                        {
+                          "message": {
+                            "role": "assistant",
+                            "content": "Done."
+                          }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+        server.start()
+
+        try {
+            val settings = AppSettings(
+                provider = LlmProvider.OpenAiCompatible,
+                apiKey = "test-key",
+                baseUrl = server.url("/v1").toString(),
+                modelId = "kimi-k2.6",
+            )
+
+            client.createChatCompletion(
+                settings = settings,
+                systemPrompt = "",
+                conversation = client.buildConversation(
+                    settings = settings,
+                    messages = listOf(
+                        LlmMessage(
+                            role = "user",
+                            contentParts = listOf(
+                                LlmTextPart("Inspect this image."),
+                                LlmImagePart(
+                                    mimeType = "image/jpeg",
+                                    base64Data = "abcd",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                tools = listOf(readTool()),
+                toolChoice = "required",
+            ).getOrThrow()
+
+            val payload = JSONObject(server.takeRequest().body.readUtf8())
+            assertEquals("auto", payload.getString("tool_choice"))
+            val content = payload.getJSONArray("messages")
+                .getJSONObject(0)
+                .getJSONArray("content")
+            assertEquals("image_url", content.getJSONObject(1).getString("type"))
+            assertEquals(
+                "data:image/jpeg;base64,abcd",
+                content.getJSONObject(1)
+                    .getJSONObject("image_url")
+                    .getString("url"),
+            )
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun moonshotHostDowngradesRequiredToolChoiceToAuto() = runBlocking {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "choices": [
+                        {
+                          "message": {
+                            "role": "assistant",
+                            "content": "Done."
+                          }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+        server.start()
+
+        try {
+            val client = OpenAiCompatibleClient(
+                httpClient = okhttp3.OkHttpClient.Builder()
+                    .dns(
+                        object : Dns {
+                            override fun lookup(hostname: String): List<InetAddress> = when (hostname) {
+                                "api.moonshot.cn" -> listOf(InetAddress.getByName("127.0.0.1"))
+                                else -> Dns.SYSTEM.lookup(hostname)
+                            }
+                        }
+                    )
+                    .build(),
+            )
+            val settings = AppSettings(
+                provider = LlmProvider.OpenAiCompatible,
+                apiKey = "test-key",
+                baseUrl = "http://api.moonshot.cn:${server.port}/v1",
+                modelId = "moonshot-v1-auto",
+            )
+
+            client.createChatCompletion(
+                settings = settings,
+                systemPrompt = "",
+                conversation = listOf(
+                    JSONObject().apply {
+                        put("role", "user")
+                        put("content", "Read README.md")
+                    }
+                ),
+                tools = listOf(readTool()),
+                toolChoice = "required",
+            ).getOrThrow()
+
+            val payload = JSONObject(server.takeRequest().body.readUtf8())
+            assertEquals("auto", payload.getString("tool_choice"))
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun moonshotKimiImageAttachmentsAreNotInlinedInAgentRequests() {
+        val attachment = ChatAttachment(
+            id = "att-1",
+            uri = "content://aether/photo.jpg",
+            name = "photo.jpg",
+            mimeType = "image/jpeg",
+            sizeBytes = 16,
+            workspacePath = "uploads/photo.jpg",
+            kind = AttachmentKind.Image,
+            inlineBase64 = "abcd",
+        )
+
+        assertFalse(
+            shouldInlineWorkspaceImageAttachment(
+                attachment = attachment,
+                settings = AppSettings(
+                    provider = LlmProvider.OpenAiCompatible,
+                    baseUrl = "https://api.moonshot.cn/v1",
+                    modelId = "kimi-k2.6",
+                ),
+            )
+        )
+        assertTrue(
+            shouldInlineWorkspaceImageAttachment(
+                attachment = attachment,
+                settings = AppSettings(
+                    provider = LlmProvider.OpenAiCompatible,
+                    baseUrl = "https://api.openai.com/v1",
+                    modelId = "gpt-5.4",
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun modelCapabilitiesResolveProviderSpecificFormats() {
+        val deepSeek = AppSettings(
+            provider = LlmProvider.OpenAiCompatible,
+            baseUrl = "https://api.deepseek.com/v1",
+            modelId = "deepseek-chat",
+        ).modelCapabilities()
+        assertEquals(LlmCompatibilityFamily.DeepSeek, deepSeek.family)
+        assertEquals(ReasoningDisableStyle.DeepSeekThinkingDisabled, deepSeek.reasoningDisableStyle)
+        assertTrue(deepSeek.mustPreserveReasoningContentForToolCalls)
+        assertTrue(deepSeek.supportsRequiredToolChoice)
+
+        val miniMax = AppSettings(
+            provider = LlmProvider.OpenAiCompatible,
+            baseUrl = "https://api.minimax.io/v1",
+            modelId = "MiniMax-M3",
+        ).modelCapabilities()
+        assertEquals(LlmCompatibilityFamily.MiniMax, miniMax.family)
+        assertEquals(ReasoningDisableStyle.MiniMaxThinkingDisabled, miniMax.reasoningDisableStyle)
+        assertTrue(miniMax.supportsReasoningSplit)
+        assertTrue(miniMax.mustPreserveReasoningContentForToolCalls)
+
+        val miMo = AppSettings(
+            provider = LlmProvider.OpenAiCompatible,
+            baseUrl = "https://api.openai-compatible.test/v1",
+            modelId = "mimo-v2.5-pro",
+        ).modelCapabilities()
+        assertEquals(LlmCompatibilityFamily.MiMo, miMo.family)
+        assertEquals(ReasoningDisableStyle.None, miMo.reasoningDisableStyle)
+        assertTrue(miMo.mustPreserveReasoningContentForToolCalls)
+
+        val moonshot = AppSettings(
+            provider = LlmProvider.OpenAiCompatible,
+            baseUrl = "https://api.moonshot.cn/v1",
+            modelId = "kimi-k2.6",
+        ).modelCapabilities()
+        assertEquals(LlmCompatibilityFamily.Moonshot, moonshot.family)
+        assertFalse(moonshot.supportsRequiredToolChoice)
+        assertFalse(moonshot.supportsInlineImageWithTools)
+
+        val openRouter = AppSettings(
+            provider = LlmProvider.OpenAiCompatible,
+            baseUrl = "https://openrouter.ai/api/v1",
+            modelId = "openai/gpt-oss-120b",
+        ).modelCapabilities()
+        assertEquals(LlmCompatibilityFamily.OpenRouter, openRouter.family)
+        assertEquals(ReasoningDisableStyle.OpenRouterReasoningEffortNone, openRouter.reasoningDisableStyle)
+
+        val generic = AppSettings(
+            provider = LlmProvider.OpenAiCompatible,
+            baseUrl = "https://api.example.com/v1",
+            modelId = "generic-model",
+        ).modelCapabilities()
+        assertEquals(LlmCompatibilityFamily.Generic, generic.family)
+        assertTrue(generic.supportsRequiredToolChoice)
+        assertTrue(generic.supportsInlineImageWithTools)
+        assertTrue(generic.supportsParallelToolCalls)
     }
 
     @Test


### PR DESCRIPTION
﻿## Summary
- Add a typed model capability resolver for OpenAI-compatible provider quirks.
- Route tool_choice, reasoning-disable parameters, reasoning_content preservation, parallel tool-call support, and image inline behavior through the capability table.
- Add Moonshot/Kimi safeguards for required tool choice and Agent image attachments, plus MiniMax reasoning_split compatibility.

## Why
Provider-specific behavior was spread across request construction and Agent attachment handling. Kimi/Moonshot thinking mode rejects required tool choice, and tool-enabled image requests are more reliable when workspace images are handed to analyze_image instead of being inlined.

## Validation
- `ANDROID_HOME=C:\Users\BaimoQilin\AppData\Local\Android\Sdk .\gradlew.bat :app:testDebugUnitTest --tests com.zhousl.aether.data.OpenAiCompatibleClientProviderFormatsTest --tests com.zhousl.aether.data.OpenAiCompatibleClientStreamingTest`
- `ANDROID_HOME=C:\Users\BaimoQilin\AppData\Local\Android\Sdk .\gradlew.bat :app:assembleDebug`
- Installed `app\build\outputs\apk\debug\app-debug.apk` to the connected ADB device with `adb install -r`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader model compatibility handling with provider-specific capability resolution (tool choice, inline image support, parallel tool calls, and reasoning controls).
  * Enhanced request payload formatting across chat modes, including reasoning split behavior and capability-aligned tool-choice normalization.
* **Bug Fixes**
  * Prevents parallel tool calls unless the selected model explicitly supports them.
  * Tightens workspace image attachment handling so images are only inlined when inline-capable and data is present.
  * Ensures OpenAI-compatible requests correctly downgrade `tool_choice` from `required` to `auto` when unsupported.
* **Tests**
  * Added provider-format and capability-resolution coverage for multiple model families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->