### PR TITLE
Fix input box blocked by keyboard (#35)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTop"
-            android:windowSoftInputMode="adjustNothing"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Aether">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Fixes #35 by changing `windowSoftInputMode` to `adjustResize` in AndroidManifest.xml, allowing Compose's `Modifier.imePadding()` to correctly adjust the layout on older Android versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard behavior by allowing the app window to resize when the on-screen keyboard appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->