### PR TITLE
fix(history): load full session messages on demand

### DIFF
--- a/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/3.json
+++ b/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/3.json
@@ -1,0 +1,332 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "e466aa4e7ee1de5676bbe07f26bb461d",
+    "entities": [
+      {
+        "tableName": "chat_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `preview` TEXT NOT NULL, `hasCustomTitle` INTEGER NOT NULL, `selectedSkillIdsJson` TEXT NOT NULL, `activeSkillsJson` TEXT NOT NULL, `activeMcpServerIdsJson` TEXT NOT NULL, `agentModeEnabled` INTEGER NOT NULL, `selectedModelKey` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomTitle",
+            "columnName": "hasCustomTitle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSkillIdsJson",
+            "columnName": "selectedSkillIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeSkillsJson",
+            "columnName": "activeSkillsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeMcpServerIdsJson",
+            "columnName": "activeMcpServerIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentModeEnabled",
+            "columnName": "agentModeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedModelKey",
+            "columnName": "selectedModelKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `id` TEXT NOT NULL, `position` INTEGER NOT NULL, `messageJson` TEXT NOT NULL, `author` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAtMillis` INTEGER, `responseGroupId` TEXT, `displayKind` TEXT, `messageSchemaVersion` INTEGER NOT NULL, `hasUsageStatistics` INTEGER NOT NULL, PRIMARY KEY(`sessionId`, `id`), FOREIGN KEY(`sessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageJson",
+            "columnName": "messageJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "responseGroupId",
+            "columnName": "responseGroupId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayKind",
+            "columnName": "displayKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "messageSchemaVersion",
+            "columnName": "messageSchemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasUsageStatistics",
+            "columnName": "hasUsageStatistics",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_sessionId_position",
+            "unique": true,
+            "columnNames": [
+              "sessionId",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chat_messages_sessionId_position` ON `${TABLE_NAME}` (`sessionId`, `position`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_responseGroupId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "responseGroupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_responseGroupId` ON `${TABLE_NAME}` (`sessionId`, `responseGroupId`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_author",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "author"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_author` ON `${TABLE_NAME}` (`sessionId`, `author`)"
+          },
+          {
+            "name": "index_chat_messages_hasUsageStatistics",
+            "unique": false,
+            "columnNames": [
+              "hasUsageStatistics"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_hasUsageStatistics` ON `${TABLE_NAME}` (`hasUsageStatistics`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_workspace_file_refs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `messageId` TEXT NOT NULL, `path` TEXT NOT NULL, PRIMARY KEY(`sessionId`, `messageId`, `path`), FOREIGN KEY(`sessionId`, `messageId`) REFERENCES `chat_messages`(`sessionId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "messageId",
+            "path"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_workspace_file_refs_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId",
+              "messageId"
+            ],
+            "referencedColumns": [
+              "sessionId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_state_meta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `currentSessionId` TEXT, `roomMigrationComplete` INTEGER NOT NULL, `workspaceFileRefsComplete` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`currentSessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentSessionId",
+            "columnName": "currentSessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roomMigrationComplete",
+            "columnName": "roomMigrationComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workspaceFileRefsComplete",
+            "columnName": "workspaceFileRefsComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_state_meta_currentSessionId",
+            "unique": false,
+            "columnNames": [
+              "currentSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_state_meta_currentSessionId` ON `${TABLE_NAME}` (`currentSessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "currentSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e466aa4e7ee1de5676bbe07f26bb461d')"
+    ]
+  }
+}

--- a/app/src/main/java/com/zhousl/aether/AetherApplication.kt
+++ b/app/src/main/java/com/zhousl/aether/AetherApplication.kt
@@ -148,6 +148,7 @@ class AetherAppRuntime(
         settingsRepository = settingsRepository,
         extensionsRepository = extensionsRepository,
         chatStateStore = chatStateStore,
+        chatRepository = chatRepository,
         bashTool = bashTool,
         runtimeRouter = runtimeRouter,
         workspaceFileBridge = workspaceFileBridge,

--- a/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
@@ -27,6 +27,7 @@ internal object ChatMessageEntityMapper {
             responseGroupId = message.responseGroupId,
             displayKind = message.displayKind.name,
             messageSchemaVersion = CurrentMessageSchemaVersion,
+            hasUsageStatistics = message.usageStatistics != null,
         )
     }
 

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -9,7 +9,6 @@ import androidx.room.withTransaction
 import com.zhousl.aether.data.chatdb.ChatHistoryDao
 import com.zhousl.aether.data.chatdb.ChatHistoryDatabase
 import com.zhousl.aether.data.chatdb.ChatMessageEntity
-import com.zhousl.aether.data.chatdb.ChatMessageJsonEntity
 import com.zhousl.aether.data.chatdb.ChatMessageSummaryEntity
 import com.zhousl.aether.data.chatdb.ChatMessageUsageStatisticsJsonEntity
 import com.zhousl.aether.data.chatdb.ChatSessionEntity
@@ -524,8 +523,11 @@ class ChatRepository(
         database.withTransaction {
             val existingMeta = chatHistoryDao.getMeta() ?: return@withTransaction
             if (existingMeta.workspaceFileRefsComplete) return@withTransaction
-            val refs = chatHistoryDao.getAllMessageJson()
-                .flatMap { row -> row.toWorkspaceFileRefs() }
+            val refs = chatHistoryDao.getSessions()
+                .map { session -> session.id }
+                .chunked(WorkspaceFileRefQueryChunkSize)
+                .flatMap { sessionIds -> chatHistoryDao.getMessageSummariesForSessions(sessionIds) }
+                .flatMap { summary -> summary.toWorkspaceFileRefs(chatHistoryDao) }
             chatHistoryDao.deleteAllWorkspaceFileRefs()
             if (refs.isNotEmpty()) {
                 chatHistoryDao.upsertWorkspaceFileRefs(refs)
@@ -534,16 +536,12 @@ class ChatRepository(
         }
     }
 
-    private fun ChatMessageJsonEntity.toWorkspaceFileRefs(): List<ChatWorkspaceFileRefEntity> {
-        val message = ChatMessageEntityMapper.toChatMessage(
-            ChatMessageEntity(
-                sessionId = sessionId,
-                id = id,
-                position = position,
-                messageJson = messageJson,
-            ),
-            position,
-        )
+    private suspend fun ChatMessageSummaryEntity.toWorkspaceFileRefs(
+        dao: ChatHistoryDao,
+    ): List<ChatWorkspaceFileRefEntity> {
+        val message = dao.loadMessageEntityInChunks(this)
+            ?.let { entity -> ChatMessageEntityMapper.toChatMessage(entity, entity.position) }
+            ?: ChatMessageEntityMapper.summaryToChatMessage(this)
         return message.collectWorkspaceFilePathsForIndex().map { path ->
             ChatWorkspaceFileRefEntity(
                 sessionId = sessionId,

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -9,8 +9,11 @@ import androidx.room.withTransaction
 import com.zhousl.aether.data.chatdb.ChatHistoryDao
 import com.zhousl.aether.data.chatdb.ChatHistoryDatabase
 import com.zhousl.aether.data.chatdb.ChatMessageEntity
+import com.zhousl.aether.data.chatdb.ChatMessageJsonEntity
 import com.zhousl.aether.data.chatdb.ChatMessageSummaryEntity
+import com.zhousl.aether.data.chatdb.ChatMessageUsageStatisticsJsonEntity
 import com.zhousl.aether.data.chatdb.ChatSessionEntity
+import com.zhousl.aether.data.chatdb.ChatSessionMessageStatsEntity
 import com.zhousl.aether.data.chatdb.ChatSessionSnapshot
 import com.zhousl.aether.data.chatdb.ChatStateMetaEntity
 import com.zhousl.aether.data.chatdb.ChatWorkspaceFileRefEntity
@@ -37,7 +40,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -54,6 +56,11 @@ private val Context.chatDataStore by preferencesDataStore(name = "aether_chats")
 data class PersistedChatState(
     val sessions: List<ChatSession> = emptyList(),
     val currentSessionId: String = DraftSessionId,
+)
+
+data class ChatUsageStatisticsSnapshot(
+    val sessionId: String,
+    val statistics: ChatUsageStatistics,
 )
 
 enum class PersistedChatWriteIntent {
@@ -88,31 +95,48 @@ class ChatRepository(
                 )
             }.flatMapLatest { state ->
                 val sessionIds = state.rows.map { it.id }
-                val messagesFlow = if (sessionIds.isEmpty()) {
+                val currentSessionId = state.currentSessionId.takeIf { it != DraftSessionId }
+                if (sessionIds.isEmpty()) {
                     clearRestoredMessageCache()
-                    flowOf(emptyList())
-                } else {
-                    chatHistoryDao.observeMessageSummariesForSessions(sessionIds).mapLatest { summaries ->
-                        restoredMessageCacheMutex.withLock {
-                            restoredMessageCache.keys.retainAll(summaries.mapTo(mutableSetOf()) { it.cacheKey })
-                            database.withTransaction {
-                                chatHistoryDao.getMessagesForSummariesSafely(
-                                    summaries = summaries,
-                                    restoredMessageCache = restoredMessageCache,
-                                )
-                            }
-                        }
-                    }
-                }
-                messagesFlow.map { messages ->
-                    val messagesBySessionId = messages.groupBy { it.sessionId }
-                    val sessions = state.rows.map { session ->
-                        session.toChatSession(messagesBySessionId[session.id].orEmpty())
-                    }
-                    PersistedChatState(
-                        sessions = sessions,
-                        currentSessionId = state.currentSessionId,
+                    flowOf(
+                        PersistedChatState(
+                            sessions = emptyList(),
+                            currentSessionId = state.currentSessionId,
+                        )
                     )
+                } else {
+                    combine(
+                        chatHistoryDao.observeMessageStatsForSessions(sessionIds),
+                        if (currentSessionId == null) {
+                            clearRestoredMessageCache()
+                            flowOf(emptyList())
+                        } else {
+                            chatHistoryDao.observeMessageSummariesForSession(currentSessionId).mapLatest { summaries ->
+                                restoredMessageCacheMutex.withLock {
+                                    restoredMessageCache.keys.retainAll(summaries.mapTo(mutableSetOf()) { it.cacheKey })
+                                    database.withTransaction {
+                                        chatHistoryDao.getMessagesForSummariesSafely(
+                                            summaries = summaries,
+                                            restoredMessageCache = restoredMessageCache,
+                                        )
+                                    }
+                                }
+                            }
+                        },
+                    ) { stats, currentMessages ->
+                        val statsBySessionId = stats.associateBy { it.sessionId }
+                        val currentMessagesBySessionId = currentMessages.groupBy { it.sessionId }
+                        val sessions = state.rows.map { session ->
+                            session.toChatSession(
+                                messages = currentMessagesBySessionId[session.id].orEmpty(),
+                                stats = statsBySessionId[session.id],
+                            )
+                        }
+                        PersistedChatState(
+                            sessions = sessions,
+                            currentSessionId = state.currentSessionId,
+                        )
+                    }
                 }
             }
         )
@@ -134,6 +158,51 @@ class ChatRepository(
             preferences.remove(SESSIONS_JSON)
             preferences.remove(CURRENT_SESSION_ID)
             preferences[ROOM_MIGRATION_COMPLETE] = true
+        }
+    }
+    suspend fun getSessionWithMessages(sessionId: String): ChatSession? {
+        migrateLegacyChatStateIfNeeded()
+        return restoredMessageCacheMutex.withLock {
+            database.withTransaction {
+                val session = chatHistoryDao.getSession(sessionId) ?: return@withTransaction null
+                val summaries = chatHistoryDao.getMessageSummariesForSession(sessionId)
+                val messages = chatHistoryDao.getMessagesForSummariesSafely(
+                    summaries = summaries,
+                    restoredMessageCache = restoredMessageCache,
+                )
+                session.toChatSession(messages = messages)
+            }
+        }
+    }
+
+    suspend fun getSessionsWithMessages(): List<ChatSession> {
+        migrateLegacyChatStateIfNeeded()
+        return restoredMessageCacheMutex.withLock {
+            database.withTransaction {
+                val sessions = chatHistoryDao.getSessions()
+                val sessionIds = sessions.map { it.id }
+                if (sessionIds.isEmpty()) return@withTransaction emptyList()
+                val summariesBySessionId = chatHistoryDao.getMessageSummariesForSessions(sessionIds)
+                    .groupBy { it.sessionId }
+                sessions.map { session ->
+                    val messages = chatHistoryDao.getMessagesForSummariesSafely(
+                        summaries = summariesBySessionId[session.id].orEmpty(),
+                        restoredMessageCache = restoredMessageCache,
+                    )
+                    session.toChatSession(messages = messages)
+                }
+            }
+        }
+    }
+
+    suspend fun getUsageStatisticsSnapshot(): List<ChatUsageStatisticsSnapshot> {
+        migrateLegacyChatStateIfNeeded()
+        return chatHistoryDao.getUsageStatisticsMessageJson().mapNotNull { row ->
+            val statistics = row.parseUsageStatisticsOrNull() ?: return@mapNotNull null
+            ChatUsageStatisticsSnapshot(
+                sessionId = row.sessionId,
+                statistics = statistics,
+            )
         }
     }
 
@@ -303,6 +372,8 @@ class ChatRepository(
             chatHistoryDao.deleteSessionsExcept(sessionIds)
             chatHistoryDao.deleteMessagesExceptSessions(sessionIds)
             val existingWorkspaceFileRefsComplete = chatHistoryDao.getMeta()?.workspaceFileRefsComplete ?: true
+            val existingMessageCounts = chatHistoryDao.getMessageStatsForSessions(sessionIds)
+                .associate { stats -> stats.sessionId to stats.messageCount }
             chatHistoryDao.upsertMeta(
                 ChatStateMetaEntity(
                     currentSessionId = safeCurrentSessionId.toStoredCurrentSessionId(),
@@ -312,12 +383,19 @@ class ChatRepository(
             )
 
             sessions.forEach { snapshot ->
-                chatHistoryDao.deleteWorkspaceFileRefsForSession(snapshot.session.id)
-                chatHistoryDao.deleteMessagesForSession(snapshot.session.id)
-                if (snapshot.messages.isNotEmpty()) {
-                    chatHistoryDao.upsertMessages(snapshot.messages)
-                    if (snapshot.workspaceFileRefs.isNotEmpty()) {
-                        chatHistoryDao.upsertWorkspaceFileRefs(snapshot.workspaceFileRefs)
+                val existingMessageCount = existingMessageCounts[snapshot.session.id] ?: 0
+                val isMetadataOnlySnapshot = writeIntent != PersistedChatWriteIntent.ReplaceFromImport &&
+                    snapshot.session.id != safeCurrentSessionId &&
+                    snapshot.messages.isEmpty() &&
+                    existingMessageCount > 0
+                if (!isMetadataOnlySnapshot) {
+                    chatHistoryDao.deleteWorkspaceFileRefsForSession(snapshot.session.id)
+                    chatHistoryDao.deleteMessagesForSession(snapshot.session.id)
+                    if (snapshot.messages.isNotEmpty()) {
+                        chatHistoryDao.upsertMessages(snapshot.messages)
+                        if (snapshot.workspaceFileRefs.isNotEmpty()) {
+                            chatHistoryDao.upsertWorkspaceFileRefs(snapshot.workspaceFileRefs)
+                        }
                     }
                 }
             }
@@ -362,6 +440,7 @@ class ChatRepository(
         val roomMeta = chatHistoryDao.getMeta()
 
         if (roomMeta?.roomMigrationComplete == true) {
+            rebuildWorkspaceFileRefsIfNeeded()
             if (legacySessionsJson.isNotBlank() || preferences[CURRENT_SESSION_ID] != null) {
                 clearLegacyChatState()
             }
@@ -438,6 +517,40 @@ class ChatRepository(
                 )
             )
         }
+        rebuildWorkspaceFileRefsIfNeeded()
+    }
+
+    private suspend fun rebuildWorkspaceFileRefsIfNeeded() {
+        database.withTransaction {
+            val existingMeta = chatHistoryDao.getMeta() ?: return@withTransaction
+            if (existingMeta.workspaceFileRefsComplete) return@withTransaction
+            val refs = chatHistoryDao.getAllMessageJson()
+                .flatMap { row -> row.toWorkspaceFileRefs() }
+            chatHistoryDao.deleteAllWorkspaceFileRefs()
+            if (refs.isNotEmpty()) {
+                chatHistoryDao.upsertWorkspaceFileRefs(refs)
+            }
+            chatHistoryDao.upsertMeta(existingMeta.copy(workspaceFileRefsComplete = true))
+        }
+    }
+
+    private fun ChatMessageJsonEntity.toWorkspaceFileRefs(): List<ChatWorkspaceFileRefEntity> {
+        val message = ChatMessageEntityMapper.toChatMessage(
+            ChatMessageEntity(
+                sessionId = sessionId,
+                id = id,
+                position = position,
+                messageJson = messageJson,
+            ),
+            position,
+        )
+        return message.collectWorkspaceFilePathsForIndex().map { path ->
+            ChatWorkspaceFileRefEntity(
+                sessionId = sessionId,
+                messageId = id,
+                path = path,
+            )
+        }.distinctBy { ref -> Triple(ref.sessionId, ref.messageId, ref.path) }
     }
 
     private suspend fun clearLegacyChatState() {
@@ -669,7 +782,10 @@ private fun ChatSession.toSnapshot(index: Int): ChatSessionSnapshot {
     )
 }
 
-private fun ChatSessionEntity.toChatSession(messages: List<LoadedChatMessage>): ChatSession {
+private fun ChatSessionEntity.toChatSession(
+    messages: List<LoadedChatMessage>,
+    stats: ChatSessionMessageStatsEntity? = null,
+): ChatSession {
     val orderedMessages = messages.sortedBy { it.position }.map { it.message }
     val activeSkills = parseActiveSkillContexts(activeSkillsJson)
     return ChatSession(
@@ -678,6 +794,8 @@ private fun ChatSessionEntity.toChatSession(messages: List<LoadedChatMessage>): 
         preview = preview,
         hasCustomTitle = hasCustomTitle,
         messages = orderedMessages,
+        messageCount = stats?.messageCount ?: orderedMessages.size,
+        lastMessageAtMillis = stats?.lastMessageAtMillis ?: orderedMessages.maxOfOrNull { it.createdAtMillis },
         selectedSkillIds = parseStringList(selectedSkillIdsJson).ifEmpty { activeSkills.map { it.skillId } },
         activeSkills = activeSkills,
         activeMcpServerIds = parseStringList(activeMcpServerIdsJson),
@@ -846,6 +964,11 @@ internal fun ChatMessage.toJson(): JSONObject = JSONObject().apply {
     put("toolInvocations", JSONArray().apply { toolInvocations.forEach { put(it.toJson()) } })
     put("attachments", JSONArray().apply { attachments.forEach { put(it.toJson()) } })
 }
+
+private fun ChatMessageUsageStatisticsJsonEntity.parseUsageStatisticsOrNull(): ChatUsageStatistics? =
+    runCatching {
+        parseUsageStatistics(JSONObject(messageJson).optJSONObject("usageStatistics"))
+    }.getOrNull()
 
 private fun parseUsageStatistics(json: JSONObject?): ChatUsageStatistics? {
     if (json == null) return null

--- a/app/src/main/java/com/zhousl/aether/data/ChatSessionMetadata.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatSessionMetadata.kt
@@ -14,6 +14,8 @@ internal fun ChatSession.withDerivedMessages(
         title = if (hasCustomTitle) title else metadata.first,
         preview = metadata.second,
         messages = syncActiveBranches(messages),
+        messageCount = messages.size,
+        lastMessageAtMillis = messages.maxOfOrNull { it.createdAtMillis },
     )
 }
 

--- a/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
@@ -205,11 +205,19 @@ class ChatStateStore(
     ): PersistedChatState {
         val localSessionsById = localState.sessions.associateBy { it.id }
         val repositorySessionIds = repositoryState.sessions.mapTo(mutableSetOf()) { it.id }
+        val mergedSessionIds = repositorySessionIds + localSessionsById.keys
+        val currentSessionId = localState.currentSessionId
+            .takeIf { id -> id != DraftSessionId && id in mergedSessionIds }
+            ?: repositoryState.currentSessionId
+                .takeIf { id -> id != DraftSessionId && id in mergedSessionIds }
+            ?: repositoryState.sessions.firstOrNull()?.id
+            ?: localState.sessions.firstOrNull()?.id
+            ?: DraftSessionId
         val mergedSessions = buildList(repositoryState.sessions.size + localState.sessions.size) {
             repositoryState.sessions.forEach { repositorySession ->
                 val localSession = localSessionsById[repositorySession.id]
                 add(
-                    if (localSession == null) {
+                    if (localSession == null || repositorySession.id != currentSessionId) {
                         repositorySession
                     } else {
                         localSession.withDerivedMessages(
@@ -227,12 +235,6 @@ class ChatStateStore(
                 }
             }
         }
-        val currentSessionId = localState.currentSessionId
-            .takeIf { id -> id != DraftSessionId && mergedSessions.any { it.id == id } }
-            ?: repositoryState.currentSessionId
-                .takeIf { id -> id != DraftSessionId && mergedSessions.any { it.id == id } }
-            ?: mergedSessions.firstOrNull()?.id
-            ?: DraftSessionId
         return PersistedChatState(
             sessions = mergedSessions,
             currentSessionId = currentSessionId,

--- a/app/src/main/java/com/zhousl/aether/data/QueuedTurnRequestBuilder.kt
+++ b/app/src/main/java/com/zhousl/aether/data/QueuedTurnRequestBuilder.kt
@@ -1,6 +1,7 @@
 package com.zhousl.aether.data
 
 import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.ChatSession
 import com.zhousl.aether.ui.syncActiveBranches
 
 internal class QueuedTurnRequestBuilder(
@@ -9,6 +10,7 @@ internal class QueuedTurnRequestBuilder(
     fun build(
         sessionId: String,
         queuedInput: ChatMessage,
+        baseMessages: List<ChatMessage> = emptyList(),
         baseSettings: AppSettings,
         providerConfigs: List<LlmProviderConfig>,
     ): SessionTurnRequest? {
@@ -20,8 +22,10 @@ internal class QueuedTurnRequestBuilder(
 
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
-            val updatedSession = session.withDerivedMessages(
-                syncActiveBranches(session.messages + queuedInput)
+            val updatedSession = buildQueuedTurnSession(
+                session = session,
+                queuedInput = queuedInput,
+                baseMessages = baseMessages,
             )
             selection = QueuedTurnSelection(
                 requestMessages = updatedSession.messages,
@@ -61,5 +65,16 @@ internal class QueuedTurnRequestBuilder(
         val activeMcpServerIds: List<String> = emptyList(),
         val agentModeEnabled: Boolean = false,
         val selectedModelKey: String = "",
+    )
+}
+
+internal fun buildQueuedTurnSession(
+    session: ChatSession,
+    queuedInput: ChatMessage,
+    baseMessages: List<ChatMessage> = emptyList(),
+): ChatSession {
+    val currentMessages = session.messages.ifEmpty { baseMessages }
+    return session.withDerivedMessages(
+        syncActiveBranches(currentMessages + queuedInput)
     )
 }

--- a/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
@@ -115,6 +115,7 @@ class SessionExecutionManager(
     private val settingsRepository: SettingsRepository,
     private val extensionsRepository: AgentExtensionsRepository,
     private val chatStateStore: ChatStateStore,
+    private val chatRepository: ChatRepository,
     private val bashTool: TermuxBashTool,
     private val runtimeRouter: RuntimeRouter,
     private val workspaceFileBridge: WorkspaceFileBridge,
@@ -318,12 +319,17 @@ class SessionExecutionManager(
         var activeMcpServerIds: List<String> = emptyList()
         var agentModeEnabled = false
 
+        val persistedSessionWithMessages = chatRepository.getSessionWithMessages(sessionId)
+
         chatStateStore.updateAndFlush { persisted ->
             val updatedSessions = persisted.sessions.toMutableList()
             val existingIndex = updatedSessions.indexOfFirst { it.id == sessionId }
             val updatedSession = if (existingIndex >= 0) {
                 val existing = updatedSessions.removeAt(existingIndex)
-                existing.withDerivedMessages(existing.messages + userMessage)
+                val baseMessages = existing.messages.ifEmpty {
+                    persistedSessionWithMessages?.messages.orEmpty()
+                }
+                existing.withDerivedMessages(baseMessages + userMessage)
             } else {
                 ChatSession(
                     id = sessionId,

--- a/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
@@ -164,6 +164,7 @@ class SessionExecutionManager(
 
     fun startTurn(request: SessionTurnRequest) {
         val handle = SessionExecutionHandle(sessionId = request.sessionId)
+        handle.replaceRetainedMessages(request.requestMessages)
         if (executionHandles.putIfAbsent(request.sessionId, handle) != null) return
 
         val validationError = validateRequest(request)
@@ -186,6 +187,7 @@ class SessionExecutionManager(
                 ),
                 thoughtDurationMillis = null,
                 outcome = SessionTurnOutcome.ValidationError,
+                baseMessages = request.requestMessages,
             )
             _turnEvents.tryEmit(completion.toTurnEvent(request.sessionId))
             return
@@ -392,7 +394,7 @@ class SessionExecutionManager(
 
                 val nextQueued = pollNextQueuedInput(handle) ?: break
                 nextRequest = buildQueuedTurnRequest(
-                    sessionId = handle.sessionId,
+                    handle = handle,
                     queuedInput = nextQueued.message,
                 )
             }
@@ -686,6 +688,7 @@ class SessionExecutionManager(
                         turnCompletedAtMillis = turnCompletedAtMillis,
                         inputMessageCount = request.requestMessages.size,
                         userMessageCount = request.requestMessages.count { it.author == MessageAuthor.User },
+                        handle = handle,
                     )
                 },
                 onFailure = { throwable ->
@@ -717,6 +720,7 @@ class SessionExecutionManager(
                         turnCompletedAtMillis = System.currentTimeMillis(),
                         inputMessageCount = request.requestMessages.size,
                         userMessageCount = request.requestMessages.count { it.author == MessageAuthor.User },
+                        handle = handle,
                     )
                 },
             )
@@ -786,14 +790,19 @@ class SessionExecutionManager(
     }
 
     private fun buildQueuedTurnRequest(
-        sessionId: String,
+        handle: SessionExecutionHandle,
         queuedInput: ChatMessage,
-    ): SessionTurnRequest? = queuedTurnRequestBuilder.build(
-        sessionId = sessionId,
-        queuedInput = queuedInput,
-        baseSettings = currentSettings.value,
-        providerConfigs = currentProviderConfigs.value,
-    )
+    ): SessionTurnRequest? {
+        val request = queuedTurnRequestBuilder.build(
+            sessionId = handle.sessionId,
+            queuedInput = queuedInput,
+            baseMessages = handle.retainedMessagesSnapshot(),
+            baseSettings = currentSettings.value,
+            providerConfigs = currentProviderConfigs.value,
+        )
+        request?.let { handle.replaceRetainedMessages(it.requestMessages) }
+        return request
+    }
 
     private fun updateSessionSelections(
         sessionId: String,
@@ -869,6 +878,8 @@ class SessionExecutionManager(
         turnCompletedAtMillis: Long? = null,
         inputMessageCount: Int = 0,
         userMessageCount: Int = 0,
+        handle: SessionExecutionHandle? = null,
+        baseMessages: List<ChatMessage> = handle?.retainedMessagesSnapshot().orEmpty(),
     ): CompletionSummary {
         var sessionTitle = resolveSessionTitle(sessionId)
         var replySummary = blocks.lastOrNull()
@@ -895,9 +906,11 @@ class SessionExecutionManager(
 
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
+            val currentMessages = session.messages.ifEmpty { baseMessages }
             val updatedSession = session.withDerivedMessages(
-                session.messages + appendedMessages
+                currentMessages + appendedMessages
             )
+            handle?.replaceRetainedMessages(updatedSession.messages)
             sessionTitle = updatedSession.title
             replySummary = updatedSession.preview
             updatedSessions.add(0, updatedSession)
@@ -1156,6 +1169,7 @@ class SessionExecutionManager(
                 blocks = blocks,
                 thoughtDurationMillis = thoughtDurationMillis,
                 outcome = SessionTurnOutcome.Neutral,
+                handle = handle,
             )
         }
     }
@@ -1199,11 +1213,14 @@ class SessionExecutionManager(
 
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
+            val currentMessages = session.messages.ifEmpty { handle.retainedMessagesSnapshot() }
+            val updatedSession = session.withDerivedMessages(
+                syncActiveBranches(currentMessages + interruptedAssistantMessages + userMessages)
+            )
+            handle.replaceRetainedMessages(updatedSession.messages)
             updatedSessions.add(
                 0,
-                session.withDerivedMessages(
-                    syncActiveBranches(session.messages + interruptedAssistantMessages + userMessages)
-                ),
+                updatedSession,
             )
             persisted.copy(sessions = updatedSessions)
         }
@@ -2512,6 +2529,7 @@ class SessionExecutionManager(
         val lock = Any()
         val queuedInputs = ArrayDeque<PendingEnvelope>()
         val steerInputs = ArrayDeque<PendingEnvelope>()
+        private var retainedMessages: List<ChatMessage> = emptyList()
         private var pendingBlockCounter: Long = 0
         private var reasoningChunkCounter: Long = 0
         private var reasoningTimelineCounter: Long = 0
@@ -2565,6 +2583,16 @@ class SessionExecutionManager(
             reasoningFirstSummarySubmitted = false
             reasoningLastSubmittedCharIndex = 0
             reasoningLastTimedSummaryAtMillis = 0L
+        }
+
+        fun retainedMessagesSnapshot(): List<ChatMessage> = synchronized(lock) {
+            retainedMessages
+        }
+
+        fun replaceRetainedMessages(messages: List<ChatMessage>) {
+            synchronized(lock) {
+                retainedMessages = messages
+            }
         }
     }
 }

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -70,13 +70,6 @@ interface ChatHistoryDao {
         observeMessageSummariesForSession(sessionId).first()
 
     @Query("""
-        SELECT sessionId, id, position, messageJson
-        FROM chat_messages
-        ORDER BY sessionId ASC, position ASC
-    """)
-    suspend fun getAllMessageJson(): List<ChatMessageJsonEntity>
-
-    @Query("""
         SELECT length(messageJson)
         FROM chat_messages
         WHERE sessionId = :sessionId AND id = :messageId

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 
 @Dao
 interface ChatHistoryDao {
@@ -19,6 +20,36 @@ interface ChatHistoryDao {
     @Query("SELECT * FROM chat_state_meta WHERE id = :id")
     suspend fun getMeta(id: String = ChatStateMetaEntityId): ChatStateMetaEntity?
 
+    @Query("SELECT * FROM chat_sessions WHERE id = :sessionId")
+    suspend fun getSession(sessionId: String): ChatSessionEntity?
+
+    @Query("SELECT COUNT(*) FROM chat_messages WHERE sessionId = :sessionId")
+    suspend fun getMessageCountForSession(sessionId: String): Int
+
+    @Query("""
+        SELECT sessionId, COUNT(*) AS messageCount, MAX(COALESCE(createdAtMillis, 0)) AS lastMessageAtMillis
+        FROM chat_messages
+        WHERE sessionId IN (:sessionIds)
+        GROUP BY sessionId
+    """)
+    suspend fun getMessageStatsForSessions(sessionIds: List<String>): List<ChatSessionMessageStatsEntity>
+
+    @Query("""
+        SELECT sessionId, COUNT(*) AS messageCount, MAX(COALESCE(createdAtMillis, 0)) AS lastMessageAtMillis
+        FROM chat_messages
+        WHERE sessionId IN (:sessionIds)
+        GROUP BY sessionId
+    """)
+    fun observeMessageStatsForSessions(sessionIds: List<String>): Flow<List<ChatSessionMessageStatsEntity>>
+
+    @Query("""
+        SELECT sessionId, messageJson
+        FROM chat_messages
+        WHERE hasUsageStatistics = 1
+        ORDER BY sessionId ASC, position ASC
+    """)
+    suspend fun getUsageStatisticsMessageJson(): List<ChatMessageUsageStatisticsJsonEntity>
+
     @Query("""
         SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength
         FROM chat_messages
@@ -33,7 +64,17 @@ interface ChatHistoryDao {
         WHERE sessionId IN (:sessionIds)
         ORDER BY sessionId ASC, position ASC
     """)
-    fun observeMessageSummariesForSessions(sessionIds: List<String>): Flow<List<ChatMessageSummaryEntity>>
+    suspend fun getMessageSummariesForSessions(sessionIds: List<String>): List<ChatMessageSummaryEntity>
+
+    suspend fun getMessageSummariesForSession(sessionId: String): List<ChatMessageSummaryEntity> =
+        observeMessageSummariesForSession(sessionId).first()
+
+    @Query("""
+        SELECT sessionId, id, position, messageJson
+        FROM chat_messages
+        ORDER BY sessionId ASC, position ASC
+    """)
+    suspend fun getAllMessageJson(): List<ChatMessageJsonEntity>
 
     @Query("""
         SELECT length(messageJson)

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
@@ -6,7 +6,6 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import org.json.JSONObject
 
 @Database(
     entities = [
@@ -15,7 +14,7 @@ import org.json.JSONObject
         ChatWorkspaceFileRefEntity::class,
         ChatStateMetaEntity::class,
     ],
-    version = 2,
+    version = 3,
     exportSchema = true,
 )
 abstract class ChatHistoryDatabase : RoomDatabase() {
@@ -30,7 +29,7 @@ abstract class ChatHistoryDatabase : RoomDatabase() {
                 context.applicationContext,
                 ChatHistoryDatabase::class.java,
                 "aether_chat_history.db",
-            ).addMigrations(Migration1To2)
+            ).addMigrations(Migration1To2, Migration2To3)
                 .build()
                 .also { instance = it }
         }
@@ -53,79 +52,26 @@ internal object Migration1To2 : Migration(1, 2) {
         db.execSQL(
             "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `chat_workspace_file_refs` (`path`)",
         )
-        val workspaceFileRefsBackfilled = backfillWorkspaceFileRefs(db)
         db.execSQL(
             "ALTER TABLE `chat_state_meta` ADD COLUMN `workspaceFileRefsComplete` INTEGER NOT NULL DEFAULT 0",
         )
-        if (workspaceFileRefsBackfilled) {
-            db.execSQL(
-                """
-                INSERT OR IGNORE INTO `chat_state_meta` (
-                    `id`,
-                    `currentSessionId`,
-                    `roomMigrationComplete`,
-                    `workspaceFileRefsComplete`
-                ) VALUES (?, NULL, 0, 1)
-                """.trimIndent(),
-                arrayOf(ChatStateMetaEntityId),
-            )
-            db.execSQL("UPDATE `chat_state_meta` SET `workspaceFileRefsComplete` = 1")
-        }
     }
+}
 
-    private fun backfillWorkspaceFileRefs(db: SupportSQLiteDatabase): Boolean {
-        var complete = true
-        db.query("SELECT `sessionId`, `id`, `messageJson` FROM `chat_messages`").use { cursor ->
-            while (cursor.moveToNext()) {
-                val sessionId = cursor.getString(0)
-                val messageId = cursor.getString(1)
-                val messageJson = cursor.getString(2)
-                val paths = runCatching { collectWorkspaceFilePaths(JSONObject(messageJson)) }
-                    .getOrElse {
-                        complete = false
-                        emptySet()
-                    }
-                paths.forEach { path ->
-                    db.execSQL(
-                        """
-                        INSERT OR IGNORE INTO `chat_workspace_file_refs` (`sessionId`, `messageId`, `path`)
-                        VALUES (?, ?, ?)
-                        """.trimIndent(),
-                        arrayOf(sessionId, messageId, path),
-                    )
-                }
-            }
-        }
-        return complete
-    }
-
-    private fun collectWorkspaceFilePaths(message: JSONObject): Set<String> = buildSet {
-        collectWorkspaceFilePaths(message, this)
-    }
-
-    private fun collectWorkspaceFilePaths(
-        message: JSONObject,
-        paths: MutableSet<String>,
-    ) {
-        val attachments = message.optJSONArray("attachments")
-        if (attachments != null) {
-            for (index in 0 until attachments.length()) {
-                attachments.optJSONObject(index)
-                    ?.optString("workspacePath")
-                    ?.trim()
-                    ?.takeIf(String::isNotEmpty)
-                    ?.let(paths::add)
-            }
-        }
-
-        val branches = message.optJSONObject("branchGroup")?.optJSONArray("branches") ?: return
-        for (branchIndex in 0 until branches.length()) {
-            val branch = branches.optJSONArray(branchIndex) ?: continue
-            for (messageIndex in 0 until branch.length()) {
-                branch.optJSONObject(messageIndex)?.let { branchMessage ->
-                    collectWorkspaceFilePaths(branchMessage, paths)
-                }
-            }
-        }
+internal object Migration2To3 : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `chat_messages` ADD COLUMN `hasUsageStatistics` INTEGER NOT NULL DEFAULT 0",
+        )
+        db.execSQL(
+            """
+            UPDATE `chat_messages`
+            SET `hasUsageStatistics` = 1
+            WHERE `messageJson` LIKE '%"usageStatistics"%'
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_chat_messages_hasUsageStatistics` ON `chat_messages` (`hasUsageStatistics`)",
+        )
     }
 }

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -35,6 +35,7 @@ data class ChatSessionEntity(
         Index(value = ["sessionId", "position"], unique = true),
         Index(value = ["sessionId", "responseGroupId"]),
         Index(value = ["sessionId", "author"]),
+        Index(value = ["hasUsageStatistics"]),
     ],
 )
 data class ChatMessageEntity(
@@ -48,6 +49,7 @@ data class ChatMessageEntity(
     val responseGroupId: String? = null,
     val displayKind: String? = null,
     val messageSchemaVersion: Int = 1,
+    val hasUsageStatistics: Boolean = false,
 )
 
 data class ChatMessageSummaryEntity(
@@ -61,6 +63,24 @@ data class ChatMessageSummaryEntity(
     val displayKind: String? = null,
     val messageSchemaVersion: Int = 1,
     val messageJsonLength: Int? = null,
+)
+
+data class ChatSessionMessageStatsEntity(
+    val sessionId: String,
+    val messageCount: Int,
+    val lastMessageAtMillis: Long?,
+)
+
+data class ChatMessageJsonEntity(
+    val sessionId: String,
+    val id: String,
+    val position: Int,
+    val messageJson: String,
+)
+
+data class ChatMessageUsageStatisticsJsonEntity(
+    val sessionId: String,
+    val messageJson: String,
 )
 
 @Entity(

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -71,13 +71,6 @@ data class ChatSessionMessageStatsEntity(
     val lastMessageAtMillis: Long?,
 )
 
-data class ChatMessageJsonEntity(
-    val sessionId: String,
-    val id: String,
-    val position: Int,
-    val messageJson: String,
-)
-
 data class ChatMessageUsageStatisticsJsonEntity(
     val sessionId: String,
     val messageJson: String,

--- a/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
@@ -183,6 +183,12 @@ fun AetherApp(
         AetherLocaleManager.applyIfChanged(context, uiState.settings.language)
     }
 
+    LaunchedEffect(uiState.currentScreen) {
+        if (uiState.currentScreen == AppScreen.Settings) {
+            viewModel.refreshUsageStatisticsSnapshots()
+        }
+    }
+
     val localizedContext = remember(context, uiState.settings.language) {
         AetherLocaleManager.localizedContext(context, uiState.settings.language)
     }
@@ -713,7 +719,7 @@ private fun AetherAppContent(
                     defaultCompactingModelKey = uiState.settings.defaultCompactingModelKey,
                     agentModeDisplayState = uiState.agentModeDisplayState,
                     providerConfigs = uiState.providerConfigs,
-                    sessions = uiState.sessions,
+                    usageStatisticsSnapshots = uiState.usageStatisticsSnapshots,
                     scheduledTasks = uiState.scheduledTasks,
                     termuxSetupState = effectiveTermuxSetupState,
                     alpineSetupState = uiState.alpineSetupState,

--- a/app/src/main/java/com/zhousl/aether/ui/AetherUiState.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherUiState.kt
@@ -5,6 +5,7 @@ import com.zhousl.aether.data.AgentModeAuthorizationState
 import com.zhousl.aether.data.AgentModeDisplayState
 import com.zhousl.aether.data.AppSettings
 import com.zhousl.aether.data.AppUpdateRelease
+import com.zhousl.aether.data.ChatUsageStatisticsSnapshot
 import com.zhousl.aether.data.InstalledSkill
 import com.zhousl.aether.data.LlmProviderConfig
 import com.zhousl.aether.data.McpServerConfig
@@ -197,6 +198,8 @@ data class ChatSession(
     val preview: String,
     val hasCustomTitle: Boolean = false,
     val messages: List<ChatMessage>,
+    val messageCount: Int = messages.size,
+    val lastMessageAtMillis: Long? = messages.maxOfOrNull { it.createdAtMillis },
     val selectedSkillIds: List<String> = emptyList(),
     val activeSkills: List<ActiveSkillContext> = emptyList(),
     val activeMcpServerIds: List<String> = emptyList(),
@@ -220,6 +223,7 @@ data class AetherUiState(
     val onboardingStep: OnboardingStep = OnboardingStep.Landing,
     val onboardingReturnScreen: AppScreen = AppScreen.Chat,
     val sessions: List<ChatSession> = emptyList(),
+    val usageStatisticsSnapshots: List<ChatUsageStatisticsSnapshot> = emptyList(),
     val currentSessionId: String = DraftSessionId,
     val draftInput: String = "",
     val draftAttachments: List<ChatAttachment> = emptyList(),

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -26,6 +26,7 @@ import com.zhousl.aether.data.LlmProvider
 import com.zhousl.aether.data.LlmProviderConfig
 import com.zhousl.aether.data.LocalRuntimeId
 import com.zhousl.aether.data.ProviderModelOption
+import com.zhousl.aether.data.PersistedChatState
 import com.zhousl.aether.data.PersistedChatWriteIntent
 import com.zhousl.aether.data.availableModelOptions
 import com.zhousl.aether.data.McpClientManager
@@ -72,7 +73,9 @@ import com.zhousl.aether.data.resolveStoredOrAutomaticModelKey
 import com.zhousl.aether.termux.TermuxSetupIssue
 import com.zhousl.aether.termux.TermuxSetupState
 import com.zhousl.aether.runtime.AlpineTerminalLaunchSpec
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -128,6 +131,7 @@ class AetherViewModel(
     private val _uiState = MutableStateFlow(AetherUiState())
     private val _transientMessages = MutableSharedFlow<UiText>(extraBufferCapacity = 4)
     private var didEvaluateWorkspaceMode = false
+    private var selectSessionJob: Job? = null
 
     val uiState: StateFlow<AetherUiState> = _uiState.asStateFlow()
     val transientMessages = _transientMessages.asSharedFlow()
@@ -177,12 +181,20 @@ class AetherViewModel(
         }
 
         viewModelScope.launch {
+            var didReceiveChatState = false
             chatStateStore.state.collect { persisted ->
+                if (!didReceiveChatState && persisted.sessions.isEmpty() && persisted.currentSessionId == DraftSessionId) {
+                    didReceiveChatState = true
+                    return@collect
+                }
+                didReceiveChatState = true
+                val hydratedPersisted = hydrateCurrentSessionMessages(persisted)
                 _uiState.update { current ->
-                    val currentExecution = current.sessionExecutionStates[persisted.currentSessionId.ifBlank { DraftSessionId }]
+                    val currentSessionId = hydratedPersisted.currentSessionId.ifBlank { DraftSessionId }
+                    val currentExecution = current.sessionExecutionStates[currentSessionId]
                     current.copy(
-                        sessions = persisted.sessions,
-                        currentSessionId = persisted.currentSessionId.ifBlank { DraftSessionId },
+                        sessions = hydratedPersisted.sessions,
+                        currentSessionId = currentSessionId,
                         isSending = currentExecution?.isRunning == true,
                         pendingResponseSessionId = currentExecution?.sessionId,
                         pendingToolInvocations = currentExecution?.pendingToolInvocations.orEmpty(),
@@ -1016,6 +1028,15 @@ class AetherViewModel(
         _uiState.update { it.copy(currentScreen = AppScreen.Settings) }
     }
 
+    fun refreshUsageStatisticsSnapshots() {
+        viewModelScope.launch {
+            val snapshots = withContext(Dispatchers.IO) {
+                runtime.chatRepository.getUsageStatisticsSnapshot()
+            }
+            _uiState.update { it.copy(usageStatisticsSnapshots = snapshots) }
+        }
+    }
+
     fun closeSettings() {
         _uiState.update {
             it.copy(
@@ -1048,9 +1069,11 @@ class AetherViewModel(
     }
 
     fun selectSession(sessionId: String) {
-        _uiState.update {
-            it.copy(
+        selectSessionJob?.cancel()
+        _uiState.update { current ->
+            current.copy(
                 currentScreen = AppScreen.Chat,
+                sessions = current.sessions.withMessagesOnlyForSession(sessionId),
                 currentSessionId = sessionId,
                 draftInput = "",
                 draftAttachments = emptyList(),
@@ -1061,11 +1084,44 @@ class AetherViewModel(
                 draftWorkspaceId = null,
                 editingSessionId = null,
                 editingMessageId = null,
-                unviewedCompletedSessionIds = it.unviewedCompletedSessionIds - sessionId,
+                unviewedCompletedSessionIds = current.unviewedCompletedSessionIds - sessionId,
                 showStarterPromptHint = false,
             )
         }
-        persistCurrentSessionId(sessionId)
+        selectSessionJob = viewModelScope.launch {
+            val loadedSession = if (sessionId == DraftSessionId) {
+                null
+            } else {
+                runCatching {
+                    withContext(Dispatchers.IO) {
+                        runtime.chatRepository.getSessionWithMessages(sessionId)
+                    }
+                }.getOrElse { throwable ->
+                    if (throwable is CancellationException) throw throwable
+                    diagnosticLogger.exception(
+                        category = "storage",
+                        event = "session_selection_hydration_failed",
+                        throwable = throwable,
+                        level = "warn",
+                        sessionId = sessionId,
+                    )
+                    null
+                }
+            }
+            loadedSession?.let { session ->
+                _uiState.update { current ->
+                    if (current.currentSessionId != sessionId) {
+                        current
+                    } else {
+                        current.copy(
+                            sessions = replaceOrPrependSession(current.sessions, session)
+                                .withMessagesOnlyForSession(sessionId),
+                        )
+                    }
+                }
+            }
+            persistSessionSelection(sessionId, loadedSession)
+        }
     }
 
     fun renameSession(
@@ -1141,9 +1197,9 @@ class AetherViewModel(
         sessionId: String,
         destinationUri: Uri,
     ) {
-        val session = _uiState.value.sessions.firstOrNull { it.id == sessionId } ?: return
         viewModelScope.launch {
             val didExport = withContext(Dispatchers.IO) {
+                val session = runtime.chatRepository.getSessionWithMessages(sessionId) ?: return@withContext false
                 writeTextToUri(
                     uri = destinationUri,
                     text = JSONObject().apply {
@@ -1162,9 +1218,10 @@ class AetherViewModel(
         val snapshot = _uiState.value
         viewModelScope.launch {
             val didExport = withContext(Dispatchers.IO) {
+                val sessions = runtime.chatRepository.getSessionsWithMessages()
                 writeTextToUri(
                     uri = destinationUri,
-                    text = buildFullAppExportJson(snapshot).toString(2),
+                    text = buildFullAppExportJson(snapshot, sessions).toString(2),
                 )
             }
             emitTransientMessage(uiString(if (didExport) R.string.message_app_data_exported else R.string.message_app_data_export_failed))
@@ -2676,9 +2733,74 @@ class AetherViewModel(
 
     private fun persistCurrentSessionId(sessionId: String) {
         chatStateStore.update { persisted ->
-            persisted.copy(currentSessionId = sessionId)
+            persisted.copy(
+                sessions = persisted.sessions.withMessagesOnlyForSession(sessionId),
+                currentSessionId = sessionId,
+            )
         }
     }
+
+    private suspend fun hydrateCurrentSessionMessages(persisted: PersistedChatState): PersistedChatState {
+        val currentSessionId = persisted.currentSessionId.ifBlank { DraftSessionId }
+        if (currentSessionId == DraftSessionId) return persisted
+        val currentSession = persisted.sessions.firstOrNull { it.id == currentSessionId } ?: return persisted
+        if (currentSession.messages.isNotEmpty() || currentSession.messageCount <= 0) return persisted
+        val loadedSession = runCatching {
+            withContext(Dispatchers.IO) {
+                runtime.chatRepository.getSessionWithMessages(currentSessionId)
+            }
+        }.getOrElse { throwable ->
+            if (throwable is CancellationException) throw throwable
+            diagnosticLogger.exception(
+                category = "storage",
+                event = "session_hydration_failed",
+                throwable = throwable,
+                level = "warn",
+                sessionId = currentSessionId,
+            )
+            null
+        } ?: return persisted
+        return persisted.copy(
+            sessions = replaceOrPrependSession(persisted.sessions, loadedSession),
+        )
+    }
+
+    private fun persistSessionSelection(
+        sessionId: String,
+        loadedSession: ChatSession?,
+    ) {
+        if (loadedSession == null) {
+            persistCurrentSessionId(sessionId)
+            return
+        }
+        chatStateStore.update { persisted ->
+            persisted.copy(
+                sessions = replaceOrPrependSession(persisted.sessions, loadedSession)
+                    .withMessagesOnlyForSession(sessionId),
+                currentSessionId = sessionId,
+            )
+        }
+    }
+
+    private fun replaceOrPrependSession(
+        sessions: List<ChatSession>,
+        session: ChatSession,
+    ): List<ChatSession> = if (sessions.any { it.id == session.id }) {
+        sessions.map { existing ->
+            if (existing.id == session.id) session else existing
+        }
+    } else {
+        listOf(session) + sessions
+    }
+
+    private fun List<ChatSession>.withMessagesOnlyForSession(sessionId: String): List<ChatSession> =
+        map { session ->
+            if (session.id == sessionId) {
+                session
+            } else {
+                session.copy(messages = emptyList())
+            }
+        }
 
     private fun replacePersistedChats(
         sessions: List<ChatSession>,
@@ -3125,6 +3247,8 @@ class AetherViewModel(
             title = if (hasCustomTitle) title else metadata.title,
             preview = metadata.preview,
             messages = syncedMessages,
+            messageCount = syncedMessages.size,
+            lastMessageAtMillis = syncedMessages.maxOfOrNull { it.createdAtMillis },
         )
     }
 
@@ -4070,15 +4194,15 @@ class AetherViewModel(
                 "recentSessions",
                 JSONArray().apply {
                     snapshot.sessions
-                        .sortedByDescending { session -> session.messages.maxOfOrNull { it.createdAtMillis } ?: 0L }
+                        .sortedByDescending { session -> session.lastMessageAtMillis ?: 0L }
                         .take(12)
                         .forEach { session ->
                             put(
                                 JSONObject().apply {
                                     put("id", session.id)
                                     put("title", session.title)
-                                    put("messageCount", session.messages.size)
-                                    put("lastMessageAtMillis", session.messages.maxOfOrNull { it.createdAtMillis } ?: 0L)
+                                    put("messageCount", session.messageCount)
+                                    put("lastMessageAtMillis", session.lastMessageAtMillis ?: 0L)
                                     put("selectedModelKey", session.selectedModelKey)
                                     put("selectedSkillCount", session.selectedSkillIds.size)
                                     put("activeMcpServerCount", session.activeMcpServerIds.size)
@@ -4161,14 +4285,17 @@ class AetherViewModel(
         }
     }
 
-    private fun buildFullAppExportJson(snapshot: AetherUiState): JSONObject =
+    private fun buildFullAppExportJson(
+        snapshot: AetherUiState,
+        sessions: List<ChatSession>,
+    ): JSONObject =
         JSONObject().apply {
             put("schemaVersion", 2)
             put("exportType", "app")
             put("exportedAtMillis", System.currentTimeMillis())
             put("settings", snapshot.settings.toJson())
             put("providerConfigs", JSONArray(serializeProviderConfigs(snapshot.providerConfigs)))
-            put("sessions", JSONArray(serializeChatSessions(snapshot.sessions.map { it.copy(activeSkills = emptyList()) })))
+            put("sessions", JSONArray(serializeChatSessions(sessions.map { it.copy(activeSkills = emptyList()) })))
             put("currentSessionId", snapshot.currentSessionId)
             put("skillBundles", skillManager.exportSkillBundles(snapshot.installedSkills))
             put("mcpServers", JSONArray(serializeMcpServerConfigs(snapshot.mcpServers)))

--- a/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/SettingsScreen.kt
@@ -136,6 +136,7 @@ import com.zhousl.aether.data.AgentModeAuthorizationState
 import com.zhousl.aether.data.AgentModeDisplayState
 import com.zhousl.aether.data.AgentWorkspaceMode
 import com.zhousl.aether.data.AutomaticModelPurpose
+import com.zhousl.aether.data.ChatUsageStatisticsSnapshot
 import com.zhousl.aether.data.AppLanguage
 import com.zhousl.aether.data.AppThemeMode
 import com.zhousl.aether.data.LlmProvider
@@ -406,7 +407,7 @@ fun SettingsScreen(
     defaultCompactingModelKey: String,
     agentModeDisplayState: AgentModeDisplayState,
     providerConfigs: List<LlmProviderConfig>,
-    sessions: List<ChatSession>,
+    usageStatisticsSnapshots: List<ChatUsageStatisticsSnapshot>,
     scheduledTasks: List<ScheduledTask>,
     termuxSetupState: TermuxSetupState,
     alpineSetupState: LocalRuntimeSetupState,
@@ -793,7 +794,7 @@ fun SettingsScreen(
                 skillCount = installedSkills.size,
                 mcpServerCount = mcpServers.size,
                 scheduledTaskCount = scheduledTasks.size,
-                statisticsSummary = buildSettingsStatisticsSummary(sessions),
+                statisticsSummary = buildSettingsStatisticsSummary(usageStatisticsSnapshots),
                 onReplayOnboarding = ::persistAndReplayOnboarding,
                 onNavigate = { page ->
                     if (page == SettingsPage.AgentMode && !termuxSetupState.isReady) {
@@ -1142,7 +1143,7 @@ fun SettingsScreen(
 
             SettingsPage.Statistics -> StatisticsSettingsPage(
                 title = stringResource(R.string.settings_statistics),
-                sessions = sessions,
+                usageStatisticsSnapshots = usageStatisticsSnapshots,
                 onBack = { currentPage = SettingsPage.Hub.name },
             )
 
@@ -1404,10 +1405,10 @@ private fun SettingsHub(
 @Composable
 private fun StatisticsSettingsPage(
     title: String,
-    sessions: List<ChatSession>,
+    usageStatisticsSnapshots: List<ChatUsageStatisticsSnapshot>,
     onBack: () -> Unit,
 ) {
-    val report = remember(sessions) { buildUsageStatisticsReport(sessions) }
+    val report = remember(usageStatisticsSnapshots) { buildUsageStatisticsReport(usageStatisticsSnapshots) }
     SubPageScaffold(title = title, onBack = onBack) {
         SettingsCardGroup {
             Column(
@@ -1909,8 +1910,10 @@ private fun HistoryPeakRow(
 }
 
 @Composable
-private fun buildSettingsStatisticsSummary(sessions: List<ChatSession>): String {
-    val report = buildUsageStatisticsReport(sessions)
+private fun buildSettingsStatisticsSummary(
+    usageStatisticsSnapshots: List<ChatUsageStatisticsSnapshot>,
+): String {
+    val report = buildUsageStatisticsReport(usageStatisticsSnapshots)
     return if (report.turnCount == 0) {
         ""
     } else {
@@ -1922,9 +1925,10 @@ private fun buildSettingsStatisticsSummary(sessions: List<ChatSession>): String 
     }
 }
 
-private fun buildUsageStatisticsReport(sessions: List<ChatSession>): UsageStatisticsReport {
-    val usageMessages = sessions.flatMap { it.messages }.filter { it.usageStatistics != null }
-    val stats = usageMessages.mapNotNull { it.usageStatistics }
+private fun buildUsageStatisticsReport(
+    usageStatisticsSnapshots: List<ChatUsageStatisticsSnapshot>,
+): UsageStatisticsReport {
+    val stats = usageStatisticsSnapshots.map { it.statistics }
     val zone = ZoneId.systemDefault()
     val today = LocalDate.now(zone)
     val daily = (13 downTo 0).map { daysAgo ->
@@ -1961,7 +1965,7 @@ private fun buildUsageStatisticsReport(sessions: List<ChatSession>): UsageStatis
         inputTokens = stats.sumOf { it.inputTokens ?: 0L },
         outputTokens = stats.sumOf { it.outputTokens ?: 0L },
         reasoningTokens = stats.sumOf { it.reasoningTokens ?: 0L },
-        sessionCount = sessions.count { session -> session.messages.any { it.usageStatistics != null } },
+        sessionCount = usageStatisticsSnapshots.map { it.sessionId }.distinct().size,
         turnCount = stats.size,
         dailyTokenUsage = daily,
         peakDay = daily.maxByOrNull { it.tokens }?.takeIf { it.tokens > 0L },

--- a/app/src/test/java/com/zhousl/aether/data/QueuedTurnRequestBuilderTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/QueuedTurnRequestBuilderTest.kt
@@ -1,0 +1,51 @@
+package com.zhousl.aether.data
+
+import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.ChatSession
+import com.zhousl.aether.ui.MessageAuthor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QueuedTurnRequestBuilderTest {
+    @Test
+    fun queuedTurnUsesBaseMessagesForMetadataOnlySession() {
+        val existingMessages = listOf(
+            ChatMessage(
+                id = "user-1",
+                author = MessageAuthor.User,
+                text = "First",
+                createdAtMillis = 1L,
+            ),
+            ChatMessage(
+                id = "agent-1",
+                author = MessageAuthor.Agent,
+                text = "Reply",
+                createdAtMillis = 2L,
+            ),
+        )
+        val metadataOnlySession = ChatSession(
+            id = "session-1",
+            title = "Existing",
+            preview = "Reply",
+            messages = emptyList(),
+            messageCount = existingMessages.size,
+            lastMessageAtMillis = 2L,
+        )
+        val queuedInput = ChatMessage(
+            id = "user-2",
+            author = MessageAuthor.User,
+            text = "Follow up",
+            createdAtMillis = 3L,
+        )
+
+        val updated = buildQueuedTurnSession(
+            session = metadataOnlySession,
+            queuedInput = queuedInput,
+            baseMessages = existingMessages,
+        )
+
+        assertEquals(listOf("user-1", "agent-1", "user-2"), updated.messages.map { it.id })
+        assertEquals(3, updated.messageCount)
+        assertEquals(3L, updated.lastMessageAtMillis)
+    }
+}


### PR DESCRIPTION
## Summary

- Keep historical sessions metadata-only during normal state restoration to avoid loading every message into UI state.
- Hydrate full messages on demand for the active session, selected sessions, scheduled tasks, exports, and Settings statistics.
- Move Settings usage statistics to a dedicated Room-backed snapshot query instead of relying on `uiState.sessions[*].messages`.
- Add an indexed `hasUsageStatistics` column with Room v2→v3 migration/schema so usage statistics no longer require scanning message JSON.
- Harden session hydration with transaction-consistent reads and defensive error logging.
- Preserve local-only session messages and in-memory session metadata while merging repository-backed state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now displays refreshed usage-statistics snapshots, and the Statistics summary is recalculated from stored usage data.
  * Exports are improved to better include sessions/messages for more complete backups and diagnostics.
* **Bug Fixes**
  * Improved chat history restoration and session hydration: metadata-only sessions now correctly retain/extend existing messages when needed.
  * Recent-session details now show more accurate message counts and last-activity times.
* **Tests**
  * Added a new test to verify queued turns correctly use base messages for metadata-only sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->