### PR TITLE
feat(provider): add custom base url configuration

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/PiProviderCatalog.kt
+++ b/app/src/main/java/com/zhousl/aether/data/PiProviderCatalog.kt
@@ -34,6 +34,7 @@ data class PiProviderDefinition(
     val supportsOAuth: Boolean = false,
     val supportsAmbientAuth: Boolean = false,
     val requiresBaseUrl: Boolean = false,
+    val supportsCustomBaseUrl: Boolean = false,
     val isBuiltIn: Boolean = true,
     val category: String = "Other",
 )
@@ -44,9 +45,24 @@ const val DefaultCustomModelId = "gpt-5.4"
 
 object PiProviderCatalog {
     val providers: List<PiProviderDefinition> = listOf(
-        builtin("openai", "OpenAI", "https://api.openai.com/v1", "gpt-5.4", category = "Recommended"),
+        builtin(
+            "openai",
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5.4",
+            supportsCustomBaseUrl = true,
+            category = "Recommended",
+        ),
         builtin("openai-codex", "OpenAI Codex", "https://chatgpt.com/backend-api", "gpt-5.3-codex-spark", supportsApiKey = false, supportsOAuth = true, category = "Recommended"),
-        builtin("anthropic", "Anthropic", "https://api.anthropic.com", "claude-sonnet-4-5", supportsOAuth = true, category = "Recommended"),
+        builtin(
+            "anthropic",
+            "Anthropic",
+            "https://api.anthropic.com",
+            "claude-sonnet-4-5",
+            supportsOAuth = true,
+            supportsCustomBaseUrl = true,
+            category = "Recommended",
+        ),
         builtin("google", "Google", "https://generativelanguage.googleapis.com/v1beta", "gemini-2.5-flash", category = "Recommended"),
         builtin("google-vertex", "Google Vertex AI", "", "gemini-2.5-flash", supportsInteractiveApiKey = false, supportsAmbientAuth = true, category = "Recommended"),
         builtin("github-copilot", "GitHub Copilot", "https://api.individual.githubcopilot.com", "gpt-5.4", supportsOAuth = true, category = "Recommended"),
@@ -122,6 +138,7 @@ private fun builtin(
     supportsOAuth: Boolean = false,
     supportsAmbientAuth: Boolean = false,
     requiresBaseUrl: Boolean = false,
+    supportsCustomBaseUrl: Boolean = false,
     category: String,
 ): PiProviderDefinition = PiProviderDefinition(
     id = id,
@@ -133,6 +150,7 @@ private fun builtin(
     supportsOAuth = supportsOAuth,
     supportsAmbientAuth = supportsAmbientAuth,
     requiresBaseUrl = requiresBaseUrl,
+    supportsCustomBaseUrl = supportsCustomBaseUrl,
     category = category,
 )
 

--- a/app/src/main/java/com/zhousl/aether/data/ProviderModelCatalogClient.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ProviderModelCatalogClient.kt
@@ -41,7 +41,7 @@ object ProviderModelCatalogClient {
             val definition = PiProviderCatalog.resolve(
                 config.piProviderId,
             )
-            if (definition.isBuiltIn) {
+            if (definition.isBuiltIn && !config.usesCustomOpenAiCompatibleBaseUrl()) {
                 return@withContext fetchPiBuiltinModels(
                     definition = definition,
                     piKernelBridge = piKernelBridge,
@@ -114,6 +114,13 @@ object ProviderModelCatalogClient {
             )
         }
         return FetchModelsResult(emptyList(), "Provider ${definition.id} is unavailable.")
+    }
+
+    private fun LlmProviderConfig.usesCustomOpenAiCompatibleBaseUrl(): Boolean {
+        val normalizedBaseUrl = baseUrl.trim().trimEnd('/')
+        return piProviderId == "openai" &&
+            normalizedBaseUrl.isNotBlank() &&
+            normalizedBaseUrl != PiProviderCatalog.resolve("openai").defaultBaseUrl
     }
 
     private fun fetchOpenAiModels(config: LlmProviderConfig): FetchModelsResult {

--- a/app/src/main/java/com/zhousl/aether/ui/ProviderConfigForm.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/ProviderConfigForm.kt
@@ -534,11 +534,9 @@ fun ProviderConfigurationForm(
         }
 
         ProviderFormCard(cardColor = cardColor) {
-            ProviderFormTextField(
-                label = stringResource(R.string.provider_form_base_url),
-                value = state.baseUrl,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                onValueChange = { state.baseUrl = it },
+            ProviderBaseUrlField(
+                state = state,
+                definition = selectedDefinition,
             )
             ProviderFormDivider()
             ProviderFormTextField(
@@ -721,27 +719,46 @@ fun ProviderAuthenticationSetup(
                             onValueChange = { state.apiKey = it },
                             isSecret = true,
                         )
+                        if (definition.supportsCustomBaseUrl) {
+                            ProviderFormDivider()
+                            ProviderBaseUrlField(
+                                state = state,
+                                definition = definition,
+                                resetToDefaultWhenBlank = true,
+                            )
+                        }
                     }
                 }
             }
 
-            ProviderAuthMethod.OAuth -> ProviderOAuthField(
-                definition = definition,
-                credentialJson = state.oauthCredentialJson,
-                oauthState = relevantAuthState,
-                onStartOAuthLogin = { flow ->
-                    onClearAuthState()
-                    onStartProviderLogin(state.buildConfig().id, definition.id, ProviderAuthMethod.OAuth, flow)
-                },
-                onDisconnect = {
-                    state.oauthCredentialJson = ""
-                    onClearAuthState()
-                },
-                onCopyDeviceCode = { code ->
-                    clipboardManager.setText(AnnotatedString(code))
-                },
-                cardColor = cardColor,
-            )
+            ProviderAuthMethod.OAuth -> {
+                ProviderOAuthField(
+                    definition = definition,
+                    credentialJson = state.oauthCredentialJson,
+                    oauthState = relevantAuthState,
+                    onStartOAuthLogin = { flow ->
+                        onClearAuthState()
+                        onStartProviderLogin(state.buildConfig().id, definition.id, ProviderAuthMethod.OAuth, flow)
+                    },
+                    onDisconnect = {
+                        state.oauthCredentialJson = ""
+                        onClearAuthState()
+                    },
+                    onCopyDeviceCode = { code ->
+                        clipboardManager.setText(AnnotatedString(code))
+                    },
+                    cardColor = cardColor,
+                )
+                if (definition.supportsCustomBaseUrl) {
+                    ProviderFormCard(cardColor = cardColor) {
+                        ProviderBaseUrlField(
+                            state = state,
+                            definition = definition,
+                            resetToDefaultWhenBlank = true,
+                        )
+                    }
+                }
+            }
 
             ProviderAuthMethod.Ambient -> ProviderFormCard(cardColor = cardColor) {
                 ProviderEnvironmentVariablesField(
@@ -753,13 +770,11 @@ fun ProviderAuthenticationSetup(
             }
         }
 
-        if (definition.requiresBaseUrl || !definition.isBuiltIn) {
+        if (definition.requiresBaseUrl || (!definition.isBuiltIn && !definition.supportsCustomBaseUrl)) {
             ProviderFormCard(cardColor = cardColor) {
-                ProviderFormTextField(
-                    label = stringResource(R.string.provider_form_base_url),
-                    value = state.baseUrl,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                    onValueChange = { state.baseUrl = it },
+                ProviderBaseUrlField(
+                    state = state,
+                    definition = definition,
                 )
             }
         }
@@ -1190,11 +1205,9 @@ fun AddProviderWizard(
                         )
                         if (!state.selectedDefinition.requiresBaseUrl && state.selectedDefinition.isBuiltIn) {
                             ProviderFormDivider()
-                            ProviderFormTextField(
-                                label = stringResource(R.string.provider_form_base_url),
-                                value = state.baseUrl,
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                                onValueChange = { state.baseUrl = it },
+                            ProviderBaseUrlField(
+                                state = state,
+                                definition = state.selectedDefinition,
                             )
                         }
                         ProviderFormDivider()
@@ -1492,6 +1505,26 @@ private fun ProviderFormCard(
 @Composable
 private fun ProviderFormDivider() {
     Spacer(modifier = Modifier.height(8.dp))
+}
+
+@Composable
+private fun ProviderBaseUrlField(
+    state: ProviderFormState,
+    definition: PiProviderDefinition,
+    resetToDefaultWhenBlank: Boolean = false,
+) {
+    ProviderFormTextField(
+        label = stringResource(R.string.provider_form_base_url),
+        value = state.baseUrl,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+        onValueChange = { value ->
+            state.baseUrl = if (resetToDefaultWhenBlank) {
+                value.ifBlank { definition.defaultBaseUrl }
+            } else {
+                value
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/test/java/com/zhousl/aether/data/ProviderModelCatalogClientTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ProviderModelCatalogClientTest.kt
@@ -101,4 +101,34 @@ class ProviderModelCatalogClientTest {
         assertEquals(null, result.error)
         assertEquals(listOf("gemini-2.5-flash"), result.models)
     }
+
+    @Test
+    fun customOpenAiBaseUrlFetchesModelsFromConfiguredEndpoint() = runBlocking {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"data":[{"id":"third-party-model"}]}""")
+        )
+        server.start()
+
+        try {
+            val result = ProviderModelCatalogClient.fetchModels(
+                LlmProviderConfig(
+                    providerId = "custom-openai",
+                    name = "Custom OpenAI",
+                    piProviderId = "openai",
+                    apiKey = "test-key",
+                    baseUrl = server.url("/v1").toString(),
+                    modelId = "",
+                )
+            )
+
+            assertEquals(null, result.error)
+            assertEquals(listOf("third-party-model"), result.models)
+            assertEquals("/v1/models", server.takeRequest().path)
+        } finally {
+            server.shutdown()
+        }
+    }
 }

--- a/pi-bridge/src/bridge.ts
+++ b/pi-bridge/src/bridge.ts
@@ -73,6 +73,7 @@ const AETHER_MANUAL_OAUTH_CALLBACK_HOST = "203.0.113.1";
 const OAUTH_FETCH_MAX_ATTEMPTS = 3;
 const DEFAULT_HARNESS_SESSION_LIMIT = 8;
 const DEFAULT_HARNESS_SESSION_TTL_MS = 30 * 60 * 1000;
+const CUSTOM_BASE_URL_BUILTIN_PROVIDER_IDS = new Set(["openai", "anthropic"]);
 
 type JsonObject = Record<string, unknown>;
 
@@ -611,6 +612,10 @@ function createAetherModel(config: ModelConfig): Model<string> {
   };
 }
 
+function normalizedBaseUrl(value: string | undefined): string {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
 function buildModels(config: ModelConfig): {
   models: MutableModels;
   model: Model<string>;
@@ -654,8 +659,14 @@ function buildModels(config: ModelConfig): {
   if (config.provider_type === "builtin") {
     const provider = builtinProviderById.get(config.pi_provider_id);
     if (!provider) throw new Error(`Unknown built-in Pi provider: ${config.pi_provider_id}`);
-    const builtinModel = provider.getModels().find((candidate) => candidate.id === config.model_id);
-    if (!builtinModel) {
+    const providerModels = provider.getModels();
+    const builtinModel = providerModels.find((candidate) => candidate.id === config.model_id);
+    const providerBaseUrl = provider.baseUrl ?? providerModels[0]?.baseUrl;
+    const usesCustomBaseUrl =
+      CUSTOM_BASE_URL_BUILTIN_PROVIDER_IDS.has(provider.id) &&
+      normalizedBaseUrl(config.base_url) !== normalizedBaseUrl(providerBaseUrl);
+    const modelTemplate = builtinModel ?? (usesCustomBaseUrl ? providerModels[0] : undefined);
+    if (!modelTemplate) {
       throw new Error(
         `Unknown model ${config.model_id} for built-in Pi provider ${config.pi_provider_id}.`,
       );
@@ -671,10 +682,25 @@ function buildModels(config: ModelConfig): {
     });
     models.setProvider(provider);
     const model = {
-      ...builtinModel,
+      ...modelTemplate,
+      ...(builtinModel
+        ? {}
+        : {
+            id: config.model_id,
+            name: config.model_id,
+            reasoning: config.reasoning ?? false,
+            contextWindow: config.context_window ?? 128000,
+            maxTokens: config.max_tokens ?? 16384,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+          }),
       ...(config.base_url ? { baseUrl: config.base_url } : {}),
       headers: {
-        ...builtinModel.headers,
+        ...modelTemplate.headers,
         ...config.custom_headers,
       },
     } as Model<string>;

--- a/pi-bridge/tests/bridge.test.mjs
+++ b/pi-bridge/tests/bridge.test.mjs
@@ -783,6 +783,73 @@ test("maps a custom OpenAI-compatible provider through Pi", async (t) => {
   assert.equal(receivedRequest.body.model, "custom-model");
 });
 
+test("uses the OpenAI native protocol for custom base URL models outside the built-in catalog", async (t) => {
+  let receivedRequest;
+  const server = createServer((request, response) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => {
+      receivedRequest = {
+        url: request.url,
+        authorization: request.headers.authorization,
+        customHeader: request.headers["x-aether-test"],
+        body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+      };
+      response.writeHead(400, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "expected test failure" } }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  const client = new BridgeClient();
+  const result = await client.request("custom-openai-native", "complete_once", {
+    model_config: {
+      provider_type: "builtin",
+      provider_config_id: "custom-openai-native",
+      pi_provider_id: "openai",
+      pi_api: "builtin",
+      model_id: "third-party-model",
+      base_url: `http://127.0.0.1:${address.port}/v1`,
+      api_key: "secret-key",
+      custom_headers: { "X-Aether-Test": "present" },
+      reasoning: false,
+      max_retries: 0,
+    },
+    system_prompt: "Reply briefly.",
+    messages: [userMessage("hello")],
+    stream: false,
+  });
+
+  assert.match(result.error_message, /expected test failure|400/);
+  assert.equal(receivedRequest.url, "/v1/responses");
+  assert.equal(receivedRequest.authorization, "Bearer secret-key");
+  assert.equal(receivedRequest.customHeader, "present");
+  assert.equal(receivedRequest.body.model, "third-party-model");
+});
+
+test("rejects unknown built-in models when the provider uses its default base URL", async () => {
+  const client = new BridgeClient();
+  await assert.rejects(
+    client.request("unknown-default-openai", "complete_once", {
+      model_config: {
+        provider_type: "builtin",
+        provider_config_id: "unknown-default-openai",
+        pi_provider_id: "openai",
+        pi_api: "builtin",
+        model_id: "third-party-model",
+        base_url: "https://api.openai.com/v1",
+        api_key: "secret-key",
+      },
+      messages: [userMessage("hello")],
+      stream: false,
+    }),
+    /Unknown model third-party-model/,
+  );
+});
+
 test("lists every built-in Pi provider and its model catalog", async () => {
   const client = new BridgeClient();
   const catalog = await client.request("providers", "list_providers");


### PR DESCRIPTION
- Allow compatible third-party endpoints in the Configure credentials flow
- Preserve native provider protocols for configured base URLs
- Refresh models from custom OpenAI-compatible endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom base URL support for select built-in providers, including OpenAI and Anthropic.
  * Updated the provider setup, wizard, and configuration UI to use a dedicated base URL field where supported.
  * Clearing a supported base URL can restore the provider’s default endpoint.

* **Bug Fixes**
  * Model discovery now fetches from the configured custom OpenAI-compatible endpoint when applicable.
  * Improved bridge handling for built-in custom-base models and stricter behavior for unknown default built-in models.

* **Tests**
  * Added coverage for custom base URL model fetching and bridge request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->