### PR TITLE
feat: expose Pi thinking modes for supported models

### DIFF
--- a/app/src/main/java/com/zhousl/aether/data/ProviderModelCatalogClient.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ProviderModelCatalogClient.kt
@@ -24,8 +24,12 @@ internal fun piThinkingLevelClamps(clamps: JSONObject): Map<String, String> =
         clamps.optString(level).takeIf { it in PiThinkingLevels }?.let { level to it }
     }.toMap()
 
-internal fun thinkingCatalogKey(providerId: String, modelId: String): String =
-    "${providerId.trim()}/${modelId.substringAfterLast('/').trim()}"
+internal fun thinkingCatalogKey(
+    providerConfigId: String,
+    providerId: String,
+    modelId: String,
+): String =
+    "${providerConfigId.trim()}:${providerId.trim()}/${modelId.substringAfterLast('/').trim()}"
 
 internal data class PiModelCapabilities(
     val reasoning: Boolean,
@@ -111,7 +115,7 @@ object ProviderModelCatalogClient {
 
         val capabilities = piModelCapabilities(
             piKernelBridge.getModelCapabilities(
-                modelConfig = config.toPiModelConfig().toJson(),
+                modelConfig = config.toPiModelConfig(reasoningEnabled = true).toJson(),
                 startIfNeeded = startPiBridgeIfNeeded,
             ),
         )

--- a/app/src/main/java/com/zhousl/aether/data/ProviderModelCatalogClient.kt
+++ b/app/src/main/java/com/zhousl/aether/data/ProviderModelCatalogClient.kt
@@ -1,6 +1,7 @@
 package com.zhousl.aether.data
 
 import com.zhousl.aether.data.pi.PiKernelBridge
+import com.zhousl.aether.data.pi.toPiModelConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -25,6 +26,23 @@ internal fun piThinkingLevelClamps(clamps: JSONObject): Map<String, String> =
 
 internal fun thinkingCatalogKey(providerId: String, modelId: String): String =
     "${providerId.trim()}/${modelId.substringAfterLast('/').trim()}"
+
+internal data class PiModelCapabilities(
+    val reasoning: Boolean,
+    val thinkingLevels: List<String>,
+    val thinkingLevelClamps: Map<String, String>,
+)
+
+internal fun piModelCapabilities(payload: JSONObject): PiModelCapabilities =
+    PiModelCapabilities(
+        reasoning = payload.optBoolean("reasoning"),
+        thinkingLevels = supportedThinkingLevels(
+            payload.optJSONArray("thinking_levels") ?: JSONArray(),
+        ),
+        thinkingLevelClamps = payload.optJSONObject("thinking_level_clamps")
+            ?.let(::piThinkingLevelClamps)
+            .orEmpty(),
+    )
 
 object ProviderModelCatalogClient {
 
@@ -64,15 +82,52 @@ object ProviderModelCatalogClient {
     ): FetchModelsResult = withContext(Dispatchers.IO) {
         try {
             val definition = PiProviderCatalog.resolve(config.piProviderId)
-            if (!definition.isBuiltIn) return@withContext FetchModelsResult(emptyList())
-            fetchPiBuiltinModels(
-                definition = definition,
-                piKernelBridge = piKernelBridge,
-                startPiBridgeIfNeeded = startPiBridgeIfNeeded,
-            )
+            if (definition.isBuiltIn) {
+                fetchPiBuiltinModels(
+                    definition = definition,
+                    piKernelBridge = piKernelBridge,
+                    startPiBridgeIfNeeded = startPiBridgeIfNeeded,
+                )
+            } else {
+                fetchPiConfiguredModel(
+                    config = config,
+                    piKernelBridge = piKernelBridge,
+                    startPiBridgeIfNeeded = startPiBridgeIfNeeded,
+                )
+            }
         } catch (e: Exception) {
             FetchModelsResult(emptyList(), e.message ?: "Unknown error")
         }
+    }
+
+    private suspend fun fetchPiConfiguredModel(
+        config: LlmProviderConfig,
+        piKernelBridge: PiKernelBridge?,
+        startPiBridgeIfNeeded: Boolean,
+    ): FetchModelsResult {
+        val modelId = config.modelId.trim()
+        if (modelId.isBlank()) return FetchModelsResult(emptyList())
+        if (piKernelBridge == null) return FetchModelsResult(listOf(modelId))
+
+        val capabilities = piModelCapabilities(
+            piKernelBridge.getModelCapabilities(
+                modelConfig = config.toPiModelConfig().toJson(),
+                startIfNeeded = startPiBridgeIfNeeded,
+            ),
+        )
+        return FetchModelsResult(
+            models = listOf(modelId),
+            thinkingLevelsByModel = if (capabilities.reasoning) {
+                mapOf(modelId to capabilities.thinkingLevels)
+            } else {
+                emptyMap()
+            },
+            thinkingLevelClampsByModel = if (capabilities.reasoning) {
+                mapOf(modelId to capabilities.thinkingLevelClamps)
+            } else {
+                emptyMap()
+            },
+        )
     }
 
     private suspend fun fetchPiBuiltinModels(

--- a/app/src/main/java/com/zhousl/aether/data/pi/PiKernelBridge.kt
+++ b/app/src/main/java/com/zhousl/aether/data/pi/PiKernelBridge.kt
@@ -83,6 +83,16 @@ class PiKernelBridge(
             startIfNeeded = startIfNeeded,
         )
 
+    suspend fun getModelCapabilities(
+        modelConfig: JSONObject,
+        startIfNeeded: Boolean = true,
+    ): JSONObject = request(
+        type = "get_model_capabilities",
+        payload = JSONObject().put("model_config", modelConfig),
+        timeoutMillis = PiBridgePingTimeoutMillis,
+        startIfNeeded = startIfNeeded,
+    )
+
     suspend fun loginProvider(
         providerConfigId: String,
         providerId: String,

--- a/app/src/main/java/com/zhousl/aether/data/pi/PiProviderMapper.kt
+++ b/app/src/main/java/com/zhousl/aether/data/pi/PiProviderMapper.kt
@@ -2,6 +2,7 @@ package com.zhousl.aether.data.pi
 
 import com.zhousl.aether.data.AppSettings
 import com.zhousl.aether.data.LlmCustomHeader
+import com.zhousl.aether.data.LlmProviderConfig
 import com.zhousl.aether.data.LlmTokenUsage
 import com.zhousl.aether.data.PiProviderCatalog
 import com.zhousl.aether.data.normalizeLlmUserAgent
@@ -79,40 +80,58 @@ data class PiCompletionResult(
     val updatedOauthCredentialJson: String = "",
 )
 
-fun AppSettings.toPiModelConfig(): PiModelConfig {
+fun AppSettings.toPiModelConfig(): PiModelConfig =
+    LlmProviderConfig(
+        id = providerConfigId,
+        providerId = piProviderId,
+        name = "",
+        piProviderId = piProviderId,
+        apiKey = apiKey,
+        baseUrl = baseUrl,
+        authMethod = providerAuthMethod,
+        oauthCredentialJson = oauthCredentialJson,
+        providerEnvironmentVariables = providerEnvironmentVariables,
+        modelId = modelId,
+        userAgent = userAgent,
+        customHeaders = customHeaders,
+    ).toPiModelConfig(
+        reasoningEnabled = toPiThinkingLevel() != "off",
+        timeoutMillis = llmInactivityReconnectTimeoutSeconds
+            .coerceIn(30, 3_600) * 1_000,
+    )
+
+internal fun LlmProviderConfig.toPiModelConfig(
+    reasoningEnabled: Boolean = false,
+    timeoutMillis: Int = 360_000,
+): PiModelConfig {
     val definition = PiProviderCatalog.resolve(piProviderId)
     val effectiveAuthMethod = if (
-        providerAuthMethod == ProviderAuthMethod.ApiKey &&
+        authMethod == ProviderAuthMethod.ApiKey &&
         !definition.supportsApiKey &&
         definition.supportsAmbientAuth
     ) {
         ProviderAuthMethod.Ambient
     } else {
-        providerAuthMethod
+        authMethod
     }
     return PiModelConfig(
         providerType = if (definition.isBuiltIn) "builtin" else "custom",
-        providerConfigId = providerConfigId.ifBlank {
+        providerConfigId = id.ifBlank {
             if (definition.isBuiltIn) definition.id else "aether-${stableProviderSuffix(baseUrl)}"
         },
         piProviderId = if (definition.isBuiltIn) {
             definition.id
         } else {
-            "aether-${stableProviderSuffix(providerConfigId.ifBlank { baseUrl })}"
+            "aether-${stableProviderSuffix(id.ifBlank { baseUrl })}"
         },
         piApi = if (definition.isBuiltIn) "builtin" else "openai-completions",
         modelId = modelId.trim(),
         baseUrl = baseUrl.trim(),
-        apiKey = if (effectiveAuthMethod == ProviderAuthMethod.ApiKey) {
-            apiKey.trim()
-        } else {
-            ""
-        },
+        apiKey = if (effectiveAuthMethod == ProviderAuthMethod.ApiKey) apiKey.trim() else "",
         customHeaders = customHeaders.toPiHeaderMap() +
             ("User-Agent" to normalizeLlmUserAgent(userAgent)),
-        reasoning = false,
-        timeoutMillis = llmInactivityReconnectTimeoutSeconds
-            .coerceIn(30, 3_600) * 1_000,
+        reasoning = reasoningEnabled && !definition.isBuiltIn,
+        timeoutMillis = timeoutMillis.coerceIn(30_000, 3_600_000),
         authMethod = effectiveAuthMethod,
         oauthCredentialJson = oauthCredentialJson,
         providerEnvironment = providerEnvironmentVariables

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -2374,17 +2374,15 @@ class AetherViewModel(
         }
         val config = current.providerConfigs.firstOrNull { it.id == option.providerConfigId }
             ?: return onResolved(false)
-        val definition = com.zhousl.aether.data.PiProviderCatalog.resolve(config.piProviderId)
-        if (!definition.isBuiltIn) {
-            onResolved(false)
-            return
-        }
+        val startPiBridgeIfNeeded = !com.zhousl.aether.data.PiProviderCatalog
+            .resolve(config.piProviderId)
+            .isBuiltIn
 
         viewModelScope.launch {
             val result = ProviderModelCatalogClient.fetchPiThinkingLevels(
-                config = config,
+                config = config.copy(modelId = option.modelId),
                 piKernelBridge = runtime.piKernelBridge,
-                startPiBridgeIfNeeded = false,
+                startPiBridgeIfNeeded = startPiBridgeIfNeeded,
             )
             if (result.error != null) {
                 onResolved(false)
@@ -2428,14 +2426,15 @@ class AetherViewModel(
             ?: return
         val config = current.providerConfigs.firstOrNull { it.id == option.providerConfigId }
             ?: return
-        val definition = com.zhousl.aether.data.PiProviderCatalog.resolve(config.piProviderId)
-        if (!definition.isBuiltIn) return
+        val startPiBridgeIfNeeded = !com.zhousl.aether.data.PiProviderCatalog
+            .resolve(config.piProviderId)
+            .isBuiltIn
 
         viewModelScope.launch {
             val result = ProviderModelCatalogClient.fetchPiThinkingLevels(
-                config = config,
+                config = config.copy(modelId = option.modelId),
                 piKernelBridge = runtime.piKernelBridge,
-                startPiBridgeIfNeeded = false,
+                startPiBridgeIfNeeded = startPiBridgeIfNeeded,
             )
             if (result.error != null) return@launch
             _uiState.update { state ->

--- a/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/AetherViewModel.kt
@@ -2281,6 +2281,15 @@ class AetherViewModel(
     fun upsertProviderConfig(config: LlmProviderConfig) {
         viewModelScope.launch {
             val normalizedConfig = normalizeProviderConfig(config)
+            val cachePrefix = "${normalizedConfig.id.trim()}:"
+            _uiState.update { current ->
+                current.copy(
+                    thinkingLevelsByProviderModel = current.thinkingLevelsByProviderModel
+                        .filterKeys { key -> !key.startsWith(cachePrefix) },
+                    thinkingLevelClampsByProviderModel = current.thinkingLevelClampsByProviderModel
+                        .filterKeys { key -> !key.startsWith(cachePrefix) },
+                )
+            }
             settingsRepository.upsertProviderConfig(normalizedConfig)
             if (
                 normalizedConfig.authMethod != ProviderAuthMethod.OAuth ||
@@ -2301,6 +2310,15 @@ class AetherViewModel(
 
     fun removeProviderConfig(id: String) {
         viewModelScope.launch {
+            val cachePrefix = "${id.trim()}:"
+            _uiState.update { current ->
+                current.copy(
+                    thinkingLevelsByProviderModel = current.thinkingLevelsByProviderModel
+                        .filterKeys { key -> !key.startsWith(cachePrefix) },
+                    thinkingLevelClampsByProviderModel = current.thinkingLevelClampsByProviderModel
+                        .filterKeys { key -> !key.startsWith(cachePrefix) },
+                )
+            }
             settingsRepository.removeProviderConfig(id)
             runCatching { runtime.piKernelBridge.clearProviderCredential(id) }
             captureAnalyticsEvent(event = "provider removed")
@@ -2367,7 +2385,11 @@ class AetherViewModel(
         val option = current.providerConfigs.availableModelOptions()
             .firstOrNull { it.key == modelKey }
             ?: return onResolved(false)
-        val cacheKey = thinkingCatalogKey(option.piProviderId, option.modelId)
+        val cacheKey = thinkingCatalogKey(
+            option.providerConfigId,
+            option.piProviderId,
+            option.modelId,
+        )
         current.thinkingLevelsByProviderModel[cacheKey]?.let { levels ->
             onResolved(levels.isNotEmpty())
             return
@@ -2388,28 +2410,29 @@ class AetherViewModel(
                 onResolved(false)
                 return@launch
             }
+            val selectedModelId = option.modelId.substringAfterLast('/').trim()
+            val selectedModelLevels = result.thinkingLevelsByModel.entries
+                .firstOrNull { (modelId, _) ->
+                    modelId.substringAfterLast('/').trim() == selectedModelId
+                }
+                ?.value
             _uiState.update { state ->
+                val levels = state.thinkingLevelsByProviderModel +
+                    result.thinkingLevelsByModel.mapKeys { (modelId, _) ->
+                        thinkingCatalogKey(config.id, config.piProviderId, modelId)
+                    } +
+                    if (selectedModelLevels == null) mapOf(cacheKey to emptyList()) else emptyMap()
+                val clamps = state.thinkingLevelClampsByProviderModel +
+                    result.thinkingLevelClampsByModel.mapKeys { (modelId, _) ->
+                        thinkingCatalogKey(config.id, config.piProviderId, modelId)
+                    }
                 state.copy(
-                    thinkingLevelsByProviderModel = state.thinkingLevelsByProviderModel +
-                        result.thinkingLevelsByModel.mapKeys { (modelId, _) ->
-                            thinkingCatalogKey(config.piProviderId, modelId)
-                        },
-                    thinkingLevelClampsByProviderModel = state.thinkingLevelClampsByProviderModel +
-                        result.thinkingLevelClampsByModel.mapKeys { (modelId, _) ->
-                            thinkingCatalogKey(config.piProviderId, modelId)
-                        },
+                    thinkingLevelsByProviderModel = levels,
+                    thinkingLevelClampsByProviderModel =
+                        if (selectedModelLevels == null) clamps - cacheKey else clamps,
                 )
             }
-            val selectedModelId = option.modelId.substringAfterLast('/').trim()
-            onResolved(
-                result.thinkingLevelsByModel.entries
-                    .firstOrNull { (modelId, _) ->
-                        modelId.substringAfterLast('/').trim() == selectedModelId
-                    }
-                    ?.value
-                    .orEmpty()
-                    .isNotEmpty(),
-            )
+            onResolved(selectedModelLevels.orEmpty().isNotEmpty())
         }
     }
 
@@ -2426,6 +2449,11 @@ class AetherViewModel(
             ?: return
         val config = current.providerConfigs.firstOrNull { it.id == option.providerConfigId }
             ?: return
+        val cacheKey = thinkingCatalogKey(
+            option.providerConfigId,
+            option.piProviderId,
+            option.modelId,
+        )
         val startPiBridgeIfNeeded = !com.zhousl.aether.data.PiProviderCatalog
             .resolve(config.piProviderId)
             .isBuiltIn
@@ -2437,16 +2465,26 @@ class AetherViewModel(
                 startPiBridgeIfNeeded = startPiBridgeIfNeeded,
             )
             if (result.error != null) return@launch
+            val selectedModelId = option.modelId.substringAfterLast('/').trim()
+            val selectedModelLevels = result.thinkingLevelsByModel.entries
+                .firstOrNull { (modelId, _) ->
+                    modelId.substringAfterLast('/').trim() == selectedModelId
+                }
+                ?.value
             _uiState.update { state ->
+                val levels = state.thinkingLevelsByProviderModel +
+                    result.thinkingLevelsByModel.mapKeys { (modelId, _) ->
+                        thinkingCatalogKey(config.id, config.piProviderId, modelId)
+                    } +
+                    if (selectedModelLevels == null) mapOf(cacheKey to emptyList()) else emptyMap()
+                val clamps = state.thinkingLevelClampsByProviderModel +
+                    result.thinkingLevelClampsByModel.mapKeys { (modelId, _) ->
+                        thinkingCatalogKey(config.id, config.piProviderId, modelId)
+                    }
                 state.copy(
-                    thinkingLevelsByProviderModel = state.thinkingLevelsByProviderModel +
-                        result.thinkingLevelsByModel.mapKeys { (modelId, _) ->
-                            thinkingCatalogKey(config.piProviderId, modelId)
-                        },
-                    thinkingLevelClampsByProviderModel = state.thinkingLevelClampsByProviderModel +
-                        result.thinkingLevelClampsByModel.mapKeys { (modelId, _) ->
-                            thinkingCatalogKey(config.piProviderId, modelId)
-                        },
+                    thinkingLevelsByProviderModel = levels,
+                    thinkingLevelClampsByProviderModel =
+                        if (selectedModelLevels == null) clamps - cacheKey else clamps,
                 )
             }
         }
@@ -2467,11 +2505,11 @@ class AetherViewModel(
                     isFetchingModels = false,
                     thinkingLevelsByProviderModel = current.thinkingLevelsByProviderModel +
                         result.thinkingLevelsByModel.mapKeys { (modelId, _) ->
-                            thinkingCatalogKey(config.piProviderId, modelId)
+                            thinkingCatalogKey(config.id, config.piProviderId, modelId)
                         },
                     thinkingLevelClampsByProviderModel = current.thinkingLevelClampsByProviderModel +
                         result.thinkingLevelClampsByModel.mapKeys { (modelId, _) ->
-                            thinkingCatalogKey(config.piProviderId, modelId)
+                            thinkingCatalogKey(config.id, config.piProviderId, modelId)
                         },
                 )
             }

--- a/app/src/main/java/com/zhousl/aether/ui/ConversationUi.kt
+++ b/app/src/main/java/com/zhousl/aether/ui/ConversationUi.kt
@@ -928,10 +928,14 @@ private fun ConversationModelSelector(
     val menuWidth = 242.dp
     val selectedOption = options.firstOrNull { it.key == menuSelectedModelKey } ?: options.firstOrNull()
     val supportedThinkingLevels = selectedOption?.let { option ->
-        thinkingLevelsByProviderModel[thinkingCatalogKey(option.piProviderId, option.modelId)]
+        thinkingLevelsByProviderModel[
+            thinkingCatalogKey(option.providerConfigId, option.piProviderId, option.modelId)
+        ]
     }.orEmpty()
     val effectiveReasoningEffort = selectedOption?.let { option ->
-        thinkingLevelClampsByProviderModel[thinkingCatalogKey(option.piProviderId, option.modelId)]
+        thinkingLevelClampsByProviderModel[
+            thinkingCatalogKey(option.providerConfigId, option.piProviderId, option.modelId)
+        ]
             ?.get(reasoningEffort)
     } ?: reasoningEffort
     val fallbackLabel = stringResource(R.string.chat_select_model)

--- a/app/src/test/java/com/zhousl/aether/data/ProviderModelCatalogClientTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ProviderModelCatalogClientTest.kt
@@ -10,10 +10,14 @@ import org.junit.Test
 
 class ProviderModelCatalogClientTest {
     @Test
-    fun thinkingCatalogKeyUsesOnlyLastModelIdSegment() {
+    fun thinkingCatalogKeyIncludesProviderConfigAndUsesLastModelIdSegment() {
         assertEquals(
-            "openrouter/gpt-5.6-sol",
-            thinkingCatalogKey("openrouter", "openai/gpt-5.6-sol"),
+            "config-a:openrouter/gpt-5.6-sol",
+            thinkingCatalogKey("config-a", "openrouter", "openai/gpt-5.6-sol"),
+        )
+        assertEquals(
+            "config-b:openrouter/gpt-5.6-sol",
+            thinkingCatalogKey("config-b", "openrouter", "openai/gpt-5.6-sol"),
         )
     }
 

--- a/app/src/test/java/com/zhousl/aether/data/ProviderModelCatalogClientTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/ProviderModelCatalogClientTest.kt
@@ -62,6 +62,26 @@ class ProviderModelCatalogClientTest {
     }
 
     @Test
+    fun modelCapabilitiesUsePiReasoningLevelsAndClamps() {
+        val capabilities = piModelCapabilities(
+            JSONObject()
+                .put("reasoning", true)
+                .put("thinking_levels", JSONArray().put("low").put("high").put("max"))
+                .put(
+                    "thinking_level_clamps",
+                    JSONObject().put("off", "low").put("medium", "high").put("xhigh", "max"),
+                ),
+        )
+
+        assertEquals(true, capabilities.reasoning)
+        assertEquals(listOf("low", "high", "max"), capabilities.thinkingLevels)
+        assertEquals(
+            mapOf("off" to "low", "medium" to "high", "xhigh" to "max"),
+            capabilities.thinkingLevelClamps,
+        )
+    }
+
+    @Test
     fun fetchModelsIncludesConfiguredUserAgentAndCustomHeaders() = runBlocking {
         val server = MockWebServer()
         server.enqueue(

--- a/app/src/test/java/com/zhousl/aether/data/pi/PiProviderMapperTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/pi/PiProviderMapperTest.kt
@@ -5,6 +5,7 @@ import com.zhousl.aether.data.AetherLlmUserAgent
 import com.zhousl.aether.data.LlmCustomHeader
 import com.zhousl.aether.data.LlmImagePart
 import com.zhousl.aether.data.LlmMessage
+import com.zhousl.aether.data.LlmProviderConfig
 import com.zhousl.aether.data.LlmTextPart
 import com.zhousl.aether.data.LlmTokenUsage
 import com.zhousl.aether.data.ProviderAuthMethod
@@ -76,6 +77,22 @@ class PiProviderMapperTest {
             modelId = "custom-model",
             reasoningEffort = "high",
         ).toPiThinkingLevel())
+    }
+
+    @Test
+    fun customCapabilityProbeAdvertisesReasoningSupport() {
+        val probe = LlmProviderConfig(
+            id = "custom-provider-id",
+            providerId = "custom",
+            name = "Custom",
+            piProviderId = "openai-compatible",
+            apiKey = "custom-key",
+            baseUrl = "https://example.test/v1",
+            modelId = "custom-model",
+        ).toPiModelConfig(reasoningEnabled = true)
+
+        assertTrue(probe.reasoning)
+        assertTrue(probe.toJson().getBoolean("reasoning"))
     }
 
     @Test

--- a/app/src/test/java/com/zhousl/aether/data/pi/PiProviderMapperTest.kt
+++ b/app/src/test/java/com/zhousl/aether/data/pi/PiProviderMapperTest.kt
@@ -33,11 +33,13 @@ class PiProviderMapperTest {
         assertEquals("gpt-5.4", config.modelId)
         assertEquals("sk-test", config.apiKey)
         assertFalse(config.reasoning)
-        assertEquals("high", AppSettings(
+        val activeReasoningSettings = AppSettings(
             piProviderId = "openai",
             modelId = "gpt-5.4",
             reasoningEffort = "high",
-        ).toPiThinkingLevel())
+        )
+        assertEquals("high", activeReasoningSettings.toPiThinkingLevel())
+        assertFalse(activeReasoningSettings.toPiModelConfig().reasoning)
     }
 
     @Test
@@ -59,7 +61,7 @@ class PiProviderMapperTest {
     }
 
     @Test
-    fun customModelDoesNotInventReasoningCapability() {
+    fun activeThinkingLevelEnablesCustomModelReasoningCapability() {
         val config = AppSettings(
             piProviderId = "openai-compatible",
             providerConfigId = "custom-provider-id",
@@ -68,7 +70,7 @@ class PiProviderMapperTest {
             reasoningEffort = "high",
         ).toPiModelConfig()
 
-        assertFalse(config.reasoning)
+        assertTrue(config.reasoning)
         assertEquals("high", AppSettings(
             piProviderId = "openai-compatible",
             modelId = "custom-model",

--- a/pi-bridge/src/bridge.ts
+++ b/pi-bridge/src/bridge.ts
@@ -85,6 +85,7 @@ const DEFAULT_HARNESS_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_AGENT_RETRY_MAX_RETRIES = 5;
 const DEFAULT_AGENT_RETRY_BASE_DELAY_MS = 2_000;
 const CUSTOM_BASE_URL_BUILTIN_PROVIDER_IDS = new Set(["openai", "anthropic"]);
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
 type JsonObject = Record<string, unknown>;
 
@@ -634,24 +635,41 @@ function apiStreamsFor(piApi: string): ProviderStreams {
   }
 }
 
+function customModelTemplate(config: ModelConfig): Model<string> | undefined {
+  const matchingApiModels = getBuiltinProviders()
+    .flatMap((providerId) => getBuiltinModels(providerId))
+    .filter((model) => model.api === config.pi_api);
+  const exact = matchingApiModels.find((model) => model.id === config.model_id);
+  if (exact) return exact as Model<string>;
+  const normalizedModelId = config.model_id.toLowerCase();
+  return matchingApiModels.find((model) => model.id.toLowerCase() === normalizedModelId) as
+    | Model<string>
+    | undefined;
+}
+
 function createAetherModel(config: ModelConfig): Model<string> {
+  const template = customModelTemplate(config);
   return {
+    ...template,
     id: config.model_id,
-    name: config.model_id,
+    name: template?.name ?? config.model_id,
     api: config.pi_api,
     provider: config.pi_provider_id,
     baseUrl: config.base_url,
-    reasoning: config.reasoning ?? false,
-    input: ["text", "image"],
-    cost: {
+    reasoning: template?.reasoning ?? config.reasoning ?? false,
+    input: template?.input ?? ["text", "image"],
+    cost: template?.cost ?? {
       input: 0,
       output: 0,
       cacheRead: 0,
       cacheWrite: 0,
     },
-    contextWindow: config.context_window ?? 128000,
-    maxTokens: config.max_tokens ?? 16384,
-    headers: config.custom_headers,
+    contextWindow: config.context_window ?? template?.contextWindow ?? 128000,
+    maxTokens: config.max_tokens ?? template?.maxTokens ?? 16384,
+    headers: {
+      ...template?.headers,
+      ...config.custom_headers,
+    },
   };
 }
 
@@ -789,6 +807,16 @@ async function credentialPayload(
   };
 }
 
+function modelCapabilitiesPayload(model: Model<string>): JsonObject {
+  return {
+    reasoning: model.reasoning,
+    thinking_levels: getSupportedThinkingLevels(model),
+    thinking_level_clamps: Object.fromEntries(
+      THINKING_LEVELS.map((level) => [level, clampThinkingLevel(model, level)]),
+    ),
+  };
+}
+
 function providerCatalogPayload(): JsonObject {
   return {
     providers: getBuiltinProviders().map((providerId) => {
@@ -808,14 +836,7 @@ function providerCatalogPayload(): JsonObject {
           id: model.id,
           name: model.name,
           api: model.api,
-          reasoning: model.reasoning,
-          thinking_levels: getSupportedThinkingLevels(model),
-          thinking_level_clamps: Object.fromEntries(
-            ["off", "minimal", "low", "medium", "high", "xhigh", "max"].map((level) => [
-              level,
-              clampThinkingLevel(model, level as "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"),
-            ]),
-          ),
+          ...modelCapabilitiesPayload(model),
           input: model.input,
           context_window: model.contextWindow,
           max_tokens: model.maxTokens,
@@ -2737,6 +2758,12 @@ async function handleRequest(request: BridgeRequest): Promise<void> {
     case "list_providers":
       writeResponse(id, providerCatalogPayload());
       return;
+    case "get_model_capabilities": {
+      const config = normalizeModelConfig(payload.model_config);
+      const { model } = buildModels(config);
+      writeResponse(id, modelCapabilitiesPayload(model));
+      return;
+    }
     case "login_provider":
       writeResponse(id, await loginProvider(id, payload));
       return;

--- a/pi-bridge/tests/bridge.test.mjs
+++ b/pi-bridge/tests/bridge.test.mjs
@@ -1327,6 +1327,25 @@ test("lists every built-in Pi provider and its model catalog", async () => {
   assert.deepEqual(oauthProviders, ["anthropic", "github-copilot", "openai-codex"]);
 });
 
+test("returns Pi thinking capabilities for a known model on a custom endpoint", async () => {
+  const client = new BridgeClient();
+  const capabilities = await client.request("custom-capabilities", "get_model_capabilities", {
+    model_config: {
+      provider_type: "custom",
+      provider_config_id: "custom-kimi",
+      pi_provider_id: "aether-modal",
+      pi_api: "openai-completions",
+      model_id: "kimi-k3",
+      base_url: "https://example.modal.run/v1",
+      reasoning: false,
+    },
+  });
+
+  assert.equal(capabilities.reasoning, true);
+  assert.deepEqual(capabilities.thinking_levels, ["low", "high", "max"]);
+  assert.equal(capabilities.thinking_level_clamps.medium, "high");
+});
+
 test("validates Pi OAuth protocol requests without legacy provider fallbacks", async () => {
   const client = new BridgeClient();
   const promptResult = await client.request("prompt-missing", "auth_prompt_result", {

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClient.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClient.kt
@@ -47,8 +47,12 @@ data class SharedModelCatalogInfo(
 
 private val SharedPiThinkingLevels = listOf("off", "minimal", "low", "medium", "high", "xhigh", "max")
 
-internal fun sharedThinkingCatalogKey(providerId: String, modelId: String): String =
-    "${providerId.trim()}/${modelId.substringAfterLast('/').trim()}"
+internal fun sharedThinkingCatalogKey(
+    providerConfigId: String,
+    providerId: String,
+    modelId: String,
+): String =
+    "${providerConfigId.trim()}:${providerId.trim()}/${modelId.substringAfterLast('/').trim()}"
 
 class SharedProviderModelCatalogClient(engine: HttpClientEngine? = null) {
     private val client = if (engine == null) createClient() else createClient(engine)
@@ -134,7 +138,14 @@ class SharedProviderModelCatalogClient(engine: HttpClientEngine? = null) {
                     } else {
                         emptyList()
                     }
-                    put(sharedThinkingCatalogKey(option.piProviderId, option.modelId), levels)
+                    put(
+                        sharedThinkingCatalogKey(
+                            option.providerConfigId,
+                            option.piProviderId,
+                            option.modelId,
+                        ),
+                        levels,
+                    )
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClient.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClient.kt
@@ -29,6 +29,12 @@ data class SharedProviderModelsResult(
     val thinkingLevelClampsByModel: Map<String, Map<String, String>> = emptyMap(),
 )
 
+data class SharedPiModelCapabilities(
+    val reasoning: Boolean,
+    val thinkingLevels: List<String>,
+    val thinkingLevelClamps: Map<String, String>,
+)
+
 data class SharedModelCatalogInfo(
     val displayName: String,
     val labId: String,
@@ -495,3 +501,12 @@ internal fun sharedThinkingLevelClamps(clamps: JsonObject): Map<String, String> 
             ?.takeIf { it in SharedPiThinkingLevels }
             ?.let { effort to it }
     }.toMap()
+
+internal fun sharedPiModelCapabilities(payload: JsonObject): SharedPiModelCapabilities =
+    SharedPiModelCapabilities(
+        reasoning = payload["reasoning"]?.jsonPrimitive?.booleanOrNull == true,
+        thinkingLevels = supportedSharedThinkingLevels(payload["thinking_levels"] as? JsonArray),
+        thinkingLevelClamps = (payload["thinking_level_clamps"] as? JsonObject)
+            ?.let(::sharedThinkingLevelClamps)
+            .orEmpty(),
+    )

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/data/pi/SharedPiChatClient.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/data/pi/SharedPiChatClient.kt
@@ -95,7 +95,13 @@ class SharedPiChatClient(
         val response = bridge.request(
             type = "complete_once",
             payload = buildJsonObject {
-                put("model_config", config.toSharedPiModelConfig(timeoutMillis))
+                put(
+                    "model_config",
+                    config.toSharedPiModelConfig(
+                        timeoutMillis = timeoutMillis,
+                        reasoningEnabled = reasoning != "off",
+                    ),
+                )
                 put("system_prompt", systemPrompt.ifBlank { platformDefaultSystemPrompt() })
                 put("messages", messages.toPiMessages())
                 put("stream", false)
@@ -143,7 +149,13 @@ class SharedPiChatClient(
             else -> executor?.definitions ?: JsonArray(emptyList())
         }
         val payload = buildJsonObject {
-            put("model_config", config.toSharedPiModelConfig(timeoutMillis))
+            put(
+                "model_config",
+                config.toSharedPiModelConfig(
+                    timeoutMillis = timeoutMillis,
+                    reasoningEnabled = reasoning != "off",
+                ),
+            )
             put("session_id", resolvedSessionId)
             put("system_prompt", systemPrompt.ifBlank { platformDefaultSystemPrompt() })
             put("messages", messages.toPiMessages())
@@ -309,7 +321,10 @@ data class SharedPiHostToolCall(
     val arguments: JsonObject,
 )
 
-fun LlmProviderConfig.toSharedPiModelConfig(timeoutMillis: Int = 360_000): JsonObject {
+fun LlmProviderConfig.toSharedPiModelConfig(
+    timeoutMillis: Int = 360_000,
+    reasoningEnabled: Boolean = false,
+): JsonObject {
     val definition = PiProviderCatalog.resolve(piProviderId)
     val effectiveAuthMethod = if (
         authMethod == ProviderAuthMethod.ApiKey &&
@@ -339,7 +354,7 @@ fun LlmProviderConfig.toSharedPiModelConfig(timeoutMillis: Int = 360_000): JsonO
             }
             put("User-Agent", normalizeLlmUserAgent(userAgent))
         })
-        put("reasoning", false)
+        put("reasoning", reasoningEnabled && !definition.isBuiltIn)
         put("context_window", 128_000)
         put("max_tokens", 16_384)
         put("timeout_ms", timeoutMillis.coerceIn(30_000, 3_600_000))

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/runtime/SharedPiBridgeClient.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/runtime/SharedPiBridgeClient.kt
@@ -84,6 +84,16 @@ class SharedPiBridgeClient(
             startIfNeeded = startIfNeeded,
         )
 
+    suspend fun getModelCapabilities(
+        modelConfig: JsonObject,
+        startIfNeeded: Boolean = true,
+    ): JsonObject = request(
+        type = "get_model_capabilities",
+        payload = buildJsonObject { put("model_config", modelConfig) },
+        timeoutMillis = 15_000,
+        startIfNeeded = startIfNeeded,
+    )
+
     suspend fun loginProvider(
         providerConfigId: String,
         providerId: String,

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/ui/AetherSharedApp.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/ui/AetherSharedApp.kt
@@ -895,8 +895,9 @@ fun AetherSharedApp(
         val modelOptions = remember(providerConfigsSnapshot) {
             providerConfigsSnapshot.availableModelOptions()
         }
-        val modelCatalogRequestKey = remember(modelOptions) {
-            modelOptions.joinToString("|") { "${it.key}:${it.fullLabel}" }
+        val modelCatalogRequestKey = remember(modelOptions, providerConfigsSnapshot) {
+            providerConfigsSnapshot.joinToString("|") { "${it.id}:${it.updatedAtMillis}" } +
+                "|" + modelOptions.joinToString("|") { "${it.key}:${it.fullLabel}" }
         }
         val modelCatalogClient = remember { SharedProviderModelCatalogClient() }
         var modelCatalogInfo by remember {
@@ -1124,15 +1125,29 @@ fun AetherSharedApp(
             }
         }
 
+        fun invalidateThinkingCatalogCache(): Job {
+            thinkingLevelsByProviderModel = emptyMap()
+            thinkingLevelClampsByProviderModel = emptyMap()
+            return appScope.launch {
+                settingsStore?.saveThinkingCatalogCache(SharedThinkingCatalogCache())
+            }
+        }
+
         fun commitProviderConfigs(
             updatedConfigs: List<LlmProviderConfig>,
             preferredActiveConfigId: String = providerConfig?.id.orEmpty(),
+            thinkingCacheAlreadyInvalidated: Boolean = false,
         ) {
             val normalized = updatedConfigs.distinctBy(LlmProviderConfig::id)
             val activeConfigId = resolveSharedActiveProviderConfigId(
                 providerConfigs = normalized,
                 preferredActiveConfigId = preferredActiveConfigId,
             )
+            val configsChanged = providerConfigs.associateBy(LlmProviderConfig::id) !=
+                normalized.associateBy(LlmProviderConfig::id)
+            if (configsChanged && !thinkingCacheAlreadyInvalidated) {
+                invalidateThinkingCatalogCache()
+            }
             providerConfigs.clear()
             providerConfigs.addAll(normalized)
             providerConfig = normalized.firstOrNull { it.id == activeConfigId }
@@ -1244,7 +1259,11 @@ fun AetherSharedApp(
                     persisted.providerConfigs.availableModelOptions()
                 }
                 val persistedThinkingKeys = persistedModelOptions.mapTo(mutableSetOf()) { option ->
-                    sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+                    sharedThinkingCatalogKey(
+                        option.providerConfigId,
+                        option.piProviderId,
+                        option.modelId,
+                    )
                 }
                 thinkingLevelsByProviderModel = persisted.thinkingCatalogCache.levelsByProviderModel
                     .filterKeys(persistedThinkingKeys::contains)
@@ -1333,7 +1352,11 @@ fun AetherSharedApp(
 
         suspend fun persistThinkingCatalogCache() {
             val validKeys = modelOptions.mapTo(mutableSetOf()) { option ->
-                sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+                sharedThinkingCatalogKey(
+                    option.providerConfigId,
+                    option.piProviderId,
+                    option.modelId,
+                )
             }
             val cache = SharedThinkingCatalogCache(
                 levelsByProviderModel = thinkingLevelsByProviderModel.filterKeys(validKeys::contains),
@@ -1363,13 +1386,17 @@ fun AetherSharedApp(
                     val runtimeResult = withContext(Dispatchers.Default) {
                         val levels = mutableMapOf<String, List<String>>()
                         val clamps = mutableMapOf<String, Map<String, String>>()
-                        configs.distinctBy(LlmProviderConfig::piProviderId).forEach { config ->
+                        configs.forEach { config ->
                             val result = providerModelsFromCatalog(runtimeCatalog, config.piProviderId)
                             result.thinkingLevelsByModel.forEach { (modelId, supported) ->
-                                levels[sharedThinkingCatalogKey(config.piProviderId, modelId)] = supported
+                                levels[
+                                    sharedThinkingCatalogKey(config.id, config.piProviderId, modelId)
+                                ] = supported
                             }
                             result.thinkingLevelClampsByModel.forEach { (modelId, supported) ->
-                                clamps[sharedThinkingCatalogKey(config.piProviderId, modelId)] = supported
+                                clamps[
+                                    sharedThinkingCatalogKey(config.id, config.piProviderId, modelId)
+                                ] = supported
                             }
                         }
                         levels to clamps
@@ -1377,7 +1404,11 @@ fun AetherSharedApp(
                     val refreshedKeys = options
                         .filter { option -> PiProviderCatalog.resolve(option.piProviderId).isBuiltIn }
                         .mapTo(mutableSetOf()) { option ->
-                            sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+                            sharedThinkingCatalogKey(
+                                option.providerConfigId,
+                                option.piProviderId,
+                                option.modelId,
+                            )
                         }
                     thinkingLevelsByProviderModel =
                         thinkingLevelsByProviderModel.filterKeys { it !in refreshedKeys } + runtimeResult.first
@@ -1389,12 +1420,16 @@ fun AetherSharedApp(
                 options
                     .filter { option -> !PiProviderCatalog.resolve(option.piProviderId).isBuiltIn }
                     .forEach { option ->
-                        val key = sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+                        val key = sharedThinkingCatalogKey(
+                            option.providerConfigId,
+                            option.piProviderId,
+                            option.modelId,
+                        )
                         val config = configs.firstOrNull { it.id == option.providerConfigId } ?: return@forEach
                         val capabilities = runSharedAppCatching {
                             bridgeClient.getModelCapabilities(
                                 modelConfig = config.copy(modelId = option.modelId)
-                                    .toSharedPiModelConfig(),
+                                    .toSharedPiModelConfig(reasoningEnabled = true),
                                 startIfNeeded = true,
                             )
                         }.getOrNull() ?: return@forEach
@@ -2541,9 +2576,12 @@ fun AetherSharedApp(
                     val restored = manager.restoreJson(value)
                     val persisted = restored.persistedSettings
                     sharedAppSettings = persisted.appSettings
-                    providerConfigs.clear()
-                    providerConfigs.addAll(persisted.providerConfigs)
-                    providerConfig = persisted.activeProviderConfig
+                    invalidateThinkingCatalogCache().join()
+                    commitProviderConfigs(
+                        updatedConfigs = persisted.providerConfigs,
+                        preferredActiveConfigId = persisted.activeProviderConfigId,
+                        thinkingCacheAlreadyInvalidated = true,
+                    )
                     installedSkills.clear()
                     installedSkills.addAll(restored.installedSkills)
                     mcpServers.clear()
@@ -2812,7 +2850,11 @@ fun AetherSharedApp(
                         if (option == null) {
                             onResolved(false)
                         } else {
-                            val thinkingKey = sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+                            val thinkingKey = sharedThinkingCatalogKey(
+                                option.providerConfigId,
+                                option.piProviderId,
+                                option.modelId,
+                            )
                             val cachedLevels = thinkingLevelsByProviderModel[thinkingKey]
                             if (cachedLevels != null) {
                                 onResolved(cachedLevels.isNotEmpty())
@@ -5156,7 +5198,11 @@ private fun SharedConversationModelSelector(
     val density = LocalDensity.current
     val selectedOption = options.findModelOption(menuSelectedModelKey) ?: options.firstOrNull()
     val thinkingKey = selectedOption?.let { option ->
-        sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+        sharedThinkingCatalogKey(
+            option.providerConfigId,
+            option.piProviderId,
+            option.modelId,
+        )
     }
     val supportedThinkingLevels = thinkingKey?.let(thinkingLevelsByProviderModel::get).orEmpty()
     val effectiveReasoningEffort = thinkingKey

--- a/shared/src/commonMain/kotlin/com/zhousl/aether/ui/AetherSharedApp.kt
+++ b/shared/src/commonMain/kotlin/com/zhousl/aether/ui/AetherSharedApp.kt
@@ -207,6 +207,7 @@ import com.zhousl.aether.data.shouldRevealFollowUpTourCard
 import com.zhousl.aether.data.withModelOption
 import com.zhousl.aether.data.toJsonObject
 import com.zhousl.aether.data.providerModelsFromCatalog
+import com.zhousl.aether.data.sharedPiModelCapabilities
 import com.zhousl.aether.data.sharedThinkingCatalogKey
 import com.zhousl.aether.data.platformRandomUuid
 import com.zhousl.aether.data.platformCurrentTimeMillis
@@ -220,6 +221,7 @@ import com.zhousl.aether.data.pi.SharedPiChatClient
 import com.zhousl.aether.data.pi.SharedPiChatMessage
 import com.zhousl.aether.data.pi.SharedPiContentPart
 import com.zhousl.aether.data.pi.SharedPiUsage
+import com.zhousl.aether.data.pi.toSharedPiModelConfig
 import com.zhousl.aether.data.pi.RuntimeHostToolExecutor
 import com.zhousl.aether.data.pi.SharedAgentManagementTools
 import com.zhousl.aether.data.pi.SharedMcpManager
@@ -1372,14 +1374,43 @@ fun AetherSharedApp(
                         }
                         levels to clamps
                     }
-                    val refreshedKeys = options.mapTo(mutableSetOf()) { option ->
-                        sharedThinkingCatalogKey(option.piProviderId, option.modelId)
-                    }
-                    thinkingLevelsByProviderModel = thinkingLevelsByProviderModel + runtimeResult.first
+                    val refreshedKeys = options
+                        .filter { option -> PiProviderCatalog.resolve(option.piProviderId).isBuiltIn }
+                        .mapTo(mutableSetOf()) { option ->
+                            sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+                        }
+                    thinkingLevelsByProviderModel =
+                        thinkingLevelsByProviderModel.filterKeys { it !in refreshedKeys } + runtimeResult.first
                     thinkingLevelClampsByProviderModel =
                         thinkingLevelClampsByProviderModel.filterKeys { it !in refreshedKeys } + runtimeResult.second
                     persistThinkingCatalogCache()
                 }
+
+                options
+                    .filter { option -> !PiProviderCatalog.resolve(option.piProviderId).isBuiltIn }
+                    .forEach { option ->
+                        val key = sharedThinkingCatalogKey(option.piProviderId, option.modelId)
+                        val config = configs.firstOrNull { it.id == option.providerConfigId } ?: return@forEach
+                        val capabilities = runSharedAppCatching {
+                            bridgeClient.getModelCapabilities(
+                                modelConfig = config.copy(modelId = option.modelId)
+                                    .toSharedPiModelConfig(),
+                                startIfNeeded = true,
+                            )
+                        }.getOrNull() ?: return@forEach
+                        val parsed = sharedPiModelCapabilities(capabilities)
+                        if (parsed.reasoning) {
+                            thinkingLevelsByProviderModel = thinkingLevelsByProviderModel +
+                                (key to parsed.thinkingLevels)
+                            thinkingLevelClampsByProviderModel = thinkingLevelClampsByProviderModel +
+                                (key to parsed.thinkingLevelClamps)
+                        } else if (key !in publicLevels) {
+                            thinkingLevelsByProviderModel = thinkingLevelsByProviderModel +
+                                (key to emptyList())
+                            thinkingLevelClampsByProviderModel = thinkingLevelClampsByProviderModel - key
+                        }
+                    }
+                persistThinkingCatalogCache()
                 true
             }.getOrDefault(false)
         }

--- a/shared/src/commonTest/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClientTest.kt
@@ -17,6 +17,19 @@ import kotlinx.serialization.json.JsonObject
 
 class SharedProviderModelCatalogClientTest {
     @Test
+    fun parsesPiModelCapabilitiesIncludingClamps() {
+        val capabilities = sharedPiModelCapabilities(
+            Json.parseToJsonElement(
+                """{"reasoning":true,"thinking_levels":["off","low","high","unknown"],"thinking_level_clamps":{"max":"high","invalid":"low"}}""",
+            ) as JsonObject,
+        )
+
+        assertTrue(capabilities.reasoning)
+        assertEquals(listOf("off", "low", "high"), capabilities.thinkingLevels)
+        assertEquals(mapOf("max" to "high"), capabilities.thinkingLevelClamps)
+    }
+
+    @Test
     fun customProviderFetchesConfiguredModelsEndpointWithHeaders() = runTest {
         val engine = MockEngine { request ->
             assertEquals("https://models.example/v1/models", request.url.toString())

--- a/shared/src/commonTest/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/zhousl/aether/data/SharedProviderModelCatalogClientTest.kt
@@ -139,8 +139,50 @@ class SharedProviderModelCatalogClientTest {
 
         assertEquals(
             listOf("off", "low", "medium", "high"),
-            levels[sharedThinkingCatalogKey("openai", "gpt-5")],
+            levels[sharedThinkingCatalogKey(config.id, "openai", "gpt-5")],
         )
+    }
+
+    @Test
+    fun thinkingLevelsAreScopedByProviderConfiguration() = runTest {
+        val engine = MockEngine {
+            respond(
+                """{"providers":{"openai":{"models":{"gpt-5":{"id":"gpt-5","reasoning":true,"reasoning_options":[{"type":"effort","values":["low","high"]}]}}}}}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val configA = customConfig(piProviderId = "openai").copy(
+            id = "config-a",
+            modelId = "gpt-5",
+            cachedModels = listOf("gpt-5"),
+            enabledModelIds = listOf("gpt-5"),
+        )
+        val configB = configA.copy(id = "config-b")
+        val options = listOf(configA, configB).availableModelOptions()
+
+        val levels = SharedProviderModelCatalogClient(engine).fetchThinkingLevels(options)
+
+        assertEquals(
+            listOf("low", "high"),
+            levels[
+                sharedThinkingCatalogKey(
+                    "config-a",
+                    "openai",
+                    "gpt-5",
+                )
+            ],
+        )
+        assertEquals(
+            listOf("low", "high"),
+            levels[
+                sharedThinkingCatalogKey(
+                    "config-b",
+                    "openai",
+                    "gpt-5",
+                )
+            ],
+        )
+        assertEquals(2, levels.size)
     }
 
     @Test
@@ -166,7 +208,7 @@ class SharedProviderModelCatalogClientTest {
 
         assertEquals(
             listOf("off", "low", "medium", "high", "xhigh"),
-            levels[sharedThinkingCatalogKey("openai-codex", "gpt-5.3-codex-spark")],
+            levels[sharedThinkingCatalogKey(config.id, "openai-codex", "gpt-5.3-codex-spark")],
         )
     }
 
@@ -189,7 +231,7 @@ class SharedProviderModelCatalogClientTest {
 
         assertEquals(
             listOf("off", "low", "medium", "high", "xhigh", "max"),
-            levels[sharedThinkingCatalogKey(config.piProviderId, "gpt-5.6-sol")],
+            levels[sharedThinkingCatalogKey(config.id, config.piProviderId, "gpt-5.6-sol")],
         )
     }
 
@@ -207,7 +249,7 @@ class SharedProviderModelCatalogClientTest {
             enabledModelIds = listOf("claude-haiku"),
         )
         val option = listOf(config).availableModelOptions().single()
-        val cacheKey = sharedThinkingCatalogKey(config.piProviderId, option.modelId)
+        val cacheKey = sharedThinkingCatalogKey(config.id, config.piProviderId, option.modelId)
 
         val levels = SharedProviderModelCatalogClient(engine).fetchThinkingLevels(listOf(option))
 

--- a/shared/src/commonTest/kotlin/com/zhousl/aether/data/pi/SharedPiChatClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/zhousl/aether/data/pi/SharedPiChatClientTest.kt
@@ -42,6 +42,23 @@ class SharedPiChatClientTest {
     }
 
     @Test
+    fun modelConfigEnablesPiReasoningForAnActiveThinkingTurn() {
+        assertEquals(
+            "true",
+            testProvider().toSharedPiModelConfig(reasoningEnabled = true)["reasoning"].toString(),
+        )
+        assertEquals(
+            "false",
+            testProvider().toSharedPiModelConfig(reasoningEnabled = false)["reasoning"].toString(),
+        )
+        assertEquals(
+            "false",
+            testProvider().copy(piProviderId = "openai")
+                .toSharedPiModelConfig(reasoningEnabled = true)["reasoning"].toString(),
+        )
+    }
+
+    @Test
     fun sendsMultimodalContentAndParsesUsage() = runTest {
         val process = ChatProtocolProcess()
         val bridge = SharedPiBridgeClient(


### PR DESCRIPTION
- Read reasoning levels and clamps from Pi model capabilities
- Apply thinking support to custom OpenAI-compatible endpoints

Fixes #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added model capability detection for reasoning support, available thinking levels, and level limits.
  - Custom and OpenAI-compatible models now support capability-based thinking settings.
  - Reasoning preferences are applied consistently when configuring and using models.
  - Model capability information can be refreshed and persisted for future use.

- **Bug Fixes**
  - Improved handling of custom models, missing bridge connections, and invalid or blank model selections.
  - Provider-specific thinking settings are now isolated and refreshed correctly.
  - Unsupported thinking levels and invalid limits are filtered more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->