### PR TITLE
fix(pi): stream bridge requests to avoid oom

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/pi/PiBridgeProtocol.kt
+++ b/app/src/main/java/com/zhousl/aether/data/pi/PiBridgeProtocol.kt
@@ -1,6 +1,5 @@
 package com.zhousl.aether.data.pi
 
-import android.util.JsonWriter
 import java.io.StringWriter
 import java.io.Writer
 import org.json.JSONArray
@@ -56,44 +55,88 @@ data class PiBridgeRequest(
     }
 
     private fun writeJson(writer: Writer) {
-        JsonWriter(writer).apply {
-            beginObject()
-            name("id").value(id)
-            name("type").value(type)
-            name("payload")
-            writeJsonValue(payload)
-            endObject()
-            flush()
-        }
+        writer.write("{\"id\":")
+        writer.writeJsonString(id)
+        writer.write(",\"type\":")
+        writer.writeJsonString(type)
+        writer.write(",\"payload\":")
+        writer.writeJsonValue(payload)
+        writer.write("}")
     }
 }
 
-private fun JsonWriter.writeJsonValue(value: Any?) {
+private fun Writer.writeJsonValue(value: Any?) {
     when (value) {
-        null, JSONObject.NULL -> nullValue()
+        null, JSONObject.NULL -> write("null")
         is JSONObject -> {
-            beginObject()
+            write("{")
             val keys = value.keys()
+            var first = true
             while (keys.hasNext()) {
                 val key = keys.next()
-                name(key)
+                if (first) {
+                    first = false
+                } else {
+                    write(",")
+                }
+                writeJsonString(key)
+                write(":")
                 writeJsonValue(value.opt(key))
             }
-            endObject()
+            write("}")
         }
         is JSONArray -> {
-            beginArray()
+            write("[")
             for (index in 0 until value.length()) {
+                if (index > 0) write(",")
                 writeJsonValue(value.opt(index))
             }
-            endArray()
+            write("]")
         }
-        is String -> value(value)
-        is Number -> value(value)
-        is Boolean -> value(value)
-        else -> value(value.toString())
+        is String -> writeJsonString(value)
+        is Number -> write(JSONObject.numberToString(value))
+        is Boolean -> write(value.toString())
+        else -> writeJsonString(value.toString())
     }
 }
+
+private fun Writer.writeJsonString(value: String) {
+    write("\"")
+    var segmentStart = 0
+    value.forEachIndexed { index, character ->
+        val replacement = when (character) {
+            '"' -> "\\\""
+            '\\' -> "\\\\"
+            '\t' -> "\\t"
+            '\b' -> "\\b"
+            '\n' -> "\\n"
+            '\r' -> "\\r"
+            '\u000c' -> "\\f"
+            '\u2028' -> "\\u2028"
+            '\u2029' -> "\\u2029"
+            else -> null
+        }
+        if (replacement != null || character <= '\u001f') {
+            if (segmentStart < index) {
+                write(value, segmentStart, index - segmentStart)
+            }
+            if (replacement != null) {
+                write(replacement)
+            } else {
+                write("\\u00")
+                write(JSON_HEX_DIGITS[character.code shr 4].code)
+                write(JSON_HEX_DIGITS[character.code and 0x0f].code)
+            }
+            segmentStart = index + 1
+        }
+    }
+    if (segmentStart < value.length) {
+        write(value, segmentStart, value.length - segmentStart)
+    }
+    write("\"")
+}
+
+private const val JSON_HEX_DIGITS = "0123456789abcdef"
 
 class PiJsonlParser(
     private val onFrame: (PiBridgeFrame) -> Unit,

--- a/app/src/main/java/com/zhousl/aether/data/pi/PiBridgeProtocol.kt
+++ b/app/src/main/java/com/zhousl/aether/data/pi/PiBridgeProtocol.kt
@@ -1,5 +1,9 @@
 package com.zhousl.aether.data.pi
 
+import android.util.JsonWriter
+import java.io.StringWriter
+import java.io.Writer
+import org.json.JSONArray
 import org.json.JSONObject
 
 data class PiBridgeFrame(
@@ -40,11 +44,55 @@ data class PiBridgeRequest(
     val type: String,
     val payload: JSONObject = JSONObject(),
 ) {
-    fun toJsonLine(): String = JSONObject().apply {
-        put("id", id)
-        put("type", type)
-        put("payload", payload)
-    }.toString()
+    fun toJsonLine(): String {
+        val writer = StringWriter()
+        writeJson(writer)
+        return writer.toString()
+    }
+
+    fun writeJsonLine(writer: Writer) {
+        writeJson(writer)
+        writer.write("\n")
+    }
+
+    private fun writeJson(writer: Writer) {
+        JsonWriter(writer).apply {
+            beginObject()
+            name("id").value(id)
+            name("type").value(type)
+            name("payload")
+            writeJsonValue(payload)
+            endObject()
+            flush()
+        }
+    }
+}
+
+private fun JsonWriter.writeJsonValue(value: Any?) {
+    when (value) {
+        null, JSONObject.NULL -> nullValue()
+        is JSONObject -> {
+            beginObject()
+            val keys = value.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                name(key)
+                writeJsonValue(value.opt(key))
+            }
+            endObject()
+        }
+        is JSONArray -> {
+            beginArray()
+            for (index in 0 until value.length()) {
+                writeJsonValue(value.opt(index))
+            }
+            endArray()
+        }
+        is String -> value(value)
+        is Number -> value(value)
+        is Boolean -> value(value)
+        else -> value(value.toString())
+    }
 }
 
 class PiJsonlParser(

--- a/app/src/main/java/com/zhousl/aether/data/pi/PiKernelBridge.kt
+++ b/app/src/main/java/com/zhousl/aether/data/pi/PiKernelBridge.kt
@@ -455,10 +455,9 @@ class PiKernelBridge(
                 eventJob = eventJob,
             )
             onSetupProgress(PiCoreSetupUpdate(PiCoreSetupPhase.VerifyingBridge))
-            val line = PiBridgeRequest(id = id, type = type, payload = payload).toJsonLine()
+            val request = PiBridgeRequest(id = id, type = type, payload = payload)
             synchronized(requestProcess.writer) {
-                requestProcess.writer.write(line)
-                requestProcess.writer.newLine()
+                request.writeJsonLine(requestProcess.writer)
                 requestProcess.writer.flush()
             }
             val frame = if (timeoutMillis == null) {

--- a/app/src/test/java/com/zhousl/aether/data/pi/PiBridgeProtocolTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/pi/PiBridgeProtocolTest.kt
@@ -1,5 +1,8 @@
 package com.zhousl.aether.data.pi
 
+import java.io.StringWriter
+import java.io.Writer
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -52,5 +55,62 @@ class PiBridgeProtocolTest {
         assertTrue(line.contains("\"type\":\"complete_once\""))
         assertTrue(line.contains("\"pi_provider_id\":\"faux\""))
         assertTrue(line.contains("\"faux_response\":\"done\""))
+    }
+
+    @Test
+    fun requestStreamsOneLfDelimitedJsonRecord() {
+        val output = StringWriter()
+
+        PiBridgeRequest(
+            id = "req",
+            type = "run_turn",
+            payload = JSONObject()
+                .put("text", "first\nsecond")
+                .put("path", "workspace/file.png"),
+        ).writeJsonLine(output)
+
+        val line = output.toString()
+        assertTrue(line.endsWith("\n"))
+        assertEquals(1, line.count { it == '\n' })
+        val request = JSONObject(line.dropLast(1))
+        assertEquals("req", request.optString("id"))
+        assertEquals("first\nsecond", request.getJSONObject("payload").optString("text"))
+        assertEquals("workspace/file.png", request.getJSONObject("payload").optString("path"))
+    }
+
+    @Test
+    fun requestStreamsLargePayloadWithoutRetainingOutput() {
+        val payloadCharacters = 4 * 1024 * 1024
+        val output = CountingWriter()
+
+        PiBridgeRequest(
+            id = "req",
+            type = "run_turn",
+            payload = JSONObject().put("data", "a".repeat(payloadCharacters)),
+        ).writeJsonLine(output)
+
+        assertTrue(output.charactersWritten > payloadCharacters)
+        assertTrue(output.largestWrite <= payloadCharacters)
+    }
+
+    private class CountingWriter : Writer() {
+        var charactersWritten = 0L
+            private set
+        var largestWrite = 0
+            private set
+
+        override fun write(buffer: CharArray, offset: Int, length: Int) {
+            charactersWritten += length
+            largestWrite = maxOf(largestWrite, length)
+        }
+
+        override fun write(value: String, offset: Int, length: Int) {
+            charactersWritten += length
+            largestWrite = maxOf(largestWrite, length)
+        }
+
+        override fun flush() = Unit
+
+        override fun close() = Unit
     }
 }

--- a/app/src/test/java/com/zhousl/aether/data/pi/PiBridgeProtocolTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/pi/PiBridgeProtocolTest.kt
@@ -2,6 +2,7 @@ package com.zhousl.aether.data.pi
 
 import java.io.StringWriter
 import java.io.Writer
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -60,13 +61,23 @@ class PiBridgeProtocolTest {
     @Test
     fun requestStreamsOneLfDelimitedJsonRecord() {
         val output = StringWriter()
+        val escapedText = "\"\\\b\u000c\n\r\t\u0001\u2028\u2029"
 
         PiBridgeRequest(
             id = "req",
             type = "run_turn",
             payload = JSONObject()
                 .put("text", "first\nsecond")
-                .put("path", "workspace/file.png"),
+                .put("path", "workspace/file.png")
+                .put("escaped", escapedText)
+                .put(
+                    "nested",
+                    JSONObject()
+                        .put("number", 3.5)
+                        .put("boolean", true)
+                        .put("null", JSONObject.NULL)
+                        .put("array", JSONArray().put(1).put("two").put(JSONObject.NULL)),
+                ),
         ).writeJsonLine(output)
 
         val line = output.toString()
@@ -76,6 +87,14 @@ class PiBridgeProtocolTest {
         assertEquals("req", request.optString("id"))
         assertEquals("first\nsecond", request.getJSONObject("payload").optString("text"))
         assertEquals("workspace/file.png", request.getJSONObject("payload").optString("path"))
+        assertEquals(escapedText, request.getJSONObject("payload").optString("escaped"))
+        val nested = request.getJSONObject("payload").getJSONObject("nested")
+        assertEquals(3.5, nested.optDouble("number"), 0.0)
+        assertTrue(nested.optBoolean("boolean"))
+        assertTrue(nested.isNull("null"))
+        assertEquals(1, nested.getJSONArray("array").optInt(0))
+        assertEquals("two", nested.getJSONArray("array").optString(1))
+        assertTrue(nested.getJSONArray("array").isNull(2))
     }
 
     @Test


### PR DESCRIPTION
- Write run turn payloads directly to the process stream
- Use JsonWriter to preserve JSONL encoding without large string allocations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved newline-delimited request JSON serialization for nested objects/arrays, nulls, primitives, and special characters (including embedded newlines and proper escaping).
  * Requests are written via a writer-based streaming approach to better support large payloads without extra buffering.

* **Tests**
  * Added coverage to verify exact single-LF newline formatting and correct nested payload encoding.
  * Added coverage to ensure large payloads stream efficiently, without retaining excessive intermediate output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->