### PR TITLE
fix(agent): preserve long-running agent responses

### DIFF
--- a/app/src/androidTest/java/com/zhousl/aether/data/ChatRepositoryCheckpointInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/zhousl/aether/data/ChatRepositoryCheckpointInstrumentedTest.kt
@@ -1,0 +1,324 @@
+package com.zhousl.aether.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.zhousl.aether.data.chatdb.ChatHistoryDatabase
+import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.ChatSession
+import com.zhousl.aether.ui.MessageAuthor
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatRepositoryCheckpointInstrumentedTest {
+    private lateinit var database: ChatHistoryDatabase
+    private lateinit var repository: ChatRepository
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        database = Room.inMemoryDatabaseBuilder(context, ChatHistoryDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = ChatRepository(context, database)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun checkpointUpsertTouchesOnlyTargetResponseAndCompletionReplacesIt() = runBlocking {
+        val sessionId = "session-checkpoint"
+        val responseGroupId = "agent-group-turn-checkpoint"
+        val before = ChatMessage(
+            id = "user-before",
+            author = MessageAuthor.User,
+            text = "before",
+        )
+        val checkpointText = ChatMessage(
+            id = "agent-checkpoint-text",
+            author = MessageAuthor.Agent,
+            text = "partial",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        val checkpointTool = ChatMessage(
+            id = "agent-checkpoint-tool",
+            author = MessageAuthor.Agent,
+            text = "tool output",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        val session = ChatSession(
+            id = sessionId,
+            title = "Checkpoint",
+            preview = "before",
+            messages = listOf(before),
+        )
+        val unrelated = ChatSession(
+            id = "unrelated-session",
+            title = "Unrelated",
+            preview = "untouched",
+            messages = listOf(
+                ChatMessage(
+                    id = "unrelated-message",
+                    author = MessageAuthor.User,
+                    text = "untouched",
+                ),
+            ),
+        )
+
+        repository.updateChatState(
+            sessions = listOf(session, unrelated),
+            currentSessionId = sessionId,
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(checkpointText),
+                ),
+            ),
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(
+                        checkpointText.copy(text = "more partial"),
+                        checkpointTool,
+                    ),
+                ),
+            ),
+        )
+
+        val checkpointPositions = database.chatHistoryDao()
+            .getMessageSummariesForSession(sessionId)
+            .map { it.position }
+        val checkpointSession = repository.getSessionWithMessages(sessionId)
+        val checkpointMessages = checkpointSession?.messages.orEmpty()
+        assertEquals(listOf(0, 1, 2), checkpointPositions)
+        assertEquals(
+            listOf("user-before", "agent-checkpoint-text", "agent-checkpoint-tool"),
+            checkpointMessages.map { it.id },
+        )
+        assertEquals("more partial", checkpointMessages[1].text)
+        assertTrue(checkpointMessages.drop(1).all { it.isIncomplete })
+        assertEquals("before", checkpointSession?.preview)
+        assertEquals(
+            listOf("unrelated-message"),
+            repository.getSessionWithMessages(unrelated.id)?.messages.orEmpty().map { it.id },
+        )
+
+        val reshapedCheckpoint = ChatMessage(
+            id = "agent-checkpoint-reshaped",
+            author = MessageAuthor.Agent,
+            text = "reshaped partial",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(reshapedCheckpoint),
+                ),
+            ),
+        )
+
+        val reshapedPositions = database.chatHistoryDao()
+            .getMessageSummariesForSession(sessionId)
+            .map { it.position }
+        val reshapedSession = repository.getSessionWithMessages(sessionId)
+        assertEquals(listOf(0, 1), reshapedPositions)
+        assertEquals(
+            listOf("user-before", "agent-checkpoint-reshaped"),
+            reshapedSession?.messages.orEmpty().map { it.id },
+        )
+
+        val completedMessages = listOf(
+            reshapedCheckpoint.copy(text = "complete", isIncomplete = false),
+        )
+        repository.updateChatState(
+            sessions = listOf(
+                session.copy(
+                    preview = "complete",
+                    messages = listOf(before) + completedMessages,
+                ),
+                unrelated,
+            ),
+            currentSessionId = sessionId,
+        )
+
+        val completedPositions = database.chatHistoryDao()
+            .getMessageSummariesForSession(sessionId)
+            .map { it.position }
+        val restoredCompletion = repository.getSessionWithMessages(sessionId)
+        assertEquals(listOf(0, 1), completedPositions)
+        assertEquals(
+            listOf("user-before", "agent-checkpoint-reshaped"),
+            restoredCompletion?.messages.orEmpty().map { it.id },
+        )
+        assertTrue(restoredCompletion?.messages.orEmpty().drop(1).all { !it.isIncomplete })
+        assertFalse(restoredCompletion?.messages.orEmpty()[1].isIncomplete)
+        assertEquals(responseGroupId, restoredCompletion?.messages.orEmpty()[1].responseGroupId)
+        assertEquals("complete", restoredCompletion?.preview)
+    }
+
+    @Test
+    fun checkpointUpsertPreservesUnrelatedMessagesAfterTarget() = runBlocking {
+        val sessionId = "session-checkpoint-tail"
+        val responseGroupId = "agent-group-target"
+        val otherResponseGroupId = "agent-group-other"
+        val before = ChatMessage(
+            id = "user-before-tail",
+            author = MessageAuthor.User,
+            text = "before",
+        )
+        val oldCheckpointMessages = listOf(
+            ChatMessage(
+                id = "agent-target-text",
+                author = MessageAuthor.Agent,
+                text = "partial",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+            ChatMessage(
+                id = "agent-target-tool",
+                author = MessageAuthor.Agent,
+                text = "tool output",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+        )
+        val userAfter = ChatMessage(
+            id = "user-after-target",
+            author = MessageAuthor.User,
+            text = "keep this user message",
+        )
+        val otherResponse = ChatMessage(
+            id = "agent-other-response",
+            author = MessageAuthor.Agent,
+            text = "keep this response",
+            responseGroupId = otherResponseGroupId,
+        )
+        val session = ChatSession(
+            id = sessionId,
+            title = "Checkpoint tail",
+            preview = "keep this response",
+            messages = listOf(before) + oldCheckpointMessages + userAfter + otherResponse,
+        )
+        repository.updateChatState(
+            sessions = listOf(session),
+            currentSessionId = sessionId,
+        )
+
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(
+                        ChatMessage(
+                            id = "agent-target-reshaped",
+                            author = MessageAuthor.Agent,
+                            text = "reshaped partial",
+                            isIncomplete = true,
+                            responseGroupId = responseGroupId,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val shrunkSummaries = database.chatHistoryDao().getMessageSummariesForSession(sessionId)
+        val shrunkMessages = repository.getSessionWithMessages(sessionId)?.messages.orEmpty()
+        assertEquals(listOf(0, 1, 2, 3), shrunkSummaries.map { it.position })
+        assertEquals(
+            listOf(
+                "user-before-tail",
+                "agent-target-reshaped",
+                "user-after-target",
+                "agent-other-response",
+            ),
+            shrunkMessages.map { it.id },
+        )
+        assertEquals(otherResponseGroupId, shrunkMessages.last().responseGroupId)
+
+        val grownCheckpointMessages = listOf(
+            ChatMessage(
+                id = "agent-target-reshaped",
+                author = MessageAuthor.Agent,
+                text = "reshaped partial",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+            ChatMessage(
+                id = "agent-target-reasoning",
+                author = MessageAuthor.Agent,
+                text = "reasoning",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+            ChatMessage(
+                id = "agent-target-result",
+                author = MessageAuthor.Agent,
+                text = "result",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = grownCheckpointMessages,
+                ),
+            ),
+        )
+
+        val grownSummaries = database.chatHistoryDao().getMessageSummariesForSession(sessionId)
+        val grownMessages = repository.getSessionWithMessages(sessionId)?.messages.orEmpty()
+        assertEquals(listOf(0, 1, 2, 3, 4, 5), grownSummaries.map { it.position })
+        assertEquals(
+            listOf(
+                "user-before-tail",
+                "agent-target-reshaped",
+                "agent-target-reasoning",
+                "agent-target-result",
+                "user-after-target",
+                "agent-other-response",
+            ),
+            grownMessages.map { it.id },
+        )
+        assertEquals(otherResponseGroupId, grownMessages.last().responseGroupId)
+    }
+}

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -61,22 +61,63 @@ data class ChatUsageStatisticsSnapshot(
     val statistics: ChatUsageStatistics,
 )
 
-enum class PersistedChatWriteIntent {
-    SyncSnapshot,
-    DeleteSession,
-    ReplaceFromImport,
+data class AssistantResponseCheckpointTarget(
+    val sessionId: String,
+    val responseGroupId: String,
+)
+
+data class AssistantResponseCheckpoint(
+    val target: AssistantResponseCheckpointTarget,
+    val fromPosition: Int,
+    val messages: List<ChatMessage>,
+) {
+    init {
+        require(fromPosition >= 0) { "fromPosition must be non-negative" }
+        require(messages.isNotEmpty()) { "messages must not be empty" }
+        require(messages.all { it.responseGroupId == target.responseGroupId }) {
+            "checkpoint messages must belong to the target response"
+        }
+    }
+}
+
+private data class AssistantResponseCheckpointUpsert(
+    val sessionId: String,
+    val responseGroupId: String,
+    val fromPosition: Int,
+    val messages: List<ChatMessage>,
+    val entities: List<ChatMessageEntity>,
+)
+
+sealed interface PersistedChatWriteIntent {
+    data object SyncSnapshot : PersistedChatWriteIntent
+    data object DeleteSession : PersistedChatWriteIntent
+    data object ReplaceFromImport : PersistedChatWriteIntent
+}
+
+interface ChatStatePersistence {
+    val chatState: Flow<PersistedChatState>
+
+    suspend fun updateChatState(
+        sessions: List<ChatSession>,
+        currentSessionId: String,
+        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
+    )
+
+    suspend fun upsertAssistantResponseCheckpoints(
+        checkpoints: List<AssistantResponseCheckpoint>,
+    )
 }
 
 class ChatRepository(
     private val context: Context,
     private val database: ChatHistoryDatabase = ChatHistoryDatabase.getInstance(context),
-) {
+) : ChatStatePersistence {
     private val chatHistoryDao: ChatHistoryDao = database.chatHistoryDao()
     private val restoredMessageCache = mutableMapOf<ChatMessageCacheKey, LoadedChatMessage>()
     private val restoredMessageCacheMutex = Mutex()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val chatState: Flow<PersistedChatState> = flow {
+    override val chatState: Flow<PersistedChatState> = flow {
         migrateLegacyChatStateIfNeeded()
         emitAll(
             combine(
@@ -140,10 +181,10 @@ class ChatRepository(
         )
     }
 
-    suspend fun updateChatState(
+    override suspend fun updateChatState(
         sessions: List<ChatSession>,
         currentSessionId: String,
-        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
+        writeIntent: PersistedChatWriteIntent,
     ) {
         migrateLegacyChatStateIfNeeded()
         replaceChatState(
@@ -342,6 +383,68 @@ class ChatRepository(
         }
     }
 
+    override suspend fun upsertAssistantResponseCheckpoints(
+        checkpoints: List<AssistantResponseCheckpoint>,
+    ) {
+        if (checkpoints.isEmpty()) return
+        val latestCheckpoints = checkpoints.associateBy { it.target }.values
+        val upserts = latestCheckpoints.map { checkpoint ->
+            AssistantResponseCheckpointUpsert(
+                sessionId = checkpoint.target.sessionId,
+                responseGroupId = checkpoint.target.responseGroupId,
+                fromPosition = checkpoint.fromPosition,
+                messages = checkpoint.messages,
+                entities = checkpoint.messages.mapIndexed { index, message ->
+                    ChatMessageEntityMapper.toEntity(
+                        sessionId = checkpoint.target.sessionId,
+                        position = checkpoint.fromPosition + index,
+                        message = message,
+                    )
+                },
+            )
+        }
+
+        upserts.forEach { upsert ->
+            invalidateRestoredMessagesFromPosition(
+                sessionId = upsert.sessionId,
+                fromPosition = upsert.fromPosition,
+            )
+        }
+        database.withTransaction {
+            upserts.forEach { upsert ->
+                if (chatHistoryDao.getSession(upsert.sessionId) == null) return@forEach
+                val previousMessageCount = chatHistoryDao.getMessageCountForResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                )
+                chatHistoryDao.parkMessagesFromPositionOutsideResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                    fromPosition = upsert.fromPosition,
+                )
+                chatHistoryDao.deleteWorkspaceFileRefsForResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                )
+                chatHistoryDao.deleteMessagesForResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                )
+                chatHistoryDao.upsertMessages(upsert.entities)
+                chatHistoryDao.restoreParkedMessagesOutsideResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                    fromPosition = upsert.fromPosition,
+                    positionDelta = upsert.entities.size - previousMessageCount,
+                )
+                replaceWorkspaceFileRefsForMessagesInTransaction(
+                    sessionId = upsert.sessionId,
+                    messages = upsert.messages,
+                )
+            }
+        }
+    }
+
     private suspend fun replaceChatState(
         sessions: List<ChatSessionSnapshot>,
         currentSessionId: String,
@@ -355,7 +458,10 @@ class ChatRepository(
                 ?: sessions.firstOrNull()?.session?.id
                 ?: DraftSessionId
             if (sessions.isEmpty()) {
-                if (writeIntent == PersistedChatWriteIntent.SyncSnapshot && chatHistoryDao.getSessions().isNotEmpty()) {
+                if (writeIntent !is PersistedChatWriteIntent.ReplaceFromImport &&
+                    writeIntent !is PersistedChatWriteIntent.DeleteSession &&
+                    chatHistoryDao.getSessions().isNotEmpty()
+                ) {
                     return@withTransaction
                 }
                 chatHistoryDao.upsertMeta(
@@ -390,7 +496,7 @@ class ChatRepository(
 
             sessions.forEach { snapshot ->
                 val existingMessageCount = existingMessageCounts[snapshot.session.id] ?: 0
-                val isMetadataOnlySnapshot = writeIntent != PersistedChatWriteIntent.ReplaceFromImport &&
+                val isMetadataOnlySnapshot = writeIntent !is PersistedChatWriteIntent.ReplaceFromImport &&
                     snapshot.session.id != safeCurrentSessionId &&
                     snapshot.messages.isEmpty() &&
                     existingMessageCount > 0
@@ -941,6 +1047,7 @@ internal fun parseMessage(message: JSONObject, messageIndex: Int): ChatMessage =
     branchGroup = parseBranchGroup(message.optJSONObject("branchGroup")),
     responseGroupId = message.optString("responseGroupId").ifBlank { null },
     assistantActionsHidden = message.optBoolean("assistantActionsHidden"),
+    isIncomplete = message.optBoolean("isIncomplete"),
     providerPayloadJson = message.optString("providerPayloadJson"),
     displayKind = parseMessageDisplayKind(message.optString("displayKind")),
     usageStatistics = parseUsageStatistics(message.optJSONObject("usageStatistics")),
@@ -962,6 +1069,9 @@ internal fun ChatMessage.toJson(): JSONObject = JSONObject().apply {
     responseGroupId?.let { put("responseGroupId", it) }
     if (assistantActionsHidden) {
         put("assistantActionsHidden", true)
+    }
+    if (isIncomplete) {
+        put("isIncomplete", true)
     }
     providerPayloadJson.takeIf { it.isNotBlank() }?.let {
         put("providerPayloadJson", it)

--- a/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -23,7 +24,7 @@ private const val ChatStateStoreLogTag = "ChatStateStore"
 
 class ChatStateStore(
     private val scope: CoroutineScope,
-    private val chatRepository: ChatRepository,
+    private val chatRepository: ChatStatePersistence,
 ) {
     private val updateLock = Any()
     private val persistMutex = Mutex()
@@ -32,6 +33,7 @@ class ChatStateStore(
     private var localGeneration = 0L
     private var persistedGeneration = 0L
     private var latestPending: PendingPersistedChatState? = null
+    private var retainedCheckpoints = emptyMap<AssistantResponseCheckpointTarget, AssistantResponseCheckpoint>()
     private var repositoryStateLoaded = false
     private val repositoryStateReady = CompletableDeferred<Unit>()
 
@@ -40,35 +42,31 @@ class ChatStateStore(
     init {
         scope.launch {
             try {
-                chatRepository.chatState.collect { persisted ->
-                    val pendingAfterInitialLoad = synchronized(updateLock) {
-                        if (!repositoryStateLoaded) {
-                            repositoryStateLoaded = true
-                            if (localGeneration == persistedGeneration) {
-                                _state.value = persisted
-                                null
-                            } else {
-                                val merged = mergeRepositoryStateWithLocalUpdates(
-                                    repositoryState = persisted,
-                                    localState = _state.value,
-                                )
-                                _state.value = merged
-                                latestPending = latestPending?.copy(state = merged)
-                                latestPending
-                            }
-                        } else {
-                            if (localGeneration == persistedGeneration) {
-                                _state.value = persisted
-                            }
-                            null
+                // Room bootstraps the store once. Later database invalidations are persistence
+                // acknowledgements and must not rebuild or publish the UI state.
+                val persisted = chatRepository.chatState.first()
+                val pendingAfterInitialLoad = synchronized(updateLock) {
+                    repositoryStateLoaded = true
+                    if (localGeneration == persistedGeneration) {
+                        _state.value = persisted
+                        null
+                    } else {
+                        val merged = mergeRepositoryStateWithLocalUpdates(
+                            repositoryState = persisted,
+                            localState = _state.value,
+                        )
+                        _state.value = merged
+                        latestPending = latestPending?.let { pending ->
+                            if (pending.primaryState == null) pending else pending.copy(primaryState = merged)
                         }
+                        latestPending
                     }
-                    if (!repositoryStateReady.isCompleted) {
-                        repositoryStateReady.complete(Unit)
-                    }
-                    if (pendingAfterInitialLoad != null) {
-                        persistWithoutQueue(pendingAfterInitialLoad)
-                    }
+                }
+                if (!repositoryStateReady.isCompleted) {
+                    repositoryStateReady.complete(Unit)
+                }
+                if (pendingAfterInitialLoad != null) {
+                    persistWithoutQueue(pendingAfterInitialLoad)
                 }
             } catch (throwable: Throwable) {
                 if (throwable is CancellationException) {
@@ -128,11 +126,19 @@ class ChatStateStore(
             }
 
             val persistError = runCatching {
-                chatRepository.updateChatState(
-                    sessions = pending.state.sessions,
-                    currentSessionId = pending.state.currentSessionId,
-                    writeIntent = pending.writeIntent,
-                )
+                pending.primaryWriteIntent?.let { writeIntent ->
+                    val primaryState = checkNotNull(pending.primaryState)
+                    chatRepository.updateChatState(
+                        sessions = primaryState.sessions,
+                        currentSessionId = primaryState.currentSessionId,
+                        writeIntent = writeIntent,
+                    )
+                }
+                if (pending.checkpoints.isNotEmpty()) {
+                    chatRepository.upsertAssistantResponseCheckpoints(
+                        checkpoints = pending.checkpoints.values.toList(),
+                    )
+                }
             }.exceptionOrNull()
             if (persistError != null) {
                 if (persistError is CancellationException) {
@@ -268,35 +274,76 @@ class ChatStateStore(
     ): PersistedChatState {
         val pending = synchronized(updateLock) {
             val updated = transform(_state.value)
+            val pendingWrite = latestPending
+            retainedCheckpoints = retainedCheckpoints.filterKeys { target ->
+                val session = updated.sessions.firstOrNull { it.id == target.sessionId }
+                session != null && session.messages.none { it.responseGroupId == target.responseGroupId }
+            }
             localGeneration += 1
             _state.value = updated
-            val effectiveWriteIntent = latestPending
-                ?.writeIntent
-                ?.takeIf { pendingIntent ->
-                    writeIntent == PersistedChatWriteIntent.SyncSnapshot &&
-                        updated.sessions.isEmpty() &&
-                        pendingIntent != PersistedChatWriteIntent.SyncSnapshot
-                }
-                ?: writeIntent
             PendingPersistedChatState(
                 generation = localGeneration,
-                state = updated,
-                writeIntent = effectiveWriteIntent,
+                primaryState = updated,
+                primaryWriteIntent = mergePrimaryWriteIntents(
+                    pendingIntent = pendingWrite?.primaryWriteIntent,
+                    writeIntent = writeIntent,
+                    updated = updated,
+                ),
+                checkpoints = retainedCheckpoints,
             ).also {
                 latestPending = it
             }
         }
+        enqueue(pending)
+        return checkNotNull(pending.primaryState)
+    }
+
+    fun updateAssistantCheckpoint(
+        checkpoint: AssistantResponseCheckpoint,
+        shouldPersist: () -> Boolean = { true },
+    ): Boolean {
+        val pending = synchronized(updateLock) {
+            if (!shouldPersist()) return false
+            retainedCheckpoints = retainedCheckpoints + (checkpoint.target to checkpoint)
+            localGeneration += 1
+            PendingPersistedChatState(
+                generation = localGeneration,
+                primaryState = latestPending?.primaryState,
+                primaryWriteIntent = latestPending?.primaryWriteIntent,
+                checkpoints = latestPending?.checkpoints.orEmpty() + (checkpoint.target to checkpoint),
+            ).also {
+                latestPending = it
+            }
+        }
+        enqueue(pending)
+        return true
+    }
+
+    private fun enqueue(pending: PendingPersistedChatState) {
         val sendResult = persistenceQueue.trySend(pending)
         if (sendResult.isFailure) {
             persistWithoutQueue(pending)
         }
-        return pending.state
+    }
+
+    private fun mergePrimaryWriteIntents(
+        pendingIntent: PersistedChatWriteIntent?,
+        writeIntent: PersistedChatWriteIntent,
+        updated: PersistedChatState,
+    ): PersistedChatWriteIntent = when {
+        pendingIntent == null -> writeIntent
+        writeIntent is PersistedChatWriteIntent.SyncSnapshot &&
+            updated.sessions.isEmpty() &&
+            (pendingIntent is PersistedChatWriteIntent.DeleteSession ||
+                pendingIntent is PersistedChatWriteIntent.ReplaceFromImport) -> pendingIntent
+        else -> writeIntent
     }
 
     private data class PendingPersistedChatState(
         val generation: Long,
-        val state: PersistedChatState,
-        val writeIntent: PersistedChatWriteIntent,
+        val primaryState: PersistedChatState?,
+        val primaryWriteIntent: PersistedChatWriteIntent?,
+        val checkpoints: Map<AssistantResponseCheckpointTarget, AssistantResponseCheckpoint>,
     )
 
     private companion object {

--- a/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
@@ -23,11 +23,13 @@ import com.zhousl.aether.ui.MessageAuthor
 import com.zhousl.aether.ui.ReasoningSummaryChunk
 import com.zhousl.aether.ui.ReasoningTrace
 import com.zhousl.aether.ui.syncActiveBranches
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,6 +43,7 @@ import org.json.JSONObject
 
 private const val ReasoningInitialSummaryTokenThreshold = 100
 private const val ReasoningTimedSummaryIntervalMillis = 5_000L
+private const val AssistantCheckpointIntervalMillis = 1_000L
 private const val ReasoningSummaryMaxInputChars = 8_000
 private const val ReasoningSummaryTitleMaxChars = 120
 private const val ReasoningSummaryDetailMaxChars = 520
@@ -75,6 +78,7 @@ data class SessionExecutionState(
     val pendingStatusText: String = "",
     val pendingStatusDetail: String = "",
     val pendingInputs: List<PendingSessionInput> = emptyList(),
+    val activeResponseGroupId: String? = null,
     val activeTurnStartedAtMillis: Long? = null,
 )
 
@@ -112,6 +116,15 @@ private data class ReasoningSummary(
     val title: String,
     val detail: String,
 )
+
+private data class AssistantResponseIdentity(
+    val responseGroupId: String,
+    val messageIdPrefix: String,
+    val createdAtMillis: Long,
+    val checkpointFromPosition: Int,
+) {
+    fun messageIdFor(blockId: String): String = "$messageIdPrefix-$blockId"
+}
 
 class SessionExecutionManager(
     private val application: Application,
@@ -208,6 +221,7 @@ class SessionExecutionManager(
                 pendingAssistantText = "",
                 pendingStatusText = "",
                 pendingStatusDetail = "",
+                activeResponseGroupId = null,
                 activeTurnStartedAtMillis = System.currentTimeMillis(),
             )
         }
@@ -284,6 +298,7 @@ class SessionExecutionManager(
                 pendingStatusText = "",
                 pendingStatusDetail = "",
                 pendingInputs = emptyList(),
+                activeResponseGroupId = null,
                 activeTurnStartedAtMillis = null,
             )
         }
@@ -420,6 +435,7 @@ class SessionExecutionManager(
                         pendingStatusText = "",
                         pendingStatusDetail = "",
                         pendingInputs = emptyList(),
+                        activeResponseGroupId = null,
                         activeTurnStartedAtMillis = null,
                     )
                 }
@@ -447,6 +463,17 @@ class SessionExecutionManager(
     ): CompletionSummary {
         val turnStartedAtMillis = System.currentTimeMillis()
         val turnId = "turn-$turnStartedAtMillis"
+        val responseIdentity = activateAssistantResponse(handle)
+        updateExecutionState(handle.sessionId) { current ->
+            current.copy(
+                activeResponseGroupId = responseIdentity.responseGroupId,
+                pendingToolInvocations = emptyList(),
+                pendingResponseBlocks = emptyList(),
+                pendingAssistantText = "",
+                pendingStatusText = "",
+                pendingStatusDetail = "",
+            )
+        }
         var firstAssistantTokenAtMillis: Long? = null
         diagnosticLogger.event(
             category = "session",
@@ -804,6 +831,7 @@ class SessionExecutionManager(
                         pendingToolInvocations = emptyList(),
                         pendingResponseBlocks = emptyList(),
                         pendingAssistantText = "",
+                        activeResponseGroupId = null,
                         activeTurnStartedAtMillis = null,
                     )
                 }
@@ -917,10 +945,13 @@ class SessionExecutionManager(
             .orEmpty()
 
         val normalizedBlocks = normalizeAssistantResponseBlocks(blocks)
+        val responseIdentity = handle?.activeResponseIdentity
         val appendedMessages = assistantMessagesForBlocks(
             normalizedBlocks = normalizedBlocks,
             thoughtDurationMillis = thoughtDurationMillis,
             assistantActionsHidden = false,
+            isIncomplete = false,
+            responseIdentity = responseIdentity,
             usageStatistics = buildChatUsageStatistics(
                 tokenUsage = tokenUsage,
                 tokenUsageSource = tokenUsageSource,
@@ -931,6 +962,7 @@ class SessionExecutionManager(
             providerPayloadJson = providerPayloadJson,
         )
 
+        deactivateAssistantCheckpoint(handle, responseIdentity)
         chatStateStore.update { persisted ->
             val sessionIndex = persisted.sessions.indexOfFirst { it.id == sessionId }
             if (sessionIndex < 0) return@update persisted
@@ -938,8 +970,11 @@ class SessionExecutionManager(
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
             val currentMessages = session.messages.ifEmpty { baseMessages }
+            val messagesWithoutCheckpoint = responseIdentity?.let { identity ->
+                currentMessages.filterNot { it.responseGroupId == identity.responseGroupId }
+            } ?: currentMessages
             val updatedSession = session.withDerivedMessages(
-                currentMessages + appendedMessages
+                messagesWithoutCheckpoint + appendedMessages
             )
             handle?.replaceRetainedMessages(updatedSession.messages)
             sessionTitle = updatedSession.title
@@ -1047,15 +1082,48 @@ class SessionExecutionManager(
         }
     }
 
+    private fun activateAssistantResponse(handle: SessionExecutionHandle): AssistantResponseIdentity {
+        val startedAtMillis = System.currentTimeMillis()
+        val turnId = "turn-$startedAtMillis-${UUID.randomUUID().toString().take(8)}"
+        return AssistantResponseIdentity(
+            responseGroupId = "agent-group-$turnId",
+            messageIdPrefix = "agent-$turnId",
+            createdAtMillis = startedAtMillis,
+            checkpointFromPosition = syncActiveBranches(handle.retainedMessagesSnapshot()).size,
+        ).also { identity ->
+            synchronized(handle.lock) {
+                handle.assistantCheckpointJob?.cancel()
+                handle.assistantCheckpointJob = null
+                handle.lastAssistantCheckpointUptimeMillis = null
+                handle.activeResponseIdentity = identity
+            }
+        }
+    }
+
+    private fun deactivateAssistantCheckpoint(
+        handle: SessionExecutionHandle?,
+        identity: AssistantResponseIdentity?,
+    ) {
+        if (handle == null || identity == null) return
+        synchronized(handle.lock) {
+            if (handle.activeResponseIdentity != identity) return
+            handle.activeResponseIdentity = null
+            handle.assistantCheckpointJob?.cancel()
+            handle.assistantCheckpointJob = null
+        }
+    }
+
     private fun assistantMessagesForBlocks(
         normalizedBlocks: List<AssistantResponseBlock>,
         thoughtDurationMillis: Long?,
         assistantActionsHidden: Boolean,
+        isIncomplete: Boolean = false,
+        responseIdentity: AssistantResponseIdentity? = null,
         usageStatistics: ChatUsageStatistics? = null,
         providerPayloadJson: String = "",
     ): List<ChatMessage> {
-        val messageTimestamp = System.currentTimeMillis()
-        val responseGroupId = "agent-group-$messageTimestamp"
+        val messageTimestamp = responseIdentity?.createdAtMillis ?: System.currentTimeMillis()
+        val responseGroupId = responseIdentity?.responseGroupId ?: "agent-group-$messageTimestamp"
         return normalizedBlocks.mapIndexedNotNull { index, block ->
             when (block) {
                 is AssistantResponseBlock.Text -> {
@@ -1063,12 +1131,13 @@ class SessionExecutionManager(
                         null
                     } else {
                         ChatMessage(
-                            id = "agent-${messageTimestamp + index}",
+                            id = responseIdentity?.messageIdFor(block.id) ?: "agent-${messageTimestamp + index}",
                             author = MessageAuthor.Agent,
                             text = block.text,
                             createdAtMillis = messageTimestamp + index,
                             responseGroupId = responseGroupId,
                             assistantActionsHidden = assistantActionsHidden,
+                            isIncomplete = isIncomplete,
                         )
                     }
                 }
@@ -1078,20 +1147,21 @@ class SessionExecutionManager(
                         null
                     } else {
                         ChatMessage(
-                            id = "agent-${messageTimestamp + index}",
+                            id = responseIdentity?.messageIdFor(block.id) ?: "agent-${messageTimestamp + index}",
                             author = MessageAuthor.Agent,
                             text = "",
                             createdAtMillis = messageTimestamp + index,
                             toolInvocations = block.toolInvocations,
                             responseGroupId = responseGroupId,
                             assistantActionsHidden = assistantActionsHidden,
+                            isIncomplete = isIncomplete,
                         )
                     }
                 }
 
                 is AssistantResponseBlock.Reasoning -> {
                     ChatMessage(
-                        id = "agent-${messageTimestamp + index}",
+                        id = responseIdentity?.messageIdFor(block.id) ?: "agent-${messageTimestamp + index}",
                         author = MessageAuthor.Agent,
                         text = "",
                         createdAtMillis = messageTimestamp + index,
@@ -1099,6 +1169,7 @@ class SessionExecutionManager(
                         reasoningTrace = block.trace,
                         responseGroupId = responseGroupId,
                         assistantActionsHidden = assistantActionsHidden,
+                        isIncomplete = isIncomplete,
                     )
                 }
             }
@@ -1240,12 +1311,15 @@ class SessionExecutionManager(
                 }
             }
         }
+        val responseIdentity = handle.activeResponseIdentity
         val interruptedAssistantMessages = assistantMessagesForBlocks(
             normalizedBlocks = normalizeAssistantResponseBlocks(pendingBlocks),
             thoughtDurationMillis = null,
             assistantActionsHidden = true,
+            responseIdentity = responseIdentity,
         )
         val userMessages = drained.map { it.message }
+        deactivateAssistantCheckpoint(handle, responseIdentity)
         chatStateStore.update { persisted ->
             val sessionIndex = persisted.sessions.indexOfFirst { it.id == handle.sessionId }
             if (sessionIndex < 0) return@update persisted
@@ -1253,8 +1327,11 @@ class SessionExecutionManager(
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
             val currentMessages = session.messages.ifEmpty { handle.retainedMessagesSnapshot() }
+            val messagesWithoutCheckpoint = responseIdentity?.let { identity ->
+                currentMessages.filterNot { it.responseGroupId == identity.responseGroupId }
+            } ?: currentMessages
             val updatedSession = session.withDerivedMessages(
-                syncActiveBranches(currentMessages + interruptedAssistantMessages + userMessages)
+                syncActiveBranches(messagesWithoutCheckpoint + interruptedAssistantMessages + userMessages)
             )
             handle.replaceRetainedMessages(updatedSession.messages)
             updatedSessions.add(
@@ -1271,6 +1348,10 @@ class SessionExecutionManager(
                 pendingStatusText = "",
                 pendingStatusDetail = "",
             )
+        }
+        val continuedResponseIdentity = activateAssistantResponse(handle)
+        updateExecutionState(handle.sessionId) { current ->
+            current.copy(activeResponseGroupId = continuedResponseIdentity.responseGroupId)
         }
     }
 
@@ -1368,12 +1449,77 @@ class SessionExecutionManager(
                 put(sessionId, transform(current))
             }
         }
+        requestAssistantCheckpoint(sessionId)
         if (
             currentSettings.value.keepTasksRunningInBackground &&
             _executionStates.value.values.any { it.isRunning }
         ) {
             ensureForegroundServiceRunning()
         }
+    }
+
+    private fun requestAssistantCheckpoint(sessionId: String) {
+        val handle = executionHandles[sessionId] ?: return
+        val identity = handle.activeResponseIdentity ?: return
+        val blocks = _executionStates.value[sessionId]?.pendingResponseBlocks.orEmpty()
+        if (blocks.isEmpty()) return
+
+        val nowUptimeMillis = SystemClock.uptimeMillis()
+        var persistNow = false
+        synchronized(handle.lock) {
+            if (handle.activeResponseIdentity != identity) return
+            val remainingMillis = handle.lastAssistantCheckpointUptimeMillis?.let { lastCheckpointUptimeMillis ->
+                AssistantCheckpointIntervalMillis - (nowUptimeMillis - lastCheckpointUptimeMillis)
+            } ?: 0L
+            if (remainingMillis <= 0L) {
+                handle.lastAssistantCheckpointUptimeMillis = nowUptimeMillis
+                handle.assistantCheckpointJob?.cancel()
+                handle.assistantCheckpointJob = null
+                persistNow = true
+            } else if (handle.assistantCheckpointJob?.isActive != true) {
+                handle.assistantCheckpointJob = scope.launch {
+                    delay(remainingMillis)
+                    persistAssistantCheckpoint(handle, identity)
+                }
+            }
+        }
+        if (persistNow) {
+            persistAssistantCheckpoint(handle, identity)
+        }
+    }
+
+    private fun persistAssistantCheckpoint(
+        handle: SessionExecutionHandle,
+        identity: AssistantResponseIdentity,
+    ) {
+        val blocks = _executionStates.value[handle.sessionId]?.pendingResponseBlocks.orEmpty()
+        if (blocks.isEmpty() || handle.activeResponseIdentity != identity) return
+        synchronized(handle.lock) {
+            if (handle.activeResponseIdentity != identity) return
+            handle.lastAssistantCheckpointUptimeMillis = SystemClock.uptimeMillis()
+            handle.assistantCheckpointJob = null
+        }
+        val checkpointMessages = assistantMessagesForBlocks(
+            normalizedBlocks = normalizeAssistantResponseBlocks(blocks),
+            thoughtDurationMillis = null,
+            assistantActionsHidden = false,
+            isIncomplete = true,
+            responseIdentity = identity,
+        )
+        if (checkpointMessages.isEmpty()) return
+
+        chatStateStore.updateAssistantCheckpoint(
+            checkpoint = AssistantResponseCheckpoint(
+                target = AssistantResponseCheckpointTarget(
+                    sessionId = handle.sessionId,
+                    responseGroupId = identity.responseGroupId,
+                ),
+                fromPosition = identity.checkpointFromPosition,
+                messages = checkpointMessages,
+            ),
+            // Ignore checkpoints that race with response completion.
+            shouldPersist = { handle.activeResponseIdentity == identity },
+        )
     }
 
     private fun ensureForegroundServiceRunning() {
@@ -2552,6 +2698,10 @@ class SessionExecutionManager(
         var reasoningFirstSummarySubmitted: Boolean = false
         var reasoningLastSubmittedCharIndex: Int = 0
         var reasoningLastTimedSummaryAtMillis: Long = 0L
+        @Volatile
+        var activeResponseIdentity: AssistantResponseIdentity? = null
+        var lastAssistantCheckpointUptimeMillis: Long? = null
+        var assistantCheckpointJob: Job? = null
 
         @Volatile
         var pauseRequested: Boolean = false

--- a/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/app/src/main/java/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -26,6 +26,9 @@ interface ChatHistoryDao {
     @Query("SELECT COUNT(*) FROM chat_messages WHERE sessionId = :sessionId")
     suspend fun getMessageCountForSession(sessionId: String): Int
 
+    @Query("SELECT COUNT(*) FROM chat_messages WHERE sessionId = :sessionId AND responseGroupId = :responseGroupId")
+    suspend fun getMessageCountForResponseGroup(sessionId: String, responseGroupId: String): Int
+
     @Query("""
         SELECT sessionId, COUNT(*) AS messageCount, MAX(COALESCE(createdAtMillis, 0)) AS lastMessageAtMillis
         FROM chat_messages
@@ -139,6 +142,9 @@ interface ChatHistoryDao {
     @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId = :messageId")
     suspend fun deleteWorkspaceFileRefsForMessage(sessionId: String, messageId: String)
 
+    @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId IN (SELECT id FROM chat_messages WHERE sessionId = :sessionId AND responseGroupId = :responseGroupId)")
+    suspend fun deleteWorkspaceFileRefsForResponseGroup(sessionId: String, responseGroupId: String)
+
     @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId IN (SELECT id FROM chat_messages WHERE sessionId = :sessionId AND position >= :fromPosition)")
     suspend fun deleteWorkspaceFileRefsFromPosition(sessionId: String, fromPosition: Int)
 
@@ -153,6 +159,36 @@ interface ChatHistoryDao {
 
     @Query("DELETE FROM chat_messages WHERE sessionId = :sessionId AND position >= :fromPosition")
     suspend fun deleteMessagesFromPosition(sessionId: String, fromPosition: Int)
+
+    @Query("DELETE FROM chat_messages WHERE sessionId = :sessionId AND responseGroupId = :responseGroupId")
+    suspend fun deleteMessagesForResponseGroup(sessionId: String, responseGroupId: String)
+
+    @Query("""
+        UPDATE chat_messages
+        SET position = -position - 1
+        WHERE sessionId = :sessionId
+            AND position >= :fromPosition
+            AND (responseGroupId IS NULL OR responseGroupId != :responseGroupId)
+    """)
+    suspend fun parkMessagesFromPositionOutsideResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+    )
+
+    @Query("""
+        UPDATE chat_messages
+        SET position = (-position - 1) + :positionDelta
+        WHERE sessionId = :sessionId
+            AND position <= -:fromPosition - 1
+            AND (responseGroupId IS NULL OR responseGroupId != :responseGroupId)
+    """)
+    suspend fun restoreParkedMessagesOutsideResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+        positionDelta: Int,
+    )
 
     @Query("DELETE FROM chat_sessions WHERE id = :sessionId")
     suspend fun deleteSession(sessionId: String)

--- a/app/src/main/java/com/zhousl/aether/data/pi/PiKernelBridge.kt
+++ b/app/src/main/java/com/zhousl/aether/data/pi/PiKernelBridge.kt
@@ -1,5 +1,6 @@
 package com.zhousl.aether.data.pi
 
+import android.os.SystemClock
 import com.zhousl.aether.data.PiExtensionLoadOptions
 import com.zhousl.aether.data.AetherDiagnosticLogger
 import com.zhousl.aether.data.DiagnosticRedactor
@@ -9,6 +10,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
@@ -20,6 +22,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.select
 import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.BufferedWriter
@@ -38,6 +42,8 @@ private const val PiAiVersion = "0.80.6"
 private const val PiAgentCoreVersion = "0.80.6"
 private const val PiCodingAgentVersion = "0.80.6"
 private const val PiBridgeRequestTimeoutMillis = 10 * 60 * 1000L
+private const val PiBridgeInactivityTimeoutMillis = PiBridgeRequestTimeoutMillis
+private const val PiBridgeInactivityTimeoutCode = "bridge_inactive"
 private const val PiBridgeOAuthTimeoutMillis = 15 * 60 * 1000L
 private const val PiBridgePingTimeoutMillis = 15_000L
 private const val CancelledRequestRetentionMillis = 5 * 60 * 1000L
@@ -45,6 +51,8 @@ private const val CancelledRequestRetentionMillis = 5 * 60 * 1000L
 private data class PendingPiBridgeRequest(
     val response: CompletableDeferred<PiBridgeFrame>,
     val processGeneration: Long,
+    val lastFrameUptimeMillis: AtomicLong,
+    val activityChannel: Channel<Unit>? = null,
     val eventChannel: Channel<PiBridgeFrame>? = null,
     val eventJob: Job? = null,
 )
@@ -143,7 +151,9 @@ class PiKernelBridge(
         request(
             type = "run_turn",
             payload = payload,
-            timeoutMillis = PiBridgeRequestTimeoutMillis,
+            // Agent turns use an inactivity deadline instead of a wall-clock deadline.
+            timeoutMillis = null,
+            inactivityTimeoutMillis = PiBridgeInactivityTimeoutMillis,
             onEvent = onEvent,
         )
 
@@ -169,7 +179,8 @@ class PiKernelBridge(
             payload = JSONObject()
                 .put("session_id", sessionId)
                 .put("message", message),
-            timeoutMillis = PiBridgeRequestTimeoutMillis,
+            timeoutMillis = null,
+            inactivityTimeoutMillis = PiBridgeInactivityTimeoutMillis,
             onEvent = onEvent,
         )
 
@@ -398,6 +409,7 @@ class PiKernelBridge(
         type: String,
         payload: JSONObject = JSONObject(),
         timeoutMillis: Long?,
+        inactivityTimeoutMillis: Long? = null,
         onEvent: (suspend (String, JSONObject) -> Unit)? = null,
         abortOnCancellation: Boolean = type == "run_turn" || type == "complete_once" || type == "follow_up",
         onSetupProgress: (PiCoreSetupUpdate) -> Unit = {},
@@ -405,6 +417,7 @@ class PiKernelBridge(
     ): JSONObject = withContext(Dispatchers.IO) {
         val id = nextRequestId(type)
         val response = CompletableDeferred<PiBridgeFrame>()
+        val activityChannel = inactivityTimeoutMillis?.let { Channel<Unit>(Channel.CONFLATED) }
         val eventChannel = onEvent?.let { Channel<PiBridgeFrame>(Channel.UNLIMITED) }
         val eventJob = if (onEvent != null && eventChannel != null) {
             eventScope.launch {
@@ -448,23 +461,28 @@ class PiKernelBridge(
             } else {
                 currentLiveProcess() ?: return@withContext JSONObject().put("closed", false)
             }
-            pendingRequests[id] = PendingPiBridgeRequest(
+            val pendingRequest = PendingPiBridgeRequest(
                 response = response,
                 processGeneration = requestProcess.generation,
+                lastFrameUptimeMillis = AtomicLong(SystemClock.uptimeMillis()),
+                activityChannel = activityChannel,
                 eventChannel = eventChannel,
                 eventJob = eventJob,
             )
+            pendingRequests[id] = pendingRequest
             onSetupProgress(PiCoreSetupUpdate(PiCoreSetupPhase.VerifyingBridge))
             val request = PiBridgeRequest(id = id, type = type, payload = payload)
             synchronized(requestProcess.writer) {
                 request.writeJsonLine(requestProcess.writer)
                 requestProcess.writer.flush()
             }
-            val frame = if (timeoutMillis == null) {
-                response.await()
-            } else {
-                withTimeout(timeoutMillis) { response.await() }
-            }
+            val frame = awaitResponse(
+                response = response,
+                activityChannel = activityChannel,
+                timeoutMillis = timeoutMillis,
+                inactivityTimeoutMillis = inactivityTimeoutMillis,
+                lastFrameUptimeMillis = pendingRequest.lastFrameUptimeMillis,
+            )
             if (!frame.ok || frame.type == "error") {
                 val error = frame.error
                 throw PiBridgeException(
@@ -480,6 +498,28 @@ class PiKernelBridge(
                 details = diagnosticDetails + mapOf("frame_type" to frame.type),
             )
             frame.payload
+        } catch (bridgeException: PiBridgeException) {
+            if (bridgeException.code == PiBridgeInactivityTimeoutCode) {
+                diagnosticLogger.event(
+                    category = "pi_bridge",
+                    event = "request_inactive",
+                    level = "warn",
+                    requestId = id,
+                    details = diagnosticDetails,
+                )
+                if (abortOnCancellation) {
+                    abortRequest(id, payload)
+                }
+            } else {
+                diagnosticLogger.exception(
+                    category = "pi_bridge",
+                    event = "request_failed",
+                    throwable = bridgeException,
+                    requestId = id,
+                    details = diagnosticDetails,
+                )
+            }
+            throw bridgeException
         } catch (cancellationException: CancellationException) {
             diagnosticLogger.event(
                 category = "pi_bridge",
@@ -489,19 +529,7 @@ class PiKernelBridge(
                 details = diagnosticDetails,
             )
             if (abortOnCancellation) {
-                markRequestCancelled(id)
-                withContext(NonCancellable) {
-                    runCatching {
-                        request(
-                            type = "abort",
-                            payload = JSONObject()
-                                .put("request_id", id)
-                                .put("session_id", payload.optString("session_id")),
-                            timeoutMillis = PiBridgePingTimeoutMillis,
-                            abortOnCancellation = false,
-                        )
-                    }
-                }
+                abortRequest(id, payload)
             }
             throw cancellationException
         } catch (throwable: Throwable) {
@@ -515,8 +543,60 @@ class PiKernelBridge(
             throw throwable
         } finally {
             pendingRequests.remove(id)
+            activityChannel?.close()
             eventChannel?.close()
             eventJob?.cancelAndJoin()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun awaitResponse(
+        response: CompletableDeferred<PiBridgeFrame>,
+        activityChannel: Channel<Unit>?,
+        timeoutMillis: Long?,
+        inactivityTimeoutMillis: Long?,
+        lastFrameUptimeMillis: AtomicLong?,
+    ): PiBridgeFrame {
+        if (timeoutMillis != null) {
+            return withTimeout(timeoutMillis) { response.await() }
+        }
+        if (inactivityTimeoutMillis == null || activityChannel == null || lastFrameUptimeMillis == null) {
+            return response.await()
+        }
+        while (!response.isCompleted) {
+            val elapsedMillis = SystemClock.uptimeMillis() - lastFrameUptimeMillis.get()
+            val remainingMillis = inactivityTimeoutMillis - elapsedMillis
+            if (remainingMillis <= 0L) {
+                throw PiBridgeException(
+                    message = "Pi bridge stopped responding.",
+                    code = PiBridgeInactivityTimeoutCode,
+                )
+            }
+            select<Unit> {
+                response.onAwait { }
+                activityChannel.onReceiveCatching { }
+                onTimeout(remainingMillis) { }
+            }
+        }
+        return response.await()
+    }
+
+    private suspend fun abortRequest(
+        requestId: String,
+        payload: JSONObject,
+    ) {
+        markRequestCancelled(requestId)
+        withContext(NonCancellable) {
+            runCatching {
+                request(
+                    type = "abort",
+                    payload = JSONObject()
+                        .put("request_id", requestId)
+                        .put("session_id", payload.optString("session_id")),
+                    timeoutMillis = PiBridgePingTimeoutMillis,
+                    abortOnCancellation = false,
+                )
+            }
         }
     }
 
@@ -736,6 +816,8 @@ class PiKernelBridge(
     ) {
         val pending = pendingRequests[frame.id]
         if (pending != null && pending.processGeneration != processGeneration) return
+        pending?.lastFrameUptimeMillis?.set(SystemClock.uptimeMillis())
+        pending?.activityChannel?.trySend(Unit)
         when {
             pending != null && pending.eventChannel != null -> {
                 if (pending.eventChannel.trySend(frame).isFailure) {

--- a/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
@@ -355,7 +355,14 @@ private fun AetherAppContent(
     val activeProviderConfig = uiState.providerConfigs.firstOrNull { it.isEnabled }
         ?: uiState.providerConfigs.firstOrNull()
     val currentSessionExecution = uiState.sessionExecutionStates[uiState.currentSessionId]
-    val currentMessages = activeSession?.messages.orEmpty()
+    val activeStreamingResponseGroupId = currentSessionExecution
+        ?.takeIf { it.isRunning }
+        ?.activeResponseGroupId
+    val currentMessages = activeSession?.messages.orEmpty().filterNot { message ->
+        activeStreamingResponseGroupId != null &&
+            message.isIncomplete &&
+            message.responseGroupId == activeStreamingResponseGroupId
+    }
     val selectedSkillIds = activeSession?.selectedSkillIds ?: uiState.draftSelectedSkillIds
     val selectedMcpServerIds = activeSession?.activeMcpServerIds ?: uiState.draftSelectedMcpServerIds
     val effectiveTermuxSetupState = effectiveTermuxSetupState(

--- a/app/src/main/java/com/zhousl/aether/ui/AetherUiState.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherUiState.kt
@@ -191,6 +191,7 @@ data class ChatMessage(
     val branchGroup: ChatBranchGroup? = null,
     val responseGroupId: String? = null,
     val assistantActionsHidden: Boolean = false,
+    val isIncomplete: Boolean = false,
     val providerPayloadJson: String = "",
     val displayKind: MessageDisplayKind = MessageDisplayKind.Standard,
     val usageStatistics: ChatUsageStatistics? = null,

--- a/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
@@ -145,6 +145,34 @@ class ChatRepositorySerializationTest {
     }
 
     @Test
+    fun sessionRoundTripPreservesIncompleteStreamingCheckpoint() {
+        val serialized = serializeChatSessions(
+            listOf(
+                ChatSession(
+                    id = "session-checkpoint",
+                    title = "Checkpoint",
+                    preview = "partial",
+                    messages = listOf(
+                        ChatMessage(
+                            id = "agent-checkpoint",
+                            author = MessageAuthor.Agent,
+                            text = "partial output",
+                            isIncomplete = true,
+                            responseGroupId = "agent-group-turn-1",
+                        )
+                    ),
+                )
+            )
+        )
+
+        val restored = parseChatSessions(serialized).single().messages.single()
+
+        assertTrue(restored.isIncomplete)
+        assertEquals("partial output", restored.text)
+        assertEquals("agent-group-turn-1", restored.responseGroupId)
+    }
+
+    @Test
     fun sessionRoundTripPreservesChromeSelection() {
         val serialized = serializeChatSessions(
             listOf(

--- a/app/src/test/java/com/zhousl/aether/data/ChatStateStoreTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ChatStateStoreTest.kt
@@ -1,0 +1,236 @@
+package com.zhousl.aether.data
+
+import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.ChatSession
+import com.zhousl.aether.ui.MessageAuthor
+import java.util.ArrayDeque
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatStateStoreTest {
+    @Test
+    fun checkpointQueuedWithDeletionPersistsWithoutPublishingCheckpointToUi() = runBlocking {
+        val deletedSession = ChatSession(
+            id = "deleted-session",
+            title = "Deleted",
+            preview = "before",
+            messages = emptyList(),
+        )
+        val checkpointSessionId = "checkpoint-session"
+        val responseGroupId = "response-group"
+        val checkpointMessage = ChatMessage(
+            id = "agent-checkpoint",
+            author = MessageAuthor.Agent,
+            text = "partial",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        val checkpointSession = ChatSession(
+            id = checkpointSessionId,
+            title = "Checkpoint",
+            preview = "before",
+            messages = emptyList(),
+        )
+        val initialState = PersistedChatState(
+            sessions = listOf(deletedSession, checkpointSession),
+            currentSessionId = checkpointSessionId,
+        )
+        val repository = RecordingChatStatePersistence(initialState)
+        val dispatcher = QueuedCoroutineDispatcher()
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        try {
+            val store = ChatStateStore(
+                scope = scope,
+                chatRepository = repository,
+            )
+            dispatcher.runUntilIdle()
+
+            store.update(writeIntent = PersistedChatWriteIntent.DeleteSession) { state ->
+                state.copy(sessions = state.sessions.filterNot { it.id == deletedSession.id })
+            }
+            val checkpoint = AssistantResponseCheckpoint(
+                target = AssistantResponseCheckpointTarget(
+                    sessionId = checkpointSessionId,
+                    responseGroupId = responseGroupId,
+                ),
+                fromPosition = 0,
+                messages = listOf(checkpointMessage),
+            )
+            assertTrue(store.updateAssistantCheckpoint(checkpoint))
+
+            assertEquals(emptyList<ChatMessage>(), store.state.value.sessions.single().messages)
+            assertTrue(repository.operations.isEmpty())
+            dispatcher.runUntilIdle()
+
+            assertEquals(emptyList<ChatMessage>(), store.state.value.sessions.single().messages)
+            val snapshotWrite = repository.operations.filterIsInstance<PersistedOperation.Snapshot>().single()
+            val checkpointWrite = repository.operations.filterIsInstance<PersistedOperation.Checkpoint>().single()
+            assertEquals(listOf(checkpointSessionId), snapshotWrite.sessions.map { it.id })
+            assertEquals(emptyList<ChatMessage>(), snapshotWrite.sessions.single().messages)
+            assertEquals(listOf(checkpoint), checkpointWrite.checkpoints)
+            assertEquals(
+                listOf(PersistedOperation.Snapshot::class, PersistedOperation.Checkpoint::class),
+                repository.operations.map { it::class },
+            )
+        } finally {
+            scope.cancel()
+            dispatcher.runUntilIdle()
+        }
+    }
+
+    @Test
+    fun checkpointQueuePersistsOnlyDirtyResponseAndReplaysActiveResponsesAfterSnapshot() = runBlocking {
+        val firstSession = ChatSession(id = "first", title = "First", preview = "")
+        val secondSession = ChatSession(id = "second", title = "Second", preview = "")
+        val repository = RecordingChatStatePersistence(
+            PersistedChatState(
+                sessions = listOf(firstSession, secondSession),
+                currentSessionId = firstSession.id,
+            )
+        )
+        val dispatcher = QueuedCoroutineDispatcher()
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        try {
+            val store = ChatStateStore(scope = scope, chatRepository = repository)
+            dispatcher.runUntilIdle()
+
+            val firstCheckpoint = checkpointFor(sessionId = firstSession.id, responseGroupId = "first-response")
+            val secondCheckpoint = checkpointFor(sessionId = secondSession.id, responseGroupId = "second-response")
+
+            store.updateAssistantCheckpoint(firstCheckpoint)
+            dispatcher.runUntilIdle()
+            store.updateAssistantCheckpoint(secondCheckpoint)
+            dispatcher.runUntilIdle()
+
+            assertEquals(
+                listOf(listOf(firstCheckpoint), listOf(secondCheckpoint)),
+                repository.operations
+                    .filterIsInstance<PersistedOperation.Checkpoint>()
+                    .map { it.checkpoints },
+            )
+
+            store.update { state ->
+                state.copy(
+                    sessions = state.sessions.map { session ->
+                        if (session.id == firstSession.id) session.copy(title = "Renamed") else session
+                    },
+                )
+            }
+            dispatcher.runUntilIdle()
+
+            val lastOperations = repository.operations.takeLast(2)
+            assertTrue(lastOperations[0] is PersistedOperation.Snapshot)
+            assertEquals(
+                setOf(firstCheckpoint, secondCheckpoint),
+                (lastOperations[1] as PersistedOperation.Checkpoint).checkpoints.toSet(),
+            )
+
+            val completed = firstCheckpoint.messages.single().copy(isIncomplete = false)
+            store.update { state ->
+                state.copy(
+                    sessions = state.sessions.map { session ->
+                        if (session.id == firstSession.id) {
+                            session.copy(messages = listOf(completed))
+                        } else {
+                            session
+                        }
+                    },
+                )
+            }
+            dispatcher.runUntilIdle()
+
+            assertEquals(
+                listOf(secondCheckpoint),
+                (repository.operations.last() as PersistedOperation.Checkpoint).checkpoints,
+            )
+        } finally {
+            scope.cancel()
+            dispatcher.runUntilIdle()
+        }
+    }
+
+    private fun checkpointFor(
+        sessionId: String,
+        responseGroupId: String,
+    ): AssistantResponseCheckpoint = AssistantResponseCheckpoint(
+        target = AssistantResponseCheckpointTarget(
+            sessionId = sessionId,
+            responseGroupId = responseGroupId,
+        ),
+        fromPosition = 0,
+        messages = listOf(
+            ChatMessage(
+                id = "$sessionId-agent",
+                author = MessageAuthor.Agent,
+                text = "partial",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+        ),
+    )
+}
+
+private class RecordingChatStatePersistence(
+    initialState: PersistedChatState,
+) : ChatStatePersistence {
+    override val chatState: Flow<PersistedChatState> = MutableStateFlow(initialState)
+    val operations = mutableListOf<PersistedOperation>()
+
+    override suspend fun updateChatState(
+        sessions: List<ChatSession>,
+        currentSessionId: String,
+        writeIntent: PersistedChatWriteIntent,
+    ) {
+        operations += PersistedOperation.Snapshot(
+            sessions = sessions,
+            currentSessionId = currentSessionId,
+            writeIntent = writeIntent,
+        )
+    }
+
+    override suspend fun upsertAssistantResponseCheckpoints(
+        checkpoints: List<AssistantResponseCheckpoint>,
+    ) {
+        operations += PersistedOperation.Checkpoint(checkpoints)
+    }
+}
+
+private sealed interface PersistedOperation {
+    data class Snapshot(
+        val sessions: List<ChatSession>,
+        val currentSessionId: String,
+        val writeIntent: PersistedChatWriteIntent,
+    ) : PersistedOperation
+
+    data class Checkpoint(
+        val checkpoints: List<AssistantResponseCheckpoint>,
+    ) : PersistedOperation
+}
+
+private class QueuedCoroutineDispatcher : CoroutineDispatcher() {
+    private val tasks = ArrayDeque<Runnable>()
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        synchronized(tasks) {
+            tasks.addLast(block)
+        }
+    }
+
+    fun runUntilIdle() {
+        while (true) {
+            val task = synchronized(tasks) {
+                if (tasks.isEmpty()) null else tasks.removeFirst()
+            } ?: return
+            task.run()
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Remove the bridge-wide wall-clock timeout from `run_turn` and `follow_up` so long-running Agent tasks are not aborted after ten minutes.
- Persist incomplete streamed assistant responses with stable response-group identities so partial output survives an interrupted app process.
- Persist checkpoints incrementally instead of rewriting the full session history, including workspace-file references.
- Coalesce checkpoint targets across concurrently running sessions so a conflated persistence queue does not drop another session’s pending response checkpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added response-group–scoped checkpoint upserts for streaming assistant messages, including incremental persistence during generation.
  * Messages now support an “incomplete” flag that’s saved and restored across launches.

* **Bug Fixes**
  * The UI now hides only incomplete messages from the currently running streaming response group.
  * Improved turn handling by using inactivity-based timeouts instead of a fixed wall-clock timeout.

* **Tests**
  * Added/expanded unit and instrumented tests for checkpoint replacement behavior, ordering, and incomplete-state serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->