### PR TITLE
fix: download GitHub archive skill URLs directly

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/AgentSkillManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AgentSkillManager.kt
@@ -472,50 +472,6 @@ class AgentSkillManager(
         }
     }
 
-    private fun resolveRemoteDownloadPlan(rawUrl: String): RemoteDownloadPlan {
-        val url = rawUrl.trim().ifBlank { error("A remote skill URL is required.") }
-        val httpUrl = url.toHttpUrlOrNull() ?: error("Skill URL is not a valid absolute URL.")
-        if (httpUrl.encodedPath.lowercase(Locale.US).endsWith(".zip")) {
-            return RemoteDownloadPlan(
-                kind = SkillInstallKind.RemoteZip,
-                downloadUrl = httpUrl.toString(),
-            )
-        }
-        if (httpUrl.host.equals("github.com", ignoreCase = true)) {
-            val segments = httpUrl.pathSegments.filter { it.isNotBlank() }
-            require(segments.size >= 2) { "GitHub URL must include owner and repository." }
-            val owner = segments[0]
-            val repository = segments[1].removeSuffix(".git")
-            if (segments.size >= 4 && segments[2] == "tree") {
-                val ref = segments[3]
-                val subpath = segments.drop(4).joinToString("/")
-                return RemoteDownloadPlan(
-                    kind = SkillInstallKind.GitHub,
-                    downloadUrl = "https://api.github.com/repos/$owner/$repository/zipball/$ref",
-                    ref = ref,
-                    subpath = subpath,
-                )
-            }
-            return RemoteDownloadPlan(
-                kind = SkillInstallKind.GitHub,
-                downloadUrl = "https://api.github.com/repos/$owner/$repository/zipball",
-            )
-        }
-        require(isGitHubCodeloadZipUrl(httpUrl.host, httpUrl.pathSegments)) {
-            "Remote skill URL must be a GitHub repository/tree URL or a direct .zip file."
-        }
-        return RemoteDownloadPlan(
-            kind = SkillInstallKind.RemoteZip,
-            downloadUrl = httpUrl.toString(),
-        )
-    }
-
-    private fun isGitHubCodeloadZipUrl(
-        host: String,
-        pathSegments: List<String>,
-    ): Boolean = host.equals("codeload.github.com", ignoreCase = true) &&
-        pathSegments.getOrNull(2)?.equals("zip", ignoreCase = true) == true
-
     private fun downloadZipIntoDirectory(
         url: String,
         destinationRoot: File,
@@ -766,7 +722,52 @@ private data class ParsedSkillDocument(
     val diagnostics: List<String>,
 )
 
-private data class RemoteDownloadPlan(
+internal fun resolveRemoteDownloadPlan(rawUrl: String): RemoteDownloadPlan {
+    val url = rawUrl.trim().ifBlank { error("A remote skill URL is required.") }
+    val httpUrl = url.toHttpUrlOrNull() ?: error("Skill URL is not a valid absolute URL.")
+    val isZipPath = httpUrl.encodedPath.lowercase(Locale.US).endsWith(".zip")
+    if (httpUrl.host.equals("github.com", ignoreCase = true)) {
+        val segments = httpUrl.pathSegments.filter { it.isNotBlank() }
+        require(segments.size >= 2) { "GitHub URL must include owner and repository." }
+        val owner = segments[0]
+        val repository = segments[1].removeSuffix(".git")
+        if (segments.size >= 4 && segments[2] == "tree") {
+            val ref = segments[3]
+            val subpath = segments.drop(4).joinToString("/")
+            return RemoteDownloadPlan(
+                kind = SkillInstallKind.GitHub,
+                downloadUrl = "https://api.github.com/repos/$owner/$repository/zipball/$ref",
+                ref = ref,
+                subpath = subpath,
+            )
+        }
+        if (isZipPath) {
+            return RemoteDownloadPlan(
+                kind = SkillInstallKind.RemoteZip,
+                downloadUrl = httpUrl.toString(),
+            )
+        }
+        return RemoteDownloadPlan(
+            kind = SkillInstallKind.GitHub,
+            downloadUrl = "https://api.github.com/repos/$owner/$repository/zipball",
+        )
+    }
+    require(isZipPath || isGitHubCodeloadZipUrl(httpUrl.host, httpUrl.pathSegments)) {
+        "Remote skill URL must be a GitHub repository/tree URL or a direct .zip file."
+    }
+    return RemoteDownloadPlan(
+        kind = SkillInstallKind.RemoteZip,
+        downloadUrl = httpUrl.toString(),
+    )
+}
+
+private fun isGitHubCodeloadZipUrl(
+    host: String,
+    pathSegments: List<String>,
+): Boolean = host.equals("codeload.github.com", ignoreCase = true) &&
+    pathSegments.getOrNull(2)?.equals("zip", ignoreCase = true) == true
+
+internal data class RemoteDownloadPlan(
     val kind: SkillInstallKind,
     val downloadUrl: String,
     val ref: String = "",

--- a/app/src/main/java/com/zhousl/aether/data/AgentSkillManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/AgentSkillManager.kt
@@ -475,6 +475,12 @@ class AgentSkillManager(
     private fun resolveRemoteDownloadPlan(rawUrl: String): RemoteDownloadPlan {
         val url = rawUrl.trim().ifBlank { error("A remote skill URL is required.") }
         val httpUrl = url.toHttpUrlOrNull() ?: error("Skill URL is not a valid absolute URL.")
+        if (httpUrl.encodedPath.lowercase(Locale.US).endsWith(".zip")) {
+            return RemoteDownloadPlan(
+                kind = SkillInstallKind.RemoteZip,
+                downloadUrl = httpUrl.toString(),
+            )
+        }
         if (httpUrl.host.equals("github.com", ignoreCase = true)) {
             val segments = httpUrl.pathSegments.filter { it.isNotBlank() }
             require(segments.size >= 2) { "GitHub URL must include owner and repository." }
@@ -495,7 +501,7 @@ class AgentSkillManager(
                 downloadUrl = "https://api.github.com/repos/$owner/$repository/zipball",
             )
         }
-        require(httpUrl.encodedPath.lowercase(Locale.US).endsWith(".zip")) {
+        require(isGitHubCodeloadZipUrl(httpUrl.host, httpUrl.pathSegments)) {
             "Remote skill URL must be a GitHub repository/tree URL or a direct .zip file."
         }
         return RemoteDownloadPlan(
@@ -503,6 +509,12 @@ class AgentSkillManager(
             downloadUrl = httpUrl.toString(),
         )
     }
+
+    private fun isGitHubCodeloadZipUrl(
+        host: String,
+        pathSegments: List<String>,
+    ): Boolean = host.equals("codeload.github.com", ignoreCase = true) &&
+        pathSegments.getOrNull(2)?.equals("zip", ignoreCase = true) == true
 
     private fun downloadZipIntoDirectory(
         url: String,

--- a/app/src/test/java/com/zhousl/aether/data/AgentSkillManagerTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/AgentSkillManagerTest.kt
@@ -1,0 +1,41 @@
+package com.zhousl.aether.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AgentSkillManagerTest {
+    @Test
+    fun keepsGitHubArchiveZipUrlAsDirectDownload() {
+        val url = "https://github.com/owner/repository/archive/refs/heads/main.zip"
+
+        val plan = resolveRemoteDownloadPlan(url)
+
+        assertEquals(SkillInstallKind.RemoteZip, plan.kind)
+        assertEquals(url, plan.downloadUrl)
+    }
+
+    @Test
+    fun acceptsGitHubCodeloadZipUrl() {
+        val url = "https://codeload.github.com/owner/repository/zip/refs/heads/main"
+
+        val plan = resolveRemoteDownloadPlan(url)
+
+        assertEquals(SkillInstallKind.RemoteZip, plan.kind)
+        assertEquals(url, plan.downloadUrl)
+    }
+
+    @Test
+    fun keepsGitHubTreeUrlWhenSubpathEndsWithZip() {
+        val plan = resolveRemoteDownloadPlan(
+            "https://github.com/owner/repository/tree/main/skills/example.zip",
+        )
+
+        assertEquals(SkillInstallKind.GitHub, plan.kind)
+        assertEquals(
+            "https://api.github.com/repos/owner/repository/zipball/main",
+            plan.downloadUrl,
+        )
+        assertEquals("main", plan.ref)
+        assertEquals("skills/example.zip", plan.subpath)
+    }
+}


### PR DESCRIPTION
- Avoid rewriting archive .zip URLs to GitHub API zipball downloads
- Accept codeload.github.com zip archive URLs from GitHub redirects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded handling of remote ZIP archive URLs, including direct `.zip` links and additional GitHub URL formats (such as `codeload` and specific `/tree/...` archive references).
* **Bug Fixes**
  * Improved URL validation and download-plan selection to ensure the correct download target and paths are derived from supported GitHub patterns.
* **Tests**
  * Added unit coverage for the supported GitHub ZIP URL variations to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->