### PR TITLE
feat: persist streaming response checkpoints

### DIFF
--- a/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/5.json
+++ b/app/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/5.json
@@ -1,0 +1,344 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "caabd047843620dcf2fdcd2f75d521b0",
+    "entities": [
+      {
+        "tableName": "chat_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `preview` TEXT NOT NULL, `hasCustomTitle` INTEGER NOT NULL, `selectedSkillIdsJson` TEXT NOT NULL, `activeSkillsJson` TEXT NOT NULL, `activeMcpServerIdsJson` TEXT NOT NULL, `agentModeEnabled` INTEGER NOT NULL, `chromeEnabled` INTEGER NOT NULL, `selectedModelKey` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomTitle",
+            "columnName": "hasCustomTitle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSkillIdsJson",
+            "columnName": "selectedSkillIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeSkillsJson",
+            "columnName": "activeSkillsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeMcpServerIdsJson",
+            "columnName": "activeMcpServerIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentModeEnabled",
+            "columnName": "agentModeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chromeEnabled",
+            "columnName": "chromeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedModelKey",
+            "columnName": "selectedModelKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `id` TEXT NOT NULL, `position` INTEGER NOT NULL, `messageJson` TEXT NOT NULL, `author` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAtMillis` INTEGER, `responseGroupId` TEXT, `displayKind` TEXT, `messageSchemaVersion` INTEGER NOT NULL, `hasUsageStatistics` INTEGER NOT NULL, `isIncomplete` INTEGER NOT NULL, PRIMARY KEY(`sessionId`, `id`), FOREIGN KEY(`sessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageJson",
+            "columnName": "messageJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "responseGroupId",
+            "columnName": "responseGroupId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayKind",
+            "columnName": "displayKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "messageSchemaVersion",
+            "columnName": "messageSchemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasUsageStatistics",
+            "columnName": "hasUsageStatistics",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncomplete",
+            "columnName": "isIncomplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_sessionId_position",
+            "unique": true,
+            "columnNames": [
+              "sessionId",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chat_messages_sessionId_position` ON `${TABLE_NAME}` (`sessionId`, `position`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_responseGroupId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "responseGroupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_responseGroupId` ON `${TABLE_NAME}` (`sessionId`, `responseGroupId`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_author",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "author"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_author` ON `${TABLE_NAME}` (`sessionId`, `author`)"
+          },
+          {
+            "name": "index_chat_messages_hasUsageStatistics",
+            "unique": false,
+            "columnNames": [
+              "hasUsageStatistics"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_hasUsageStatistics` ON `${TABLE_NAME}` (`hasUsageStatistics`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_workspace_file_refs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `messageId` TEXT NOT NULL, `path` TEXT NOT NULL, PRIMARY KEY(`sessionId`, `messageId`, `path`), FOREIGN KEY(`sessionId`, `messageId`) REFERENCES `chat_messages`(`sessionId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "messageId",
+            "path"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_workspace_file_refs_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId",
+              "messageId"
+            ],
+            "referencedColumns": [
+              "sessionId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_state_meta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `currentSessionId` TEXT, `roomMigrationComplete` INTEGER NOT NULL, `workspaceFileRefsComplete` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`currentSessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentSessionId",
+            "columnName": "currentSessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roomMigrationComplete",
+            "columnName": "roomMigrationComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workspaceFileRefsComplete",
+            "columnName": "workspaceFileRefsComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_state_meta_currentSessionId",
+            "unique": false,
+            "columnNames": [
+              "currentSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_state_meta_currentSessionId` ON `${TABLE_NAME}` (`currentSessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "currentSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'caabd047843620dcf2fdcd2f75d521b0')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/zhousl/aether/data/ChatRepositoryCheckpointInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/zhousl/aether/data/ChatRepositoryCheckpointInstrumentedTest.kt
@@ -1,0 +1,343 @@
+package com.zhousl.aether.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.zhousl.aether.data.chatdb.ChatHistoryDatabase
+import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.ChatSession
+import com.zhousl.aether.ui.MessageAuthor
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private val TestSessionsJson = stringPreferencesKey("sessions_json")
+private val TestCurrentSessionId = stringPreferencesKey("current_session_id")
+private val TestRoomMigrationComplete = booleanPreferencesKey("room_migration_complete")
+
+private suspend fun clearLegacyChatState(context: Context) {
+    context.chatDataStore.edit { preferences ->
+        preferences.remove(TestSessionsJson)
+        preferences.remove(TestCurrentSessionId)
+        preferences.remove(TestRoomMigrationComplete)
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class ChatRepositoryCheckpointInstrumentedTest {
+    private lateinit var database: ChatHistoryDatabase
+    private lateinit var repository: ChatRepository
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        runBlocking { clearLegacyChatState(context) }
+        database = Room.inMemoryDatabaseBuilder(context, ChatHistoryDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = ChatRepository(context, database)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        runBlocking { clearLegacyChatState(context) }
+    }
+
+    @Test
+    fun checkpointUpsertTouchesOnlyTargetResponseAndCompletionReplacesIt() = runBlocking {
+        val sessionId = "session-checkpoint"
+        val responseGroupId = "agent-group-turn-checkpoint"
+        val before = ChatMessage(
+            id = "user-before",
+            author = MessageAuthor.User,
+            text = "before",
+        )
+        val checkpointText = ChatMessage(
+            id = "agent-checkpoint-text",
+            author = MessageAuthor.Agent,
+            text = "partial",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        val checkpointTool = ChatMessage(
+            id = "agent-checkpoint-tool",
+            author = MessageAuthor.Agent,
+            text = "tool output",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        val session = ChatSession(
+            id = sessionId,
+            title = "Checkpoint",
+            preview = "before",
+            messages = listOf(before),
+        )
+        val unrelated = ChatSession(
+            id = "unrelated-session",
+            title = "Unrelated",
+            preview = "untouched",
+            messages = listOf(
+                ChatMessage(
+                    id = "unrelated-message",
+                    author = MessageAuthor.User,
+                    text = "untouched",
+                ),
+            ),
+        )
+
+        repository.updateChatState(
+            sessions = listOf(session, unrelated),
+            currentSessionId = sessionId,
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(checkpointText),
+                ),
+            ),
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(
+                        checkpointText.copy(text = "more partial"),
+                        checkpointTool,
+                    ),
+                ),
+            ),
+        )
+
+        val checkpointPositions = database.chatHistoryDao()
+            .getMessageSummariesForSession(sessionId)
+            .map { it.position }
+        val checkpointSession = repository.getSessionWithMessages(sessionId)
+        val checkpointMessages = checkpointSession?.messages.orEmpty()
+        assertEquals(listOf(0, 1, 2), checkpointPositions)
+        assertEquals(
+            listOf("user-before", "agent-checkpoint-text", "agent-checkpoint-tool"),
+            checkpointMessages.map { it.id },
+        )
+        assertEquals("more partial", checkpointMessages[1].text)
+        assertTrue(checkpointMessages.drop(1).all { it.isIncomplete })
+        assertEquals("before", checkpointSession?.preview)
+        assertEquals(
+            listOf("unrelated-message"),
+            repository.getSessionWithMessages(unrelated.id)?.messages.orEmpty().map { it.id },
+        )
+
+        val reshapedCheckpoint = ChatMessage(
+            id = "agent-checkpoint-reshaped",
+            author = MessageAuthor.Agent,
+            text = "reshaped partial",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(reshapedCheckpoint),
+                ),
+            ),
+        )
+
+        val reshapedPositions = database.chatHistoryDao()
+            .getMessageSummariesForSession(sessionId)
+            .map { it.position }
+        val reshapedSession = repository.getSessionWithMessages(sessionId)
+        assertEquals(listOf(0, 1), reshapedPositions)
+        assertEquals(
+            listOf("user-before", "agent-checkpoint-reshaped"),
+            reshapedSession?.messages.orEmpty().map { it.id },
+        )
+
+        val completedMessages = listOf(
+            reshapedCheckpoint.copy(text = "complete", isIncomplete = false),
+        )
+        repository.updateChatState(
+            sessions = listOf(
+                session.copy(
+                    preview = "complete",
+                    messages = listOf(before) + completedMessages,
+                ),
+                unrelated,
+            ),
+            currentSessionId = sessionId,
+        )
+
+        val completedPositions = database.chatHistoryDao()
+            .getMessageSummariesForSession(sessionId)
+            .map { it.position }
+        val restoredCompletion = repository.getSessionWithMessages(sessionId)
+        assertEquals(listOf(0, 1), completedPositions)
+        assertEquals(
+            listOf("user-before", "agent-checkpoint-reshaped"),
+            restoredCompletion?.messages.orEmpty().map { it.id },
+        )
+        assertTrue(restoredCompletion?.messages.orEmpty().drop(1).all { !it.isIncomplete })
+        assertFalse(restoredCompletion?.messages.orEmpty()[1].isIncomplete)
+        assertEquals(responseGroupId, restoredCompletion?.messages.orEmpty()[1].responseGroupId)
+        assertEquals("complete", restoredCompletion?.preview)
+    }
+
+    @Test
+    fun checkpointUpsertPreservesUnrelatedMessagesAfterTarget() = runBlocking {
+        val sessionId = "session-checkpoint-tail"
+        val responseGroupId = "agent-group-target"
+        val otherResponseGroupId = "agent-group-other"
+        val before = ChatMessage(
+            id = "user-before-tail",
+            author = MessageAuthor.User,
+            text = "before",
+        )
+        val oldCheckpointMessages = listOf(
+            ChatMessage(
+                id = "agent-target-text",
+                author = MessageAuthor.Agent,
+                text = "partial",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+            ChatMessage(
+                id = "agent-target-tool",
+                author = MessageAuthor.Agent,
+                text = "tool output",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+        )
+        val userAfter = ChatMessage(
+            id = "user-after-target",
+            author = MessageAuthor.User,
+            text = "keep this user message",
+        )
+        val otherResponse = ChatMessage(
+            id = "agent-other-response",
+            author = MessageAuthor.Agent,
+            text = "keep this response",
+            responseGroupId = otherResponseGroupId,
+        )
+        val session = ChatSession(
+            id = sessionId,
+            title = "Checkpoint tail",
+            preview = "keep this response",
+            messages = listOf(before) + oldCheckpointMessages + userAfter + otherResponse,
+        )
+        repository.updateChatState(
+            sessions = listOf(session),
+            currentSessionId = sessionId,
+        )
+
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = listOf(
+                        ChatMessage(
+                            id = "agent-target-reshaped",
+                            author = MessageAuthor.Agent,
+                            text = "reshaped partial",
+                            isIncomplete = true,
+                            responseGroupId = responseGroupId,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val shrunkSummaries = database.chatHistoryDao().getMessageSummariesForSession(sessionId)
+        val shrunkMessages = repository.getSessionWithMessages(sessionId)?.messages.orEmpty()
+        assertEquals(listOf(0, 1, 2, 3), shrunkSummaries.map { it.position })
+        assertEquals(
+            listOf(
+                "user-before-tail",
+                "agent-target-reshaped",
+                "user-after-target",
+                "agent-other-response",
+            ),
+            shrunkMessages.map { it.id },
+        )
+        assertEquals(otherResponseGroupId, shrunkMessages.last().responseGroupId)
+
+        val grownCheckpointMessages = listOf(
+            ChatMessage(
+                id = "agent-target-reshaped",
+                author = MessageAuthor.Agent,
+                text = "reshaped partial",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+            ChatMessage(
+                id = "agent-target-reasoning",
+                author = MessageAuthor.Agent,
+                text = "reasoning",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+            ChatMessage(
+                id = "agent-target-result",
+                author = MessageAuthor.Agent,
+                text = "result",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+        )
+        repository.upsertAssistantResponseCheckpoints(
+            checkpoints = listOf(
+                AssistantResponseCheckpoint(
+                    target = AssistantResponseCheckpointTarget(
+                        sessionId = sessionId,
+                        responseGroupId = responseGroupId,
+                    ),
+                    fromPosition = 1,
+                    messages = grownCheckpointMessages,
+                ),
+            ),
+        )
+
+        val grownSummaries = database.chatHistoryDao().getMessageSummariesForSession(sessionId)
+        val grownMessages = repository.getSessionWithMessages(sessionId)?.messages.orEmpty()
+        assertEquals(listOf(0, 1, 2, 3, 4, 5), grownSummaries.map { it.position })
+        assertEquals(
+            listOf(
+                "user-before-tail",
+                "agent-target-reshaped",
+                "agent-target-reasoning",
+                "agent-target-result",
+                "user-after-target",
+                "agent-other-response",
+            ),
+            grownMessages.map { it.id },
+        )
+        assertEquals(otherResponseGroupId, grownMessages.last().responseGroupId)
+    }
+}

--- a/app/src/androidTest/java/com/zhousl/aether/data/chatdb/ChatHistoryMigrationTest.kt
+++ b/app/src/androidTest/java/com/zhousl/aether/data/chatdb/ChatHistoryMigrationTest.kt
@@ -3,7 +3,10 @@ package com.zhousl.aether.data.chatdb
 import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.platform.app.InstrumentationRegistry
+import com.zhousl.aether.data.ChatMessageEntityMapper
+import com.zhousl.aether.ui.MessageAuthor
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -18,7 +21,7 @@ class ChatHistoryMigrationTest {
     )
 
     @Test
-    fun migrate1To4PreservesDataAndAddsCurrentSchema() {
+    fun migrate1To5PreservesDataAndAddsCurrentSchema() {
         helper.createDatabase(TEST_DATABASE, 1).apply {
             execSQL(
                 """
@@ -36,7 +39,7 @@ class ChatHistoryMigrationTest {
                     createdAtMillis, responseGroupId, displayKind, messageSchemaVersion
                 ) VALUES (
                     'session-1', 'message-1', 0,
-                    '{"usageStatistics":{"inputTokens":1}}',
+                    '{"usageStatistics":{"inputTokens":1},"isIncomplete":true}',
                     'assistant', 'With usage', NULL, NULL, NULL, 1
                 )
                 """.trimIndent(),
@@ -54,6 +57,18 @@ class ChatHistoryMigrationTest {
             )
             execSQL(
                 """
+                INSERT INTO chat_messages (
+                    sessionId, id, position, messageJson, author, text,
+                    createdAtMillis, responseGroupId, displayKind, messageSchemaVersion
+                ) VALUES (
+                    'session-1', 'message-3', 2,
+                    '{"note":"\"isIncomplete\":true","isIncomplete":false}',
+                    'assistant', 'Complete with lookalike text', NULL, NULL, NULL, 1
+                )
+                """.trimIndent(),
+            )
+            execSQL(
+                """
                 INSERT INTO chat_state_meta (id, currentSessionId, roomMigrationComplete)
                 VALUES ('singleton', 'session-1', 1)
                 """.trimIndent(),
@@ -63,11 +78,9 @@ class ChatHistoryMigrationTest {
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE,
-            4,
+            5,
             true,
-            Migration1To2,
-            Migration2To3,
-            Migration3To4,
+            *ChatHistoryMigrations,
         ).use { database ->
             database.query(
                 "SELECT id, chromeEnabled FROM chat_sessions WHERE id = 'session-1'",
@@ -78,14 +91,20 @@ class ChatHistoryMigrationTest {
             }
 
             database.query(
-                "SELECT id, hasUsageStatistics FROM chat_messages ORDER BY position",
+                "SELECT id, hasUsageStatistics, isIncomplete FROM chat_messages ORDER BY position",
             ).use { cursor ->
                 assertTrue(cursor.moveToFirst())
                 assertEquals("message-1", cursor.getString(0))
                 assertEquals(1, cursor.getInt(1))
+                assertEquals(1, cursor.getInt(2))
                 assertTrue(cursor.moveToNext())
                 assertEquals("message-2", cursor.getString(0))
                 assertEquals(0, cursor.getInt(1))
+                assertEquals(0, cursor.getInt(2))
+                assertTrue(cursor.moveToNext())
+                assertEquals("message-3", cursor.getString(0))
+                assertEquals(0, cursor.getInt(1))
+                assertEquals(0, cursor.getInt(2))
             }
 
             database.query("PRAGMA table_info(chat_workspace_file_refs)").use { cursor ->
@@ -101,7 +120,104 @@ class ChatHistoryMigrationTest {
         }
     }
 
+    @Test
+    fun migrate4To5LeavesMalformedMessageJsonForMapperRecovery() {
+        val malformedJson = "{not-valid-json"
+        helper.createDatabase(MALFORMED_JSON_DATABASE, 4).apply {
+            execSQL(
+                """
+                INSERT INTO chat_sessions (
+                    id, title, preview, hasCustomTitle, selectedSkillIdsJson,
+                    activeSkillsJson, activeMcpServerIdsJson, agentModeEnabled,
+                    chromeEnabled, selectedModelKey, sortOrder
+                ) VALUES ('session-1', 'Title', 'Preview', 0, '[]', '[]', '[]', 0, 0, '', 0)
+                """.trimIndent(),
+            )
+            execSQL(
+                """
+                INSERT INTO chat_messages (
+                    sessionId, id, position, messageJson, author, text,
+                    createdAtMillis, responseGroupId, displayKind, messageSchemaVersion,
+                    hasUsageStatistics
+                ) VALUES (
+                    'session-1', 'message-1', 0, '{"isIncomplete":true}',
+                    'assistant', 'Incomplete response', 1001, 'group-1', NULL, 1, 0
+                )
+                """.trimIndent(),
+            )
+            execSQL(
+                """
+                INSERT INTO chat_messages (
+                    sessionId, id, position, messageJson, author, text,
+                    createdAtMillis, responseGroupId, displayKind, messageSchemaVersion,
+                    hasUsageStatistics
+                ) VALUES (
+                    'session-1', 'message-2', 1, '$malformedJson',
+                    'assistant', 'Partial response', 1002, 'group-2', NULL, 1, 0
+                )
+                """.trimIndent(),
+            )
+            close()
+        }
+
+        helper.runMigrationsAndValidate(
+            MALFORMED_JSON_DATABASE,
+            5,
+            true,
+            *ChatHistoryMigrations,
+        ).use { database ->
+            database.query(
+                "SELECT id, isIncomplete FROM chat_messages ORDER BY position",
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("message-1", cursor.getString(0))
+                assertEquals(1, cursor.getInt(1))
+                assertTrue(cursor.moveToNext())
+                assertEquals("message-2", cursor.getString(0))
+                assertEquals(0, cursor.getInt(1))
+            }
+
+            database.query(
+                """
+                SELECT sessionId, id, position, messageJson, author, text,
+                    createdAtMillis, responseGroupId, displayKind, messageSchemaVersion,
+                    hasUsageStatistics, isIncomplete
+                FROM chat_messages
+                WHERE id = 'message-2'
+                """.trimIndent(),
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                val recovered = ChatMessageEntityMapper.toChatMessage(
+                    entity = ChatMessageEntity(
+                        sessionId = cursor.getString(0),
+                        id = cursor.getString(1),
+                        position = cursor.getInt(2),
+                        messageJson = cursor.getString(3),
+                        author = cursor.getString(4),
+                        text = cursor.getString(5),
+                        createdAtMillis = cursor.getLong(6),
+                        responseGroupId = cursor.getString(7),
+                        displayKind = cursor.getString(8),
+                        messageSchemaVersion = cursor.getInt(9),
+                        hasUsageStatistics = cursor.getInt(10) != 0,
+                        isIncomplete = cursor.getInt(11) != 0,
+                    ),
+                    messageIndex = 1,
+                )
+
+                assertEquals("message-2", recovered.id)
+                assertEquals(MessageAuthor.Agent, recovered.author)
+                assertEquals("Partial response", recovered.text)
+                assertEquals(1002L, recovered.createdAtMillis)
+                assertEquals("group-2", recovered.responseGroupId)
+                assertEquals(malformedJson, recovered.providerPayloadJson)
+                assertFalse(recovered.isIncomplete)
+            }
+        }
+    }
+
     private companion object {
         const val TEST_DATABASE = "chat-history-migration-test"
+        const val MALFORMED_JSON_DATABASE = "chat-history-malformed-json-migration-test"
     }
 }

--- a/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatMessageEntityMapper.kt
@@ -38,14 +38,15 @@ internal object ChatMessageEntityMapper {
         displayKind = message.displayKind.name,
         messageSchemaVersion = CurrentMessageSchemaVersion,
         hasUsageStatistics = message.usageStatistics != null,
+        isIncomplete = message.isIncomplete,
     )
 
     fun toChatMessage(
         entity: ChatMessageEntity,
         messageIndex: Int,
     ): ChatMessage = runCatching {
-        // Keep messageJson as the compatibility source of truth during the typed-column transition.
-        parseMessage(JSONObject(entity.messageJson), messageIndex)
+        // The typed column is authoritative while messageJson remains a compatibility payload.
+        parseMessage(JSONObject(entity.messageJson), messageIndex).withStoredIncompleteFlag(entity.isIncomplete)
     }.getOrElse { throwable ->
         ChatMessage(
             id = entity.id,
@@ -56,6 +57,7 @@ internal object ChatMessageEntityMapper {
             },
             createdAtMillis = entity.createdAtMillis ?: timestampFromMessageId(entity.id),
             responseGroupId = entity.responseGroupId,
+            isIncomplete = entity.isIncomplete,
             providerPayloadJson = entity.messageJson,
             displayKind = entity.displayKind.toMessageDisplayKind(),
         )
@@ -67,8 +69,12 @@ internal object ChatMessageEntityMapper {
         text = entity.text,
         createdAtMillis = entity.createdAtMillis ?: timestampFromMessageId(entity.id),
         responseGroupId = entity.responseGroupId,
+        isIncomplete = entity.isIncomplete,
         displayKind = entity.displayKind.toMessageDisplayKind(),
     )
+
+    private fun ChatMessage.withStoredIncompleteFlag(isIncomplete: Boolean): ChatMessage =
+        if (isIncomplete != this.isIncomplete) copy(isIncomplete = isIncomplete) else this
 
     private fun String?.toMessageDisplayKind(): MessageDisplayKind =
         MessageDisplayKind.entries.firstOrNull { it.name == this } ?: MessageDisplayKind.Standard

--- a/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatRepository.kt
@@ -54,7 +54,7 @@ internal fun shouldStartNewMessageJsonBatch(currentBytes: Long, nextBytes: Long)
     currentBytes > 0L && nextBytes > MessageJsonBatchByteLimit - currentBytes
 
 
-private val Context.chatDataStore by preferencesDataStore(name = "aether_chats")
+internal val Context.chatDataStore by preferencesDataStore(name = "aether_chats")
 
 data class PersistedChatState(
     val sessions: List<ChatSession> = emptyList(),
@@ -66,22 +66,62 @@ data class ChatUsageStatisticsSnapshot(
     val statistics: ChatUsageStatistics,
 )
 
+data class AssistantResponseCheckpointTarget(
+    val sessionId: String,
+    val responseGroupId: String,
+)
+
+data class AssistantResponseCheckpoint(
+    val target: AssistantResponseCheckpointTarget,
+    val fromPosition: Int,
+    val messages: List<ChatMessage>,
+) {
+    init {
+        require(fromPosition >= 0) { "fromPosition must be non-negative" }
+        require(messages.isNotEmpty()) { "messages must not be empty" }
+        require(messages.all { it.responseGroupId == target.responseGroupId }) {
+            "checkpoint messages must belong to the target response"
+        }
+    }
+}
+
 enum class PersistedChatWriteIntent {
     SyncSnapshot,
     DeleteSession,
     ReplaceFromImport,
 }
 
+interface ChatStatePersistence {
+    val chatState: Flow<PersistedChatState>
+
+    suspend fun updateChatState(
+        sessions: List<ChatSession>,
+        currentSessionId: String,
+        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
+    )
+
+    suspend fun upsertAssistantResponseCheckpoints(
+        checkpoints: List<AssistantResponseCheckpoint>,
+    )
+}
+
+private data class AssistantResponseCheckpointUpsert(
+    val sessionId: String,
+    val responseGroupId: String,
+    val fromPosition: Int,
+    val messages: List<ChatMessage>,
+)
+
 class ChatRepository(
     private val context: Context,
     private val database: ChatHistoryDatabase = AndroidChatHistoryDatabaseFactory.getInstance(context),
-) {
+) : ChatStatePersistence {
     private val chatHistoryDao: ChatHistoryDao = database.chatHistoryDao()
     private val restoredMessageCache = mutableMapOf<ChatMessageCacheKey, LoadedChatMessage>()
     private val restoredMessageCacheMutex = Mutex()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val chatState: Flow<PersistedChatState> = flow {
+    override val chatState: Flow<PersistedChatState> = flow {
         migrateLegacyChatStateIfNeeded()
         emitAll(
             combine(
@@ -145,10 +185,10 @@ class ChatRepository(
         )
     }
 
-    suspend fun updateChatState(
+    override suspend fun updateChatState(
         sessions: List<ChatSession>,
         currentSessionId: String,
-        writeIntent: PersistedChatWriteIntent = PersistedChatWriteIntent.SyncSnapshot,
+        writeIntent: PersistedChatWriteIntent,
     ) {
         migrateLegacyChatStateIfNeeded()
         replaceChatStateBatched(
@@ -163,6 +203,18 @@ class ChatRepository(
             preferences[ROOM_MIGRATION_COMPLETE] = true
         }
     }
+
+    suspend fun updateChatState(
+        sessions: List<ChatSession>,
+        currentSessionId: String,
+    ) {
+        updateChatState(
+            sessions = sessions,
+            currentSessionId = currentSessionId,
+            writeIntent = PersistedChatWriteIntent.SyncSnapshot,
+        )
+    }
+
     suspend fun getSessionWithMessages(sessionId: String): ChatSession? {
         migrateLegacyChatStateIfNeeded()
         return restoredMessageCacheMutex.withLock {
@@ -339,6 +391,87 @@ class ChatRepository(
             messages = messages,
             startPosition = fromPosition,
         )
+    }
+
+    override suspend fun upsertAssistantResponseCheckpoints(
+        checkpoints: List<AssistantResponseCheckpoint>,
+    ) {
+        if (checkpoints.isEmpty()) return
+        val upserts = checkpoints
+            .associateBy { it.target }
+            .values
+            .map { checkpoint ->
+                AssistantResponseCheckpointUpsert(
+                    sessionId = checkpoint.target.sessionId,
+                    responseGroupId = checkpoint.target.responseGroupId,
+                    fromPosition = checkpoint.fromPosition,
+                    messages = checkpoint.messages,
+                )
+            }
+
+        upserts.forEach { upsert ->
+            invalidateRestoredMessagesFromPosition(
+                sessionId = upsert.sessionId,
+                fromPosition = upsert.fromPosition,
+            )
+        }
+        database.withTransaction {
+            upserts.forEach { upsert ->
+                if (chatHistoryDao.getSession(upsert.sessionId) == null) return@forEach
+                val previousMessageCount = chatHistoryDao.getMessageCountForResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                    fromPosition = upsert.fromPosition,
+                )
+                val previousSessionMessageCount = chatHistoryDao.getMessageCountForSession(upsert.sessionId)
+                val parkedMessageIds = chatHistoryDao.getMessageIdsToParkOutsideResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                    fromPosition = upsert.fromPosition,
+                    toPosition = previousSessionMessageCount,
+                )
+                chatHistoryDao.parkMessagesFromPositionOutsideResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                    fromPosition = upsert.fromPosition,
+                    toPosition = previousSessionMessageCount,
+                )
+                chatHistoryDao.deleteWorkspaceFileRefsForResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                    fromPosition = upsert.fromPosition,
+                )
+                chatHistoryDao.deleteMessagesForResponseGroup(
+                    sessionId = upsert.sessionId,
+                    responseGroupId = upsert.responseGroupId,
+                    fromPosition = upsert.fromPosition,
+                )
+                chatHistoryDao.upsertMessages(
+                    upsert.messages.mapIndexed { index, message ->
+                        ChatMessageEntityMapper.toEntity(
+                            sessionId = upsert.sessionId,
+                            position = upsert.fromPosition + index,
+                            message = message,
+                        )
+                    }
+                )
+                if (parkedMessageIds.isNotEmpty()) {
+                    chatHistoryDao.restoreParkedMessagesOutsideResponseGroup(
+                        sessionId = upsert.sessionId,
+                        responseGroupId = upsert.responseGroupId,
+                        fromPosition = upsert.fromPosition,
+                        toPosition = previousSessionMessageCount,
+                        checkpointEndPosition = upsert.fromPosition + upsert.messages.size,
+                        parkedMessageIds = parkedMessageIds,
+                        positionDelta = upsert.messages.size - previousMessageCount,
+                    )
+                }
+                replaceWorkspaceFileRefsForMessagesInTransaction(
+                    sessionId = upsert.sessionId,
+                    messages = upsert.messages,
+                )
+            }
+        }
     }
 
     private suspend fun ChatHistoryDao.upsertMessagesChunked(
@@ -739,6 +872,7 @@ private fun ChatMessageSummaryEntity.toMessageEntity(messageJson: String): ChatM
     responseGroupId = responseGroupId,
     displayKind = displayKind,
     messageSchemaVersion = messageSchemaVersion,
+    isIncomplete = isIncomplete,
 )
 
 private val ChatMessageSummaryEntity.cacheKey: ChatMessageCacheKey
@@ -753,6 +887,7 @@ private val ChatMessageSummaryEntity.cacheKey: ChatMessageCacheKey
         displayKind = displayKind,
         messageSchemaVersion = messageSchemaVersion,
         messageJsonLength = messageJsonLength,
+        isIncomplete = isIncomplete,
     )
 
 private data class ChatMessageCacheKey(
@@ -766,6 +901,7 @@ private data class ChatMessageCacheKey(
     val displayKind: String?,
     val messageSchemaVersion: Int,
     val messageJsonLength: Int?,
+    val isIncomplete: Boolean,
 )
 
 private data class LoadedChatMessage(
@@ -971,6 +1107,7 @@ internal fun parseMessage(message: JSONObject, messageIndex: Int): ChatMessage =
     branchGroup = parseBranchGroup(message.optJSONObject("branchGroup")),
     responseGroupId = message.optString("responseGroupId").ifBlank { null },
     assistantActionsHidden = message.optBoolean("assistantActionsHidden"),
+    isIncomplete = message.optBoolean("isIncomplete"),
     providerPayloadJson = message.optString("providerPayloadJson"),
     displayKind = parseMessageDisplayKind(message.optString("displayKind")),
     usageStatistics = parseUsageStatistics(message.optJSONObject("usageStatistics")),
@@ -992,6 +1129,9 @@ internal fun ChatMessage.toJson(): JSONObject = JSONObject().apply {
     responseGroupId?.let { put("responseGroupId", it) }
     if (assistantActionsHidden) {
         put("assistantActionsHidden", true)
+    }
+    if (isIncomplete) {
+        put("isIncomplete", true)
     }
     providerPayloadJson.takeIf { it.isNotBlank() }?.let {
         put("providerPayloadJson", it)

--- a/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ChatStateStore.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -23,7 +24,7 @@ private const val ChatStateStoreLogTag = "ChatStateStore"
 
 class ChatStateStore(
     private val scope: CoroutineScope,
-    private val chatRepository: ChatRepository,
+    private val chatRepository: ChatStatePersistence,
 ) {
     private val updateLock = Any()
     private val persistMutex = Mutex()
@@ -32,6 +33,7 @@ class ChatStateStore(
     private var localGeneration = 0L
     private var persistedGeneration = 0L
     private var latestPending: PendingPersistedChatState? = null
+    private var retainedCheckpoints = emptyMap<AssistantResponseCheckpointTarget, AssistantResponseCheckpoint>()
     private var repositoryStateLoaded = false
     private val repositoryStateReady = CompletableDeferred<Unit>()
 
@@ -40,35 +42,29 @@ class ChatStateStore(
     init {
         scope.launch {
             try {
-                chatRepository.chatState.collect { persisted ->
-                    val pendingAfterInitialLoad = synchronized(updateLock) {
-                        if (!repositoryStateLoaded) {
-                            repositoryStateLoaded = true
-                            if (localGeneration == persistedGeneration) {
-                                _state.value = persisted
-                                null
-                            } else {
-                                val merged = mergeRepositoryStateWithLocalUpdates(
-                                    repositoryState = persisted,
-                                    localState = _state.value,
-                                )
-                                _state.value = merged
-                                latestPending = latestPending?.copy(state = merged)
-                                latestPending
-                            }
-                        } else {
-                            if (localGeneration == persistedGeneration) {
-                                _state.value = persisted
-                            }
-                            null
+                val persisted = chatRepository.chatState.first()
+                val pendingAfterInitialLoad = synchronized(updateLock) {
+                    repositoryStateLoaded = true
+                    if (localGeneration == persistedGeneration) {
+                        _state.value = persisted
+                        null
+                    } else {
+                        val merged = mergeRepositoryStateWithLocalUpdates(
+                            repositoryState = persisted,
+                            localState = _state.value,
+                        )
+                        _state.value = merged
+                        latestPending = latestPending?.let { pending ->
+                            if (pending.primaryState == null) pending else pending.copy(primaryState = merged)
                         }
+                        latestPending
                     }
-                    if (!repositoryStateReady.isCompleted) {
-                        repositoryStateReady.complete(Unit)
-                    }
-                    if (pendingAfterInitialLoad != null) {
-                        persistWithoutQueue(pendingAfterInitialLoad)
-                    }
+                }
+                if (!repositoryStateReady.isCompleted) {
+                    repositoryStateReady.complete(Unit)
+                }
+                if (pendingAfterInitialLoad != null) {
+                    persistWithoutQueue(pendingAfterInitialLoad)
                 }
             } catch (throwable: Throwable) {
                 if (throwable is CancellationException) {
@@ -119,32 +115,49 @@ class ChatStateStore(
         propagateFailure: Boolean = false,
     ) {
         persistMutex.withLock {
-            if (synchronized(updateLock) { !repositoryStateLoaded }) {
-                return@withLock
-            }
-
-            if (synchronized(updateLock) { pending.generation <= persistedGeneration }) {
-                return@withLock
-            }
+            val pendingToWrite = synchronized(updateLock) {
+                if (!repositoryStateLoaded) {
+                    return@withLock
+                }
+                val latest = latestPending
+                val candidate = if (latest != null && latest.generation >= pending.generation) {
+                    latest
+                } else {
+                    pending
+                }
+                if (candidate.generation <= persistedGeneration) {
+                    null
+                } else {
+                    candidate
+                }
+            } ?: return@withLock
 
             val persistError = runCatching {
-                chatRepository.updateChatState(
-                    sessions = pending.state.sessions,
-                    currentSessionId = pending.state.currentSessionId,
-                    writeIntent = pending.writeIntent,
-                )
+                pendingToWrite.primaryWriteIntent?.let { writeIntent ->
+                    val primaryState = checkNotNull(pendingToWrite.primaryState)
+                    chatRepository.updateChatState(
+                        sessions = primaryState.sessions,
+                        currentSessionId = primaryState.currentSessionId,
+                        writeIntent = writeIntent,
+                    )
+                }
+                if (pendingToWrite.checkpoints.isNotEmpty()) {
+                    chatRepository.upsertAssistantResponseCheckpoints(
+                        checkpoints = pendingToWrite.checkpoints.values.toList(),
+                    )
+                }
             }.exceptionOrNull()
             if (persistError != null) {
                 if (persistError is CancellationException) {
                     throw persistError
                 }
                 synchronized(updateLock) {
-                    if (latestPending == null || pending.generation >= latestPending!!.generation) {
-                        latestPending = pending
+                    if (latestPending == null || pendingToWrite.generation >= latestPending!!.generation) {
+                        latestPending = pendingToWrite
                     }
                 }
                 Log.e(ChatStateStoreLogTag, "Failed to persist chat state", persistError)
-                scheduleRetry(pending)
+                scheduleRetry(pendingToWrite)
                 if (propagateFailure) {
                     throw persistError
                 }
@@ -152,11 +165,11 @@ class ChatStateStore(
             }
 
             synchronized(updateLock) {
-                if (pending.generation > persistedGeneration) {
-                    persistedGeneration = pending.generation
+                if (pendingToWrite.generation > persistedGeneration) {
+                    persistedGeneration = pendingToWrite.generation
                 }
                 val latest = latestPending
-                if (latest != null && latest.generation <= pending.generation) {
+                if (latest != null && latest.generation <= pendingToWrite.generation) {
                     latestPending = null
                 }
             }
@@ -268,35 +281,76 @@ class ChatStateStore(
     ): PersistedChatState {
         val pending = synchronized(updateLock) {
             val updated = transform(_state.value)
+            val pendingWrite = latestPending
+            retainedCheckpoints = retainedCheckpoints.filterKeys { target ->
+                val session = updated.sessions.firstOrNull { it.id == target.sessionId }
+                session != null && session.messages.none { it.responseGroupId == target.responseGroupId }
+            }
             localGeneration += 1
             _state.value = updated
-            val effectiveWriteIntent = latestPending
-                ?.writeIntent
-                ?.takeIf { pendingIntent ->
-                    writeIntent == PersistedChatWriteIntent.SyncSnapshot &&
-                        updated.sessions.isEmpty() &&
-                        pendingIntent != PersistedChatWriteIntent.SyncSnapshot
-                }
-                ?: writeIntent
             PendingPersistedChatState(
                 generation = localGeneration,
-                state = updated,
-                writeIntent = effectiveWriteIntent,
+                primaryState = updated,
+                primaryWriteIntent = mergePrimaryWriteIntents(
+                    pendingIntent = pendingWrite?.primaryWriteIntent,
+                    writeIntent = writeIntent,
+                    updated = updated,
+                ),
+                checkpoints = retainedCheckpoints,
             ).also {
                 latestPending = it
             }
         }
+        enqueue(pending)
+        return checkNotNull(pending.primaryState)
+    }
+
+    fun updateAssistantCheckpoint(
+        checkpoint: AssistantResponseCheckpoint,
+        shouldPersist: () -> Boolean = { true },
+    ): Boolean {
+        val pending = synchronized(updateLock) {
+            if (!shouldPersist()) return false
+            retainedCheckpoints = retainedCheckpoints + (checkpoint.target to checkpoint)
+            localGeneration += 1
+            PendingPersistedChatState(
+                generation = localGeneration,
+                primaryState = latestPending?.primaryState,
+                primaryWriteIntent = latestPending?.primaryWriteIntent,
+                checkpoints = latestPending?.checkpoints.orEmpty() + (checkpoint.target to checkpoint),
+            ).also {
+                latestPending = it
+            }
+        }
+        enqueue(pending)
+        return true
+    }
+
+    private fun enqueue(pending: PendingPersistedChatState) {
         val sendResult = persistenceQueue.trySend(pending)
         if (sendResult.isFailure) {
             persistWithoutQueue(pending)
         }
-        return pending.state
+    }
+
+    private fun mergePrimaryWriteIntents(
+        pendingIntent: PersistedChatWriteIntent?,
+        writeIntent: PersistedChatWriteIntent,
+        updated: PersistedChatState,
+    ): PersistedChatWriteIntent = when {
+        pendingIntent == null -> writeIntent
+        writeIntent == PersistedChatWriteIntent.SyncSnapshot &&
+            updated.sessions.isEmpty() &&
+            (pendingIntent == PersistedChatWriteIntent.DeleteSession ||
+                pendingIntent == PersistedChatWriteIntent.ReplaceFromImport) -> pendingIntent
+        else -> writeIntent
     }
 
     private data class PendingPersistedChatState(
         val generation: Long,
-        val state: PersistedChatState,
-        val writeIntent: PersistedChatWriteIntent,
+        val primaryState: PersistedChatState?,
+        val primaryWriteIntent: PersistedChatWriteIntent?,
+        val checkpoints: Map<AssistantResponseCheckpointTarget, AssistantResponseCheckpoint>,
     )
 
     private companion object {

--- a/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
+++ b/app/src/main/java/com/zhousl/aether/data/SessionExecutionManager.kt
@@ -23,11 +23,13 @@ import com.zhousl.aether.ui.MessageAuthor
 import com.zhousl.aether.ui.ReasoningSummaryChunk
 import com.zhousl.aether.ui.ReasoningTrace
 import com.zhousl.aether.ui.syncActiveBranches
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,6 +43,7 @@ import org.json.JSONObject
 
 private const val ReasoningInitialSummaryTokenThreshold = 100
 private const val ReasoningTimedSummaryIntervalMillis = 5_000L
+private const val AssistantCheckpointIntervalMillis = 1_000L
 private const val ReasoningSummaryMaxInputChars = 8_000
 private const val ReasoningSummaryTitleMaxChars = 120
 private const val ReasoningSummaryDetailMaxChars = 520
@@ -75,6 +78,7 @@ data class SessionExecutionState(
     val pendingStatusText: String = "",
     val pendingStatusDetail: String = "",
     val pendingInputs: List<PendingSessionInput> = emptyList(),
+    val activeResponseGroupId: String? = null,
     val activeTurnStartedAtMillis: Long? = null,
 )
 
@@ -112,6 +116,15 @@ private data class ReasoningSummary(
     val title: String,
     val detail: String,
 )
+
+private data class AssistantResponseIdentity(
+    val responseGroupId: String,
+    val messageIdPrefix: String,
+    val createdAtMillis: Long,
+    val checkpointFromPosition: Int,
+) {
+    fun messageIdFor(blockId: String): String = "$messageIdPrefix-$blockId"
+}
 
 class SessionExecutionManager(
     private val application: Application,
@@ -208,6 +221,7 @@ class SessionExecutionManager(
                 pendingAssistantText = "",
                 pendingStatusText = "",
                 pendingStatusDetail = "",
+                activeResponseGroupId = null,
                 activeTurnStartedAtMillis = System.currentTimeMillis(),
             )
         }
@@ -269,6 +283,7 @@ class SessionExecutionManager(
             handle = handle,
             snapshot = snapshot ?: SessionExecutionState(sessionId = sessionId),
         )
+        deactivateAssistantCheckpoint(handle, handle.activeResponseIdentity)
         scope.launch(Dispatchers.IO) {
             runCatching { chatStateStore.flush() }
         }
@@ -284,6 +299,7 @@ class SessionExecutionManager(
                 pendingStatusText = "",
                 pendingStatusDetail = "",
                 pendingInputs = emptyList(),
+                activeResponseGroupId = null,
                 activeTurnStartedAtMillis = null,
             )
         }
@@ -408,6 +424,7 @@ class SessionExecutionManager(
                 )
             }
         } finally {
+            deactivateAssistantCheckpoint(handle, handle.activeResponseIdentity)
             clearPendingInputs(handle)
             if (executionHandles.remove(handle.sessionId, handle)) {
                 updateExecutionState(handle.sessionId) {
@@ -420,6 +437,7 @@ class SessionExecutionManager(
                         pendingStatusText = "",
                         pendingStatusDetail = "",
                         pendingInputs = emptyList(),
+                        activeResponseGroupId = null,
                         activeTurnStartedAtMillis = null,
                     )
                 }
@@ -447,6 +465,17 @@ class SessionExecutionManager(
     ): CompletionSummary {
         val turnStartedAtMillis = System.currentTimeMillis()
         val turnId = "turn-$turnStartedAtMillis"
+        val responseIdentity = activateAssistantResponse(handle)
+        updateExecutionState(handle.sessionId) { current ->
+            current.copy(
+                activeResponseGroupId = responseIdentity.responseGroupId,
+                pendingToolInvocations = emptyList(),
+                pendingResponseBlocks = emptyList(),
+                pendingAssistantText = "",
+                pendingStatusText = "",
+                pendingStatusDetail = "",
+            )
+        }
         var firstAssistantTokenAtMillis: Long? = null
         diagnosticLogger.event(
             category = "session",
@@ -809,6 +838,7 @@ class SessionExecutionManager(
                         pendingToolInvocations = emptyList(),
                         pendingResponseBlocks = emptyList(),
                         pendingAssistantText = "",
+                        activeResponseGroupId = null,
                         activeTurnStartedAtMillis = null,
                     )
                 }
@@ -922,10 +952,14 @@ class SessionExecutionManager(
             .orEmpty()
 
         val normalizedBlocks = normalizeAssistantResponseBlocks(blocks)
+        val responseIdentity = handle?.activeResponseIdentity
         val appendedMessages = assistantMessagesForBlocks(
             normalizedBlocks = normalizedBlocks,
             thoughtDurationMillis = thoughtDurationMillis,
             assistantActionsHidden = false,
+            isIncomplete = false,
+            responseIdentity = responseIdentity,
+            messageCreatedAtMillis = turnCompletedAtMillis,
             usageStatistics = buildChatUsageStatistics(
                 tokenUsage = tokenUsage,
                 tokenUsageSource = tokenUsageSource,
@@ -936,6 +970,7 @@ class SessionExecutionManager(
             providerPayloadJson = providerPayloadJson,
         )
 
+        deactivateAssistantCheckpoint(handle, responseIdentity)
         chatStateStore.update { persisted ->
             val sessionIndex = persisted.sessions.indexOfFirst { it.id == sessionId }
             if (sessionIndex < 0) return@update persisted
@@ -943,8 +978,11 @@ class SessionExecutionManager(
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
             val currentMessages = session.messages.ifEmpty { baseMessages }
+            val messagesWithoutCheckpoint = responseIdentity?.let { identity ->
+                currentMessages.filterNot { it.responseGroupId == identity.responseGroupId }
+            } ?: currentMessages
             val updatedSession = session.withDerivedMessages(
-                currentMessages + appendedMessages
+                messagesWithoutCheckpoint + appendedMessages
             )
             handle?.replaceRetainedMessages(updatedSession.messages)
             sessionTitle = updatedSession.title
@@ -1052,15 +1090,53 @@ class SessionExecutionManager(
         }
     }
 
+    private fun activateAssistantResponse(handle: SessionExecutionHandle): AssistantResponseIdentity {
+        val startedAtMillis = System.currentTimeMillis()
+        val turnId = "turn-$startedAtMillis-${UUID.randomUUID().toString().take(8)}"
+        return AssistantResponseIdentity(
+            responseGroupId = "agent-group-$turnId",
+            messageIdPrefix = "agent-$turnId",
+            createdAtMillis = startedAtMillis,
+            checkpointFromPosition = syncActiveBranches(handle.retainedMessagesSnapshot()).size,
+        ).also { identity ->
+            synchronized(handle.lock) {
+                handle.assistantCheckpointJob?.cancel()
+                handle.assistantCheckpointJob = null
+                handle.lastAssistantCheckpointUptimeMillis = null
+                handle.activeResponseIdentity = identity
+            }
+        }
+    }
+
+    private fun deactivateAssistantCheckpoint(
+        handle: SessionExecutionHandle?,
+        identity: AssistantResponseIdentity?,
+    ) {
+        if (handle == null || identity == null) return
+        synchronized(handle.lock) {
+            if (handle.activeResponseIdentity != identity) return
+            handle.activeResponseIdentity = null
+            handle.assistantCheckpointJob?.cancel()
+            handle.assistantCheckpointJob = null
+        }
+    }
+
     private fun assistantMessagesForBlocks(
         normalizedBlocks: List<AssistantResponseBlock>,
         thoughtDurationMillis: Long?,
         assistantActionsHidden: Boolean,
+        isIncomplete: Boolean = false,
+        responseIdentity: AssistantResponseIdentity? = null,
+        messageCreatedAtMillis: Long? = null,
         usageStatistics: ChatUsageStatistics? = null,
         providerPayloadJson: String = "",
     ): List<ChatMessage> {
-        val messageTimestamp = System.currentTimeMillis()
-        val responseGroupId = "agent-group-$messageTimestamp"
+        val messageTimestamp = if (isIncomplete) {
+            responseIdentity?.createdAtMillis ?: messageCreatedAtMillis ?: System.currentTimeMillis()
+        } else {
+            messageCreatedAtMillis ?: System.currentTimeMillis()
+        }
+        val responseGroupId = responseIdentity?.responseGroupId ?: "agent-group-$messageTimestamp"
         return normalizedBlocks.mapIndexedNotNull { index, block ->
             when (block) {
                 is AssistantResponseBlock.Text -> {
@@ -1068,12 +1144,13 @@ class SessionExecutionManager(
                         null
                     } else {
                         ChatMessage(
-                            id = "agent-${messageTimestamp + index}",
+                            id = responseIdentity?.messageIdFor(block.id) ?: "agent-${messageTimestamp + index}",
                             author = MessageAuthor.Agent,
                             text = block.text,
                             createdAtMillis = messageTimestamp + index,
                             responseGroupId = responseGroupId,
                             assistantActionsHidden = assistantActionsHidden,
+                            isIncomplete = isIncomplete,
                         )
                     }
                 }
@@ -1083,20 +1160,21 @@ class SessionExecutionManager(
                         null
                     } else {
                         ChatMessage(
-                            id = "agent-${messageTimestamp + index}",
+                            id = responseIdentity?.messageIdFor(block.id) ?: "agent-${messageTimestamp + index}",
                             author = MessageAuthor.Agent,
                             text = "",
                             createdAtMillis = messageTimestamp + index,
                             toolInvocations = block.toolInvocations,
                             responseGroupId = responseGroupId,
                             assistantActionsHidden = assistantActionsHidden,
+                            isIncomplete = isIncomplete,
                         )
                     }
                 }
 
                 is AssistantResponseBlock.Reasoning -> {
                     ChatMessage(
-                        id = "agent-${messageTimestamp + index}",
+                        id = responseIdentity?.messageIdFor(block.id) ?: "agent-${messageTimestamp + index}",
                         author = MessageAuthor.Agent,
                         text = "",
                         createdAtMillis = messageTimestamp + index,
@@ -1104,6 +1182,7 @@ class SessionExecutionManager(
                         reasoningTrace = block.trace,
                         responseGroupId = responseGroupId,
                         assistantActionsHidden = assistantActionsHidden,
+                        isIncomplete = isIncomplete,
                     )
                 }
             }
@@ -1245,12 +1324,15 @@ class SessionExecutionManager(
                 }
             }
         }
+        val responseIdentity = handle.activeResponseIdentity
         val interruptedAssistantMessages = assistantMessagesForBlocks(
             normalizedBlocks = normalizeAssistantResponseBlocks(pendingBlocks),
             thoughtDurationMillis = null,
             assistantActionsHidden = true,
+            responseIdentity = responseIdentity,
         )
         val userMessages = drained.map { it.message }
+        deactivateAssistantCheckpoint(handle, responseIdentity)
         chatStateStore.update { persisted ->
             val sessionIndex = persisted.sessions.indexOfFirst { it.id == handle.sessionId }
             if (sessionIndex < 0) return@update persisted
@@ -1258,8 +1340,11 @@ class SessionExecutionManager(
             val updatedSessions = persisted.sessions.toMutableList()
             val session = updatedSessions.removeAt(sessionIndex)
             val currentMessages = session.messages.ifEmpty { handle.retainedMessagesSnapshot() }
+            val messagesWithoutCheckpoint = responseIdentity?.let { identity ->
+                currentMessages.filterNot { it.responseGroupId == identity.responseGroupId }
+            } ?: currentMessages
             val updatedSession = session.withDerivedMessages(
-                syncActiveBranches(currentMessages + interruptedAssistantMessages + userMessages)
+                syncActiveBranches(messagesWithoutCheckpoint + interruptedAssistantMessages + userMessages)
             )
             handle.replaceRetainedMessages(updatedSession.messages)
             updatedSessions.add(
@@ -1276,6 +1361,10 @@ class SessionExecutionManager(
                 pendingStatusText = "",
                 pendingStatusDetail = "",
             )
+        }
+        val continuedResponseIdentity = activateAssistantResponse(handle)
+        updateExecutionState(handle.sessionId) { current ->
+            current.copy(activeResponseGroupId = continuedResponseIdentity.responseGroupId)
         }
     }
 
@@ -1373,12 +1462,77 @@ class SessionExecutionManager(
                 put(sessionId, transform(current))
             }
         }
+        requestAssistantCheckpoint(sessionId)
         if (
             currentSettings.value.keepTasksRunningInBackground &&
             _executionStates.value.values.any { it.isRunning }
         ) {
             ensureForegroundServiceRunning()
         }
+    }
+
+    private fun requestAssistantCheckpoint(sessionId: String) {
+        val handle = executionHandles[sessionId] ?: return
+        val identity = handle.activeResponseIdentity ?: return
+        val blocks = _executionStates.value[sessionId]?.pendingResponseBlocks.orEmpty()
+        if (blocks.isEmpty()) return
+
+        val nowUptimeMillis = SystemClock.uptimeMillis()
+        var persistNow = false
+        synchronized(handle.lock) {
+            if (handle.activeResponseIdentity != identity) return
+            val remainingMillis = handle.lastAssistantCheckpointUptimeMillis?.let { lastCheckpointUptimeMillis ->
+                AssistantCheckpointIntervalMillis - (nowUptimeMillis - lastCheckpointUptimeMillis)
+            } ?: 0L
+            if (remainingMillis <= 0L) {
+                handle.lastAssistantCheckpointUptimeMillis = nowUptimeMillis
+                handle.assistantCheckpointJob?.cancel()
+                handle.assistantCheckpointJob = null
+                persistNow = true
+            } else if (handle.assistantCheckpointJob?.isActive != true) {
+                handle.assistantCheckpointJob = scope.launch {
+                    delay(remainingMillis)
+                    persistAssistantCheckpoint(handle, identity)
+                }
+            }
+        }
+        if (persistNow) {
+            persistAssistantCheckpoint(handle, identity)
+        }
+    }
+
+    private fun persistAssistantCheckpoint(
+        handle: SessionExecutionHandle,
+        identity: AssistantResponseIdentity,
+    ) {
+        val blocks = _executionStates.value[handle.sessionId]?.pendingResponseBlocks.orEmpty()
+        if (blocks.isEmpty() || handle.activeResponseIdentity != identity) return
+        synchronized(handle.lock) {
+            if (handle.activeResponseIdentity != identity) return
+            handle.lastAssistantCheckpointUptimeMillis = SystemClock.uptimeMillis()
+            handle.assistantCheckpointJob = null
+        }
+        val checkpointMessages = assistantMessagesForBlocks(
+            normalizedBlocks = normalizeAssistantResponseBlocks(blocks),
+            thoughtDurationMillis = null,
+            assistantActionsHidden = false,
+            isIncomplete = true,
+            responseIdentity = identity,
+        )
+        if (checkpointMessages.isEmpty()) return
+
+        chatStateStore.updateAssistantCheckpoint(
+            checkpoint = AssistantResponseCheckpoint(
+                target = AssistantResponseCheckpointTarget(
+                    sessionId = handle.sessionId,
+                    responseGroupId = identity.responseGroupId,
+                ),
+                fromPosition = identity.checkpointFromPosition,
+                messages = checkpointMessages,
+            ),
+            // Ignore checkpoints that race with response completion.
+            shouldPersist = { handle.activeResponseIdentity == identity },
+        )
     }
 
     private fun ensureForegroundServiceRunning() {
@@ -2557,6 +2711,10 @@ class SessionExecutionManager(
         var reasoningFirstSummarySubmitted: Boolean = false
         var reasoningLastSubmittedCharIndex: Int = 0
         var reasoningLastTimedSummaryAtMillis: Long = 0L
+        @Volatile
+        var activeResponseIdentity: AssistantResponseIdentity? = null
+        var lastAssistantCheckpointUptimeMillis: Long? = null
+        var assistantCheckpointJob: Job? = null
 
         @Volatile
         var pauseRequested: Boolean = false

--- a/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherApp.kt
@@ -363,7 +363,19 @@ private fun AetherAppContent(
     val activeProviderConfig = uiState.providerConfigs.firstOrNull { it.isEnabled }
         ?: uiState.providerConfigs.firstOrNull()
     val currentSessionExecution = uiState.sessionExecutionStates[uiState.currentSessionId]
-    val currentMessages = activeSession?.messages.orEmpty()
+    val activeStreamingResponseGroupId = currentSessionExecution
+        ?.takeIf { it.isRunning }
+        ?.activeResponseGroupId
+    val sessionMessages = activeSession?.messages.orEmpty()
+    val currentMessages = remember(sessionMessages, activeStreamingResponseGroupId) {
+        if (activeStreamingResponseGroupId == null) {
+            sessionMessages
+        } else {
+            sessionMessages.filterNot { message ->
+                message.isIncomplete && message.responseGroupId == activeStreamingResponseGroupId
+            }
+        }
+    }
     val selectedSkillIds = activeSession?.selectedSkillIds ?: uiState.draftSelectedSkillIds
     val selectedMcpServerIds = activeSession?.activeMcpServerIds ?: uiState.draftSelectedMcpServerIds
     val effectiveTermuxSetupState = effectiveTermuxSetupState(

--- a/app/src/main/java/com/zhousl/aether/ui/AetherUiState.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherUiState.kt
@@ -191,6 +191,7 @@ data class ChatMessage(
     val branchGroup: ChatBranchGroup? = null,
     val responseGroupId: String? = null,
     val assistantActionsHidden: Boolean = false,
+    val isIncomplete: Boolean = false,
     val providerPayloadJson: String = "",
     val displayKind: MessageDisplayKind = MessageDisplayKind.Standard,
     val usageStatistics: ChatUsageStatistics? = null,

--- a/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ChatRepositorySerializationTest.kt
@@ -1,5 +1,6 @@
 package com.zhousl.aether.data
 
+import com.zhousl.aether.data.chatdb.ChatMessageEntity
 import com.zhousl.aether.data.chatdb.ChatMessageSummaryEntity
 import com.zhousl.aether.ui.AttachmentKind
 import com.zhousl.aether.ui.ChatAttachment
@@ -112,6 +113,7 @@ class ChatRepositorySerializationTest {
                 author = MessageAuthor.Agent.name,
                 text = "Recovered from typed columns",
                 createdAtMillis = 123L,
+                isIncomplete = true,
             )
         )
 
@@ -119,8 +121,47 @@ class ChatRepositorySerializationTest {
         assertEquals(MessageAuthor.Agent, message.author)
         assertEquals("Recovered from typed columns", message.text)
         assertEquals(123L, message.createdAtMillis)
+        assertTrue(message.isIncomplete)
         assertTrue(message.toolInvocations.isEmpty())
         assertTrue(message.providerPayloadJson.isNullOrBlank())
+    }
+
+    @Test
+    fun entityFallbackPreservesStoredIncompleteFlag() {
+        val message = ChatMessageEntityMapper.toChatMessage(
+            ChatMessageEntity(
+                sessionId = "session-1",
+                id = "agent-1",
+                position = 0,
+                messageJson = "{not-valid-json",
+                author = MessageAuthor.Agent.name,
+                text = "Partial response",
+                isIncomplete = true,
+            ),
+            messageIndex = 0,
+        )
+
+        assertEquals("agent-1", message.id)
+        assertEquals("Partial response", message.text)
+        assertTrue(message.isIncomplete)
+    }
+
+    @Test
+    fun entityMappingUsesStoredIncompleteColumnAsAuthority() {
+        val message = ChatMessageEntityMapper.toChatMessage(
+            ChatMessageEntity(
+                sessionId = "session-1",
+                id = "agent-1",
+                position = 0,
+                messageJson = "{\"id\":\"agent-1\",\"isIncomplete\":true}",
+                author = MessageAuthor.Agent.name,
+                text = "Complete response",
+                isIncomplete = false,
+            ),
+            messageIndex = 0,
+        )
+
+        assertFalse(message.isIncomplete)
     }
 
     @Test
@@ -152,6 +193,34 @@ class ChatRepositorySerializationTest {
 
         assertFalse(result.recoveredFromCorruption)
         assertEquals("session-1", result.sessions.single().id)
+    }
+
+    @Test
+    fun sessionRoundTripPreservesIncompleteStreamingCheckpoint() {
+        val serialized = serializeChatSessions(
+            listOf(
+                ChatSession(
+                    id = "session-checkpoint",
+                    title = "Checkpoint",
+                    preview = "partial",
+                    messages = listOf(
+                        ChatMessage(
+                            id = "agent-checkpoint",
+                            author = MessageAuthor.Agent,
+                            text = "partial output",
+                            isIncomplete = true,
+                            responseGroupId = "agent-group-turn-1",
+                        )
+                    ),
+                )
+            )
+        )
+
+        val restored = parseChatSessions(serialized).single().messages.single()
+
+        assertTrue(restored.isIncomplete)
+        assertEquals("partial output", restored.text)
+        assertEquals("agent-group-turn-1", restored.responseGroupId)
     }
 
     @Test

--- a/app/src/test/java/com/zhousl/aether/data/ChatStateStoreTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ChatStateStoreTest.kt
@@ -1,0 +1,246 @@
+package com.zhousl.aether.data
+
+import com.zhousl.aether.ui.ChatMessage
+import com.zhousl.aether.ui.ChatSession
+import com.zhousl.aether.ui.MessageAuthor
+import java.util.ArrayDeque
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatStateStoreTest {
+    @Test
+    fun checkpointQueuedWithDeletionPersistsWithoutPublishingCheckpointToUi() = runBlocking {
+        val deletedSession = ChatSession(
+            id = "deleted-session",
+            title = "Deleted",
+            preview = "before",
+            messages = emptyList(),
+        )
+        val checkpointSessionId = "checkpoint-session"
+        val responseGroupId = "response-group"
+        val checkpointMessage = ChatMessage(
+            id = "agent-checkpoint",
+            author = MessageAuthor.Agent,
+            text = "partial",
+            isIncomplete = true,
+            responseGroupId = responseGroupId,
+        )
+        val checkpointSession = ChatSession(
+            id = checkpointSessionId,
+            title = "Checkpoint",
+            preview = "before",
+            messages = emptyList(),
+        )
+        val initialState = PersistedChatState(
+            sessions = listOf(deletedSession, checkpointSession),
+            currentSessionId = checkpointSessionId,
+        )
+        val repository = RecordingChatStatePersistence(initialState)
+        val dispatcher = QueuedCoroutineDispatcher()
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        try {
+            val store = ChatStateStore(
+                scope = scope,
+                chatRepository = repository,
+            )
+            dispatcher.runUntilIdle()
+
+            store.update(writeIntent = PersistedChatWriteIntent.DeleteSession) { state ->
+                state.copy(sessions = state.sessions.filterNot { it.id == deletedSession.id })
+            }
+            val checkpoint = AssistantResponseCheckpoint(
+                target = AssistantResponseCheckpointTarget(
+                    sessionId = checkpointSessionId,
+                    responseGroupId = responseGroupId,
+                ),
+                fromPosition = 0,
+                messages = listOf(checkpointMessage),
+            )
+            assertTrue(store.updateAssistantCheckpoint(checkpoint))
+
+            assertEquals(emptyList<ChatMessage>(), store.state.value.sessions.single().messages)
+            assertTrue(repository.operations.isEmpty())
+            dispatcher.runUntilIdle()
+
+            assertEquals(emptyList<ChatMessage>(), store.state.value.sessions.single().messages)
+            val snapshotWrite = repository.operations.filterIsInstance<PersistedOperation.Snapshot>().single()
+            val checkpointWrite = repository.operations.filterIsInstance<PersistedOperation.Checkpoint>().single()
+            assertEquals(listOf(checkpointSessionId), snapshotWrite.sessions.map { it.id })
+            assertEquals(emptyList<ChatMessage>(), snapshotWrite.sessions.single().messages)
+            assertEquals(listOf(checkpoint), checkpointWrite.checkpoints)
+            assertEquals(
+                listOf(PersistedOperation.Snapshot::class, PersistedOperation.Checkpoint::class),
+                repository.operations.map { it::class },
+            )
+        } finally {
+            scope.cancel()
+            dispatcher.runUntilIdle()
+        }
+    }
+
+    @Test
+    fun checkpointQueuePersistsOnlyDirtyResponseAndReplaysActiveResponsesAfterSnapshot() = runBlocking {
+        val firstSession = ChatSession(
+            id = "first",
+            title = "First",
+            preview = "",
+            messages = emptyList(),
+        )
+        val secondSession = ChatSession(
+            id = "second",
+            title = "Second",
+            preview = "",
+            messages = emptyList(),
+        )
+        val repository = RecordingChatStatePersistence(
+            PersistedChatState(
+                sessions = listOf(firstSession, secondSession),
+                currentSessionId = firstSession.id,
+            )
+        )
+        val dispatcher = QueuedCoroutineDispatcher()
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        try {
+            val store = ChatStateStore(scope = scope, chatRepository = repository)
+            dispatcher.runUntilIdle()
+
+            val firstCheckpoint = checkpointFor(sessionId = firstSession.id, responseGroupId = "first-response")
+            val secondCheckpoint = checkpointFor(sessionId = secondSession.id, responseGroupId = "second-response")
+
+            store.updateAssistantCheckpoint(firstCheckpoint)
+            dispatcher.runUntilIdle()
+            store.updateAssistantCheckpoint(secondCheckpoint)
+            dispatcher.runUntilIdle()
+
+            assertEquals(
+                listOf(listOf(firstCheckpoint), listOf(secondCheckpoint)),
+                repository.operations
+                    .filterIsInstance<PersistedOperation.Checkpoint>()
+                    .map { it.checkpoints },
+            )
+
+            store.update { state ->
+                state.copy(
+                    sessions = state.sessions.map { session ->
+                        if (session.id == firstSession.id) session.copy(title = "Renamed") else session
+                    },
+                )
+            }
+            dispatcher.runUntilIdle()
+
+            val lastOperations = repository.operations.takeLast(2)
+            assertTrue(lastOperations[0] is PersistedOperation.Snapshot)
+            assertEquals(
+                setOf(firstCheckpoint, secondCheckpoint),
+                (lastOperations[1] as PersistedOperation.Checkpoint).checkpoints.toSet(),
+            )
+
+            val completed = firstCheckpoint.messages.single().copy(isIncomplete = false)
+            store.update { state ->
+                state.copy(
+                    sessions = state.sessions.map { session ->
+                        if (session.id == firstSession.id) {
+                            session.copy(messages = listOf(completed))
+                        } else {
+                            session
+                        }
+                    },
+                )
+            }
+            dispatcher.runUntilIdle()
+
+            assertEquals(
+                listOf(secondCheckpoint),
+                (repository.operations.last() as PersistedOperation.Checkpoint).checkpoints,
+            )
+        } finally {
+            scope.cancel()
+            dispatcher.runUntilIdle()
+        }
+    }
+
+    private fun checkpointFor(
+        sessionId: String,
+        responseGroupId: String,
+    ): AssistantResponseCheckpoint = AssistantResponseCheckpoint(
+        target = AssistantResponseCheckpointTarget(
+            sessionId = sessionId,
+            responseGroupId = responseGroupId,
+        ),
+        fromPosition = 0,
+        messages = listOf(
+            ChatMessage(
+                id = "$sessionId-agent",
+                author = MessageAuthor.Agent,
+                text = "partial",
+                isIncomplete = true,
+                responseGroupId = responseGroupId,
+            ),
+        ),
+    )
+}
+
+private class RecordingChatStatePersistence(
+    initialState: PersistedChatState,
+) : ChatStatePersistence {
+    override val chatState: Flow<PersistedChatState> = MutableStateFlow(initialState)
+    val operations = mutableListOf<PersistedOperation>()
+
+    override suspend fun updateChatState(
+        sessions: List<ChatSession>,
+        currentSessionId: String,
+        writeIntent: PersistedChatWriteIntent,
+    ) {
+        operations += PersistedOperation.Snapshot(
+            sessions = sessions,
+            currentSessionId = currentSessionId,
+            writeIntent = writeIntent,
+        )
+    }
+
+    override suspend fun upsertAssistantResponseCheckpoints(
+        checkpoints: List<AssistantResponseCheckpoint>,
+    ) {
+        operations += PersistedOperation.Checkpoint(checkpoints)
+    }
+}
+
+private sealed interface PersistedOperation {
+    data class Snapshot(
+        val sessions: List<ChatSession>,
+        val currentSessionId: String,
+        val writeIntent: PersistedChatWriteIntent,
+    ) : PersistedOperation
+
+    data class Checkpoint(
+        val checkpoints: List<AssistantResponseCheckpoint>,
+    ) : PersistedOperation
+}
+
+private class QueuedCoroutineDispatcher : CoroutineDispatcher() {
+    private val tasks = ArrayDeque<Runnable>()
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        synchronized(tasks) {
+            tasks.addLast(block)
+        }
+    }
+
+    fun runUntilIdle() {
+        while (true) {
+            val task = synchronized(tasks) {
+                if (tasks.isEmpty()) null else tasks.removeFirst()
+            } ?: return
+            task.run()
+        }
+    }
+}

--- a/shared/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/5.json
+++ b/shared/schemas/com.zhousl.aether.data.chatdb.ChatHistoryDatabase/5.json
@@ -1,0 +1,344 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "caabd047843620dcf2fdcd2f75d521b0",
+    "entities": [
+      {
+        "tableName": "chat_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `preview` TEXT NOT NULL, `hasCustomTitle` INTEGER NOT NULL, `selectedSkillIdsJson` TEXT NOT NULL, `activeSkillsJson` TEXT NOT NULL, `activeMcpServerIdsJson` TEXT NOT NULL, `agentModeEnabled` INTEGER NOT NULL, `chromeEnabled` INTEGER NOT NULL, `selectedModelKey` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomTitle",
+            "columnName": "hasCustomTitle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSkillIdsJson",
+            "columnName": "selectedSkillIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeSkillsJson",
+            "columnName": "activeSkillsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeMcpServerIdsJson",
+            "columnName": "activeMcpServerIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentModeEnabled",
+            "columnName": "agentModeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chromeEnabled",
+            "columnName": "chromeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedModelKey",
+            "columnName": "selectedModelKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `id` TEXT NOT NULL, `position` INTEGER NOT NULL, `messageJson` TEXT NOT NULL, `author` TEXT NOT NULL, `text` TEXT NOT NULL, `createdAtMillis` INTEGER, `responseGroupId` TEXT, `displayKind` TEXT, `messageSchemaVersion` INTEGER NOT NULL, `hasUsageStatistics` INTEGER NOT NULL, `isIncomplete` INTEGER NOT NULL, PRIMARY KEY(`sessionId`, `id`), FOREIGN KEY(`sessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageJson",
+            "columnName": "messageJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "responseGroupId",
+            "columnName": "responseGroupId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayKind",
+            "columnName": "displayKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "messageSchemaVersion",
+            "columnName": "messageSchemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasUsageStatistics",
+            "columnName": "hasUsageStatistics",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncomplete",
+            "columnName": "isIncomplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_sessionId_position",
+            "unique": true,
+            "columnNames": [
+              "sessionId",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chat_messages_sessionId_position` ON `${TABLE_NAME}` (`sessionId`, `position`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_responseGroupId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "responseGroupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_responseGroupId` ON `${TABLE_NAME}` (`sessionId`, `responseGroupId`)"
+          },
+          {
+            "name": "index_chat_messages_sessionId_author",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "author"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_sessionId_author` ON `${TABLE_NAME}` (`sessionId`, `author`)"
+          },
+          {
+            "name": "index_chat_messages_hasUsageStatistics",
+            "unique": false,
+            "columnNames": [
+              "hasUsageStatistics"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_hasUsageStatistics` ON `${TABLE_NAME}` (`hasUsageStatistics`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_workspace_file_refs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `messageId` TEXT NOT NULL, `path` TEXT NOT NULL, PRIMARY KEY(`sessionId`, `messageId`, `path`), FOREIGN KEY(`sessionId`, `messageId`) REFERENCES `chat_messages`(`sessionId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId",
+            "messageId",
+            "path"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_workspace_file_refs_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId",
+              "messageId"
+            ],
+            "referencedColumns": [
+              "sessionId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_state_meta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `currentSessionId` TEXT, `roomMigrationComplete` INTEGER NOT NULL, `workspaceFileRefsComplete` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`currentSessionId`) REFERENCES `chat_sessions`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentSessionId",
+            "columnName": "currentSessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "roomMigrationComplete",
+            "columnName": "roomMigrationComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workspaceFileRefsComplete",
+            "columnName": "workspaceFileRefsComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_state_meta_currentSessionId",
+            "unique": false,
+            "columnNames": [
+              "currentSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_state_meta_currentSessionId` ON `${TABLE_NAME}` (`currentSessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_sessions",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "currentSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'caabd047843620dcf2fdcd2f75d521b0')"
+    ]
+  }
+}

--- a/shared/src/androidMain/kotlin/com/zhousl/aether/data/chatdb/AndroidChatHistoryDatabaseFactory.kt
+++ b/shared/src/androidMain/kotlin/com/zhousl/aether/data/chatdb/AndroidChatHistoryDatabaseFactory.kt
@@ -2,8 +2,7 @@ package com.zhousl.aether.data.chatdb
 
 import android.content.Context
 import androidx.room.Room
-import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 
 object AndroidChatHistoryDatabaseFactory {
     @Volatile
@@ -14,56 +13,9 @@ object AndroidChatHistoryDatabaseFactory {
             context.applicationContext,
             ChatHistoryDatabase::class.java,
             "aether_chat_history.db",
-        ).addMigrations(Migration1To2, Migration2To3, Migration3To4)
+        ).setDriver(BundledSQLiteDriver())
+            .addMigrations(*ChatHistoryMigrations)
             .build()
             .also { instance = it }
-    }
-}
-
-object Migration1To2 : Migration(1, 2) {
-    override fun migrate(db: SupportSQLiteDatabase) {
-        db.execSQL(
-            """
-            CREATE TABLE IF NOT EXISTS `chat_workspace_file_refs` (
-                `sessionId` TEXT NOT NULL,
-                `messageId` TEXT NOT NULL,
-                `path` TEXT NOT NULL,
-                PRIMARY KEY(`sessionId`, `messageId`, `path`),
-                FOREIGN KEY(`sessionId`, `messageId`) REFERENCES `chat_messages`(`sessionId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE
-            )
-            """.trimIndent(),
-        )
-        db.execSQL(
-            "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `chat_workspace_file_refs` (`path`)",
-        )
-        db.execSQL(
-            "ALTER TABLE `chat_state_meta` ADD COLUMN `workspaceFileRefsComplete` INTEGER NOT NULL DEFAULT 0",
-        )
-    }
-}
-
-object Migration2To3 : Migration(2, 3) {
-    override fun migrate(db: SupportSQLiteDatabase) {
-        db.execSQL(
-            "ALTER TABLE `chat_messages` ADD COLUMN `hasUsageStatistics` INTEGER NOT NULL DEFAULT 0",
-        )
-        db.execSQL(
-            """
-            UPDATE `chat_messages`
-            SET `hasUsageStatistics` = 1
-            WHERE `messageJson` LIKE '%"usageStatistics"%'
-            """.trimIndent(),
-        )
-        db.execSQL(
-            "CREATE INDEX IF NOT EXISTS `index_chat_messages_hasUsageStatistics` ON `chat_messages` (`hasUsageStatistics`)",
-        )
-    }
-}
-
-object Migration3To4 : Migration(3, 4) {
-    override fun migrate(db: SupportSQLiteDatabase) {
-        db.execSQL(
-            "ALTER TABLE `chat_sessions` ADD COLUMN `chromeEnabled` INTEGER NOT NULL DEFAULT 0",
-        )
     }
 }

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryDao.kt
@@ -45,6 +45,13 @@ interface ChatHistoryDao {
     @Query("SELECT COUNT(*) FROM chat_messages WHERE sessionId = :sessionId")
     suspend fun getMessageCountForSession(sessionId: String): Int
 
+    @Query("SELECT COUNT(*) FROM chat_messages WHERE sessionId = :sessionId AND responseGroupId = :responseGroupId AND position >= :fromPosition")
+    suspend fun getMessageCountForResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+    ): Int
+
     @Query("SELECT * FROM chat_messages WHERE sessionId = :sessionId ORDER BY position ASC")
     suspend fun getMessagesForSession(sessionId: String): List<ChatMessageEntity>
 
@@ -65,7 +72,7 @@ interface ChatHistoryDao {
     fun observeMessageStatsForSessions(sessionIds: List<String>): Flow<List<ChatSessionMessageStatsEntity>>
 
     @Query("""
-        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength
+        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength, isIncomplete
         FROM chat_messages
         WHERE hasUsageStatistics = 1
         ORDER BY sessionId ASC, position ASC
@@ -73,7 +80,7 @@ interface ChatHistoryDao {
     suspend fun getUsageStatisticsMessageSummaries(): List<ChatMessageSummaryEntity>
 
     @Query("""
-        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength
+        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength, isIncomplete
         FROM chat_messages
         WHERE sessionId = :sessionId
         ORDER BY position ASC
@@ -81,7 +88,7 @@ interface ChatHistoryDao {
     fun observeMessageSummariesForSession(sessionId: String): Flow<List<ChatMessageSummaryEntity>>
 
     @Query("""
-        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength
+        SELECT sessionId, id, position, author, text, createdAtMillis, responseGroupId, displayKind, messageSchemaVersion, length(messageJson) AS messageJsonLength, isIncomplete
         FROM chat_messages
         WHERE sessionId IN (:sessionIds)
         ORDER BY sessionId ASC, position ASC
@@ -164,6 +171,13 @@ interface ChatHistoryDao {
     @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId = :messageId")
     suspend fun deleteWorkspaceFileRefsForMessage(sessionId: String, messageId: String)
 
+    @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId IN (SELECT id FROM chat_messages WHERE sessionId = :sessionId AND responseGroupId = :responseGroupId AND position >= :fromPosition)")
+    suspend fun deleteWorkspaceFileRefsForResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+    )
+
     @Query("DELETE FROM chat_workspace_file_refs WHERE sessionId = :sessionId AND messageId IN (SELECT id FROM chat_messages WHERE sessionId = :sessionId AND position >= :fromPosition)")
     suspend fun deleteWorkspaceFileRefsFromPosition(sessionId: String, fromPosition: Int)
 
@@ -178,6 +192,63 @@ interface ChatHistoryDao {
 
     @Query("DELETE FROM chat_messages WHERE sessionId = :sessionId AND position >= :fromPosition")
     suspend fun deleteMessagesFromPosition(sessionId: String, fromPosition: Int)
+
+    @Query("DELETE FROM chat_messages WHERE sessionId = :sessionId AND responseGroupId = :responseGroupId AND position >= :fromPosition")
+    suspend fun deleteMessagesForResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+    )
+
+    @Query("""
+        SELECT id
+        FROM chat_messages
+        WHERE sessionId = :sessionId
+            AND position >= :fromPosition
+            AND position < :toPosition
+            AND (responseGroupId IS NULL OR responseGroupId != :responseGroupId)
+    """)
+    suspend fun getMessageIdsToParkOutsideResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+        toPosition: Int,
+    ): List<String>
+
+    @Query("""
+        UPDATE chat_messages
+        SET position = -position - 1
+        WHERE sessionId = :sessionId
+            AND position >= :fromPosition
+            AND position < :toPosition
+            AND (responseGroupId IS NULL OR responseGroupId != :responseGroupId)
+    """)
+    suspend fun parkMessagesFromPositionOutsideResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+        toPosition: Int,
+    )
+
+    @Query("""
+        UPDATE chat_messages
+        SET position = (-position - 1) + :positionDelta
+        WHERE sessionId = :sessionId
+            AND id IN (:parkedMessageIds)
+            AND position >= (0 - :toPosition)
+            AND position <= (0 - :fromPosition) - 1
+            AND (-position - 1) + :positionDelta >= :checkpointEndPosition
+            AND (responseGroupId IS NULL OR responseGroupId != :responseGroupId)
+    """)
+    suspend fun restoreParkedMessagesOutsideResponseGroup(
+        sessionId: String,
+        responseGroupId: String,
+        fromPosition: Int,
+        toPosition: Int,
+        checkpointEndPosition: Int,
+        parkedMessageIds: List<String>,
+        positionDelta: Int,
+    )
 
     @Query("DELETE FROM chat_sessions WHERE id = :sessionId")
     suspend fun deleteSession(sessionId: String)

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryDatabase.kt
@@ -12,7 +12,7 @@ import androidx.room.RoomDatabaseConstructor
         ChatWorkspaceFileRefEntity::class,
         ChatStateMetaEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 @ConstructedBy(ChatHistoryDatabaseConstructor::class)

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryEntities.kt
@@ -51,6 +51,7 @@ data class ChatMessageEntity(
     val displayKind: String? = null,
     val messageSchemaVersion: Int = 1,
     val hasUsageStatistics: Boolean = false,
+    val isIncomplete: Boolean = false,
 )
 
 data class ChatMessageSummaryEntity(
@@ -64,6 +65,7 @@ data class ChatMessageSummaryEntity(
     val displayKind: String? = null,
     val messageSchemaVersion: Int = 1,
     val messageJsonLength: Int? = null,
+    val isIncomplete: Boolean = false,
 )
 
 data class ChatSessionMessageStatsEntity(
@@ -118,4 +120,3 @@ data class ChatSessionSnapshot(
     val messages: List<ChatMessageEntity>,
     val workspaceFileRefs: List<ChatWorkspaceFileRefEntity> = emptyList(),
 )
-

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryMigrations.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/ChatHistoryMigrations.kt
@@ -1,0 +1,76 @@
+package com.zhousl.aether.data.chatdb
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+val Migration1To2 = object : Migration(1, 2) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chat_workspace_file_refs` (
+                `sessionId` TEXT NOT NULL,
+                `messageId` TEXT NOT NULL,
+                `path` TEXT NOT NULL,
+                PRIMARY KEY(`sessionId`, `messageId`, `path`),
+                FOREIGN KEY(`sessionId`, `messageId`) REFERENCES `chat_messages`(`sessionId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        connection.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_chat_workspace_file_refs_path` ON `chat_workspace_file_refs` (`path`)",
+        )
+        connection.execSQL(
+            "ALTER TABLE `chat_state_meta` ADD COLUMN `workspaceFileRefsComplete` INTEGER NOT NULL DEFAULT 0",
+        )
+    }
+}
+
+val Migration2To3 = object : Migration(2, 3) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE `chat_messages` ADD COLUMN `hasUsageStatistics` INTEGER NOT NULL DEFAULT 0",
+        )
+        connection.execSQL(
+            """
+            UPDATE `chat_messages`
+            SET `hasUsageStatistics` = 1
+            WHERE `messageJson` LIKE '%"usageStatistics"%'
+            """.trimIndent(),
+        )
+        connection.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_chat_messages_hasUsageStatistics` ON `chat_messages` (`hasUsageStatistics`)",
+        )
+    }
+}
+
+val Migration3To4 = object : Migration(3, 4) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE `chat_sessions` ADD COLUMN `chromeEnabled` INTEGER NOT NULL DEFAULT 0",
+        )
+    }
+}
+
+val Migration4To5 = object : Migration(4, 5) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE `chat_messages` ADD COLUMN `isIncomplete` INTEGER NOT NULL DEFAULT 0",
+        )
+        connection.execSQL(
+            """
+            UPDATE `chat_messages`
+            SET `isIncomplete` = 1
+            WHERE json_valid(`messageJson`) = 1
+                AND json_extract(`messageJson`, '$.isIncomplete') = 1
+            """.trimIndent(),
+        )
+    }
+}
+
+val ChatHistoryMigrations = arrayOf(
+    Migration1To2,
+    Migration2To3,
+    Migration3To4,
+    Migration4To5,
+)

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/SharedChatHistoryStore.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/chatdb/SharedChatHistoryStore.kt
@@ -383,6 +383,7 @@ class SharedChatHistoryStore(
                     responseGroupId = message.responseGroupId.ifBlank { null },
                     displayKind = message.displayKind.name,
                     hasUsageStatistics = message.usage != null,
+                    isIncomplete = false,
                 )
             }
         }
@@ -449,6 +450,7 @@ class SharedChatHistoryStore(
                     responseGroupId = message.responseGroupId.ifBlank { null },
                     displayKind = message.displayKind.name,
                     hasUsageStatistics = message.usage != null,
+                    isIncomplete = false,
                 )
             }
         )

--- a/shared/src/iosMain/kotlin/com/zhousl/aether/data/chatdb/IosChatHistoryDatabaseFactory.kt
+++ b/shared/src/iosMain/kotlin/com/zhousl/aether/data/chatdb/IosChatHistoryDatabaseFactory.kt
@@ -8,4 +8,5 @@ fun createIosChatHistoryDatabase(path: String): ChatHistoryDatabase =
     Room.databaseBuilder<ChatHistoryDatabase>(name = path)
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.Default)
+        .addMigrations(*ChatHistoryMigrations)
         .build()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-progress assistant responses are checkpointed, allowing streaming content to be restored after interruptions or app restarts.
  * Incomplete messages are tracked and excluded from the visible conversation until finalized.
  * Response updates preserve surrounding messages, session details, and workspace references.

* **Bug Fixes**
  * Improved persistence of incomplete message content and completion status.
  * Added database migration support to preserve existing chat history and metadata.

* **Tests**
  * Expanded coverage for checkpoint replacement, recovery, serialization, deletion, and database migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->