### PR TITLE
fix: prevent encrypted reasoning replay through custom gateways

### DIFF
--- a/pi-bridge/src/bridge.ts
+++ b/pi-bridge/src/bridge.ts
@@ -666,6 +666,27 @@ function isCustomResponsesEndpoint(
   );
 }
 
+const ISOLATED_REASONING_REPLAY_MODEL_SUFFIX = "#aether-isolated-reasoning-replay";
+
+function isolateResponsesReasoningReplay<T extends { role: string }>(messages: T[]): T[] {
+  return messages.map((message) => {
+    if (
+      message.role !== "assistant" ||
+      !("api" in message) ||
+      message.api !== "openai-responses" ||
+      !("model" in message) ||
+      typeof message.model !== "string" ||
+      message.model.endsWith(ISOLATED_REASONING_REPLAY_MODEL_SUFFIX)
+    ) {
+      return message;
+    }
+    return {
+      ...message,
+      model: `${message.model}${ISOLATED_REASONING_REPLAY_MODEL_SUFFIX}`,
+    };
+  });
+}
+
 function normalizeHeaders(value: unknown): Record<string, string> {
   const inputHeaders = asObject(value);
   const headers: Record<string, string> = {};
@@ -820,6 +841,7 @@ function buildModels(config: ModelConfig): {
   models: MutableModels;
   model: Model<string>;
   provider: Provider;
+  isolateReasoningReplay: boolean;
   credentialStore?: BridgeCredentialStore;
 } {
   bridgeDebug("build_models_start", {
@@ -863,7 +885,7 @@ function buildModels(config: ModelConfig): {
     }
     models.setProvider(faux.provider);
     const model = faux.getModel(config.model_id) ?? faux.getModel();
-    return { models, model, provider: faux.provider };
+    return { models, model, provider: faux.provider, isolateReasoningReplay: false };
   }
 
   if (config.provider_type === "builtin") {
@@ -877,11 +899,12 @@ function buildModels(config: ModelConfig): {
       throw new Error(`Built-in Pi provider ${config.pi_provider_id} has no protocol template.`);
     }
     const defaultBaseUrl = provider.baseUrl ?? modelTemplate.baseUrl;
-    const customBaseUrlModelOverrides = isCustomResponsesEndpoint(
+    const isolateReasoningReplay = isCustomResponsesEndpoint(
       modelTemplate,
       config.base_url,
       defaultBaseUrl,
-    )
+    );
+    const customBaseUrlModelOverrides = isolateReasoningReplay
       ? {
           // Custom Responses endpoints must not inherit official prompt-cache capabilities.
           compat: {
@@ -924,7 +947,7 @@ function buildModels(config: ModelConfig): {
         ...config.custom_headers,
       },
     } as Model<string>;
-    return { models, model, provider, credentialStore };
+    return { models, model, provider, isolateReasoningReplay, credentialStore };
   }
 
   const models = createModels();
@@ -953,12 +976,13 @@ function buildModels(config: ModelConfig): {
     api: apiStreamsFor(config.pi_api),
   });
   models.setProvider(provider);
-  return { models, model, provider };
+  return { models, model, provider, isolateReasoningReplay: false };
 }
 
 async function buildModelRuntime(config: ModelConfig): Promise<{
   modelRuntime: ModelRuntime;
   model: Model<string>;
+  isolateReasoningReplay: boolean;
   credentialStore?: BridgeCredentialStore;
 }> {
   const startedAt = Date.now();
@@ -983,6 +1007,7 @@ async function buildModelRuntime(config: ModelConfig): Promise<{
   return {
     modelRuntime,
     model: built.model,
+    isolateReasoningReplay: built.isolateReasoningReplay,
     credentialStore: built.credentialStore,
   };
 }
@@ -1994,6 +2019,13 @@ function extensionUiContext(): ExtensionUIContext {
   } as unknown as ExtensionUIContext;
 }
 
+const aetherResponsesCompatibilityExtensionFactory: ExtensionFactory = (pi) => {
+  pi.on("context", (event): { messages: typeof event.messages } => ({
+    // Gateway-routed encrypted reasoning may not be decryptable by the next upstream credential.
+    messages: isolateResponsesReasoningReplay(event.messages),
+  }));
+};
+
 const aetherChromeExtensionFactory: ExtensionFactory = (pi) => {
   pi.registerTool({
     name: "browser",
@@ -2166,7 +2198,10 @@ async function createNativeAgentSession(
     agentDir,
     settingsManager,
     additionalExtensionPaths,
-    extensionFactories: platform === "android" ? [aetherChromeExtensionFactory] : [],
+    extensionFactories: [
+      ...(built.isolateReasoningReplay ? [aetherResponsesCompatibilityExtensionFactory] : []),
+      ...(platform === "android" ? [aetherChromeExtensionFactory] : []),
+    ],
     additionalSkillPaths: stringArray(payload.skill_paths),
     appendSystemPrompt: [asString(payload.system_prompt)].filter(Boolean),
   });
@@ -2561,11 +2596,14 @@ async function followUpNativeAgentSession(id: string, payload: JsonObject): Prom
 
 async function runSimpleCompletion(id: string, payload: JsonObject, stream: boolean): Promise<JsonObject> {
   const config = normalizeModelConfig(payload.model_config ?? defaultModelConfig);
-  const { models, model, credentialStore } = buildModels(config);
+  const { models, model, isolateReasoningReplay, credentialStore } = buildModels(config);
   const controller = new AbortController();
   activeAborters.set(id, () => controller.abort());
   try {
     const context = buildContext(payload);
+    if (isolateReasoningReplay) {
+      context.messages = isolateResponsesReasoningReplay(context.messages);
+    }
     const options = streamOptionsFor(payload, controller.signal, config, model);
     if (stream) {
       const eventStream = models.streamSimple(model, context, options);

--- a/pi-bridge/tests/bridge.test.mjs
+++ b/pi-bridge/tests/bridge.test.mjs
@@ -829,6 +829,53 @@ function openAIResponseEvents(responseNumber) {
   ];
 }
 
+function openAIEncryptedReasoningToolEvents() {
+  const reasoningItem = {
+    type: "reasoning",
+    id: "rs_gateway_1",
+    status: "completed",
+    summary: [{ type: "summary_text", text: "route-specific reasoning" }],
+    encrypted_content: "gAAAA-route-specific-encrypted-content",
+  };
+  const functionCall = {
+    type: "function_call",
+    id: "fc_gateway_1",
+    call_id: "call_gateway_1",
+    name: "aether_config_get",
+    arguments: JSON.stringify({ value: "general" }),
+    status: "completed",
+  };
+  return [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...reasoningItem, status: "in_progress", summary: [], encrypted_content: null },
+    },
+    { type: "response.output_item.done", output_index: 0, item: reasoningItem },
+    {
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...functionCall, status: "in_progress", arguments: "" },
+    },
+    { type: "response.output_item.done", output_index: 1, item: functionCall },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_gateway_1",
+        status: "completed",
+        output: [reasoningItem, functionCall],
+        usage: {
+          input_tokens: 5,
+          output_tokens: 3,
+          total_tokens: 8,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 2 },
+        },
+      },
+    },
+  ];
+}
+
 async function createOpenAIResponsesServer() {
   const requests = [];
   let responseCount = 0;
@@ -1678,6 +1725,86 @@ test("omits explicit cache mode for custom OpenAI Responses endpoints", async (t
       false,
     );
   }
+});
+
+test("does not replay encrypted reasoning through custom OpenAI Responses gateways", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "aether-responses-replay-"));
+  const requests = [];
+  const server = createServer((request, response) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      requests.push(body);
+      const replayedEncryptedReasoning = body.input?.some(
+        (item) => item.type === "reasoning" && item.encrypted_content,
+      );
+      if (requests.length > 1 && replayedEncryptedReasoning) {
+        response.writeHead(400, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          error: {
+            message: "The encrypted content could not be verified.",
+            type: "invalid_request_error",
+            code: "invalid_encrypted_content",
+          },
+        }));
+        return;
+      }
+
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      const events = requests.length === 1
+        ? openAIEncryptedReasoningToolEvents()
+        : openAIResponseEvents(requests.length);
+      for (const event of events) response.write(`data: ${JSON.stringify(event)}\n\n`);
+      response.end("data: [DONE]\n\n");
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const client = new BridgeClient({ HOME: home, USERPROFILE: home });
+  t.after(async () => {
+    await client.close();
+    await new Promise((resolve) => server.close(resolve));
+    await rm(home, { recursive: true, force: true });
+  });
+
+  const sessionId = "custom-responses-reasoning-replay";
+  const run = client.request(
+    "custom-responses-reasoning-turn",
+    "run_turn",
+    {
+      ...turnPayload(
+        sessionId,
+        [userMessage("Use the settings tool, then answer.")],
+        openAIResponsesModelConfig(`http://127.0.0.1:${address.port}/v1`, {
+          provider_config_id: sessionId,
+        }),
+        [hostTool("aether_config_get")],
+      ),
+      workspace_directory: home,
+      session_directory: home,
+      reasoning: "high",
+      max_retries: 0,
+    },
+    20_000,
+  );
+  const hostCall = await client.waitForEvent(
+    (frame) => frame.id === "custom-responses-reasoning-turn" && frame.event === "host_tool_request",
+  );
+  await respondToHostTool(client, hostCall, "custom-responses-reasoning-tool-result");
+  const result = await run;
+
+  assert.equal(result.assistant_text, "answer-2", JSON.stringify(result));
+  assert.equal(requests.length, 2);
+  assert.ok(requests[0].include.includes("reasoning.encrypted_content"));
+  assert.equal(
+    requests[1].input.some((item) => item.type === "reasoning" && item.encrypted_content),
+    false,
+  );
+  const replayedFunctionCall = requests[1].input.find((item) => item.type === "function_call");
+  assert.ok(replayedFunctionCall);
+  assert.equal(Object.hasOwn(replayedFunctionCall, "id"), false);
 });
 
 test("preserves explicit cache mode for the official OpenAI Responses endpoint", async (t) => {


### PR DESCRIPTION
Fix `invalid_encrypted_content` errors when resuming conversations through custom OpenAI Responses or LiteLLM-compatible gateways.

### Log

```text
Request failed: OpenAI API error (400): invalid_encrypted_content
The encrypted content could not be decrypted or parsed.
```

This change uses pi's standard context hook and built-in message transformation to isolate non-replayable reasoning content for custom endpoints. Official `api.openai.com` behavior remains unchanged.

### Validation

- `npm test` — 35 tests passed.
- Verified successfully on a physical Android device.
- Custom and official Responses regression tests: 3 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with custom OpenAI Responses endpoints by isolating encrypted reasoning during conversation replay.
  * Prevented encrypted reasoning from being reused across credentials or after host-tool interactions.
  * Preserved function-call replay support even when original event identifiers are unavailable.

* **Tests**
  * Added coverage for encrypted reasoning and function-call event handling across replayed conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->