### PR TITLE
feat(notification): Live Updates focus notifications for active tasks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/com/zhousl/aether/AetherForegroundService.kt
+++ b/app/src/main/java/com/zhousl/aether/AetherForegroundService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.IBinder
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import java.util.concurrent.atomic.AtomicBoolean
@@ -43,7 +44,7 @@ class AetherForegroundService : Service() {
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     stopSelf()
                 } else {
-                    enterForeground(
+                    updateForeground(
                         runtime.notificationController.buildForegroundNotification(
                             sessions = sessions,
                             executionStates = executionStates,
@@ -88,6 +89,20 @@ class AetherForegroundService : Service() {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
         )
         hasEnteredForeground = true
+    }
+
+    /**
+     * Updates the Live Update foreground notification in place (same ID), so the
+     * system keeps the promoted-ongoing behavior and just refreshes the content
+     * — this is what makes the task progress "live".
+     */
+    private fun updateForeground(notification: android.app.Notification) {
+        val notificationManager = NotificationManagerCompat.from(this)
+        if (hasEnteredForeground) {
+            notificationManager.notify(ForegroundNotificationId, notification)
+        } else {
+            enterForeground(notification)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/zhousl/aether/AetherNotificationController.kt
+++ b/app/src/main/java/com/zhousl/aether/AetherNotificationController.kt
@@ -17,6 +17,7 @@ import com.zhousl.aether.ui.ChatSession
 
 private const val ForegroundChannelId = "aether_background_runs"
 private const val CompletionChannelId = "aether_completed_runs"
+private const val LiveUpdateChannelId = "aether_live_updates"
 const val ForegroundNotificationId = 1001
 
 class AetherNotificationController(
@@ -43,10 +44,32 @@ class AetherNotificationController(
         ).apply {
             description = "Alerts you when a background Aether session finishes."
         }
+        val liveUpdateChannel = NotificationChannel(
+            LiveUpdateChannelId,
+            "Live task progress",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Shows real-time progress of Aether tasks while the app is in the background."
+            setShowBadge(false)
+        }
         manager.createNotificationChannel(foregroundChannel)
         manager.createNotificationChannel(completionChannel)
+        manager.createNotificationChannel(liveUpdateChannel)
     }
 
+    /**
+     * Builds the foreground notification for active background sessions.
+     *
+     * On Android 15+ (API 35+) the notification is promoted to a **Live Update**
+     * (a.k.a. focus notification): while the app is in the foreground the
+     * notification stays quiet, and when the app loses focus (goes to the
+     * background) the system surfaces it more prominently — status-bar chip,
+     * lock screen and top of the notification drawer — with the latest task
+     * progress, without the user opening the app.
+     *
+     * On older devices this gracefully degrades to a standard ongoing
+     * foreground notification.
+     */
     fun buildForegroundNotification(
         sessions: List<ChatSession>,
         executionStates: Map<String, SessionExecutionState>,
@@ -71,23 +94,46 @@ class AetherNotificationController(
             PendingIntent.FLAG_UPDATE_CURRENT or pendingIntentMutabilityFlags(),
         )
 
-        return NotificationCompat.Builder(context, ForegroundChannelId)
+        // Live status detail: the most relevant running tool/status for each active session.
+        val liveStatusLines = activeSessions.mapNotNull { session ->
+            val state = executionStates[session.id] ?: return@mapNotNull null
+            val detail = state.pendingStatusDetail.ifBlank { state.pendingStatusText }
+            val tool = state.pendingToolInvocations.firstOrNull { it.isRunning }?.toolName
+            val suffix = when {
+                tool != null -> " · $tool"
+                detail.isNotBlank() -> " · $detail"
+                else -> ""
+            }
+            (session.title.ifBlank { "Untitled chat" } + suffix).takeIf { it.isNotBlank() }
+        }
+
+        val builder = NotificationCompat.Builder(
+            context,
+            if (activeSessions.isNotEmpty()) LiveUpdateChannelId else ForegroundChannelId,
+        )
             .setSmallIcon(R.drawable.ic_notification_small)
             .setContentTitle(title)
             .setContentText(body)
             .setStyle(
                 NotificationCompat.BigTextStyle()
                     .bigText(
-                        activeSessions.joinToString(separator = "\n") { session ->
-                            "- ${session.title.ifBlank { "Untitled chat" }}"
-                        }.ifBlank { body }
+                        liveStatusLines.joinToString("\n").ifBlank { body }
                     )
             )
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .setContentIntent(contentIntent)
-            .build()
+
+        if (activeSessions.isNotEmpty()) {
+            // Live Update / focus notification (Android 15+): request promoted-ongoing
+            // rendering so the task progress is elevated while the app is backgrounded.
+            // AndroidX Core 1.17 maps this to EXTRA_REQUEST_PROMOTED_ONGOING on the
+            // platform notification, which is the supported compat path for Live Updates.
+            builder.setRequestPromotedOngoing(true)
+        }
+
+        return builder.build()
     }
 
     fun notifyCompletion(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 kotlin = "2.4.0"
-coreKtx = "1.13.1"
+coreKtx = "1.17.0"
 lifecycleRuntimeKtx = "2.8.6"
 activityCompose = "1.9.2"
 appcompat = "1.7.0"


### PR DESCRIPTION
## What

Implements Android 15+ **Live Updates** (promoted ongoing foreground notifications) for active tasks, using the AndroidX compat path (`NotificationCompat`).

This addresses the "随时看到进度" (see progress anytime) part of #40 — a promoted ongoing notification shows real-time task progress while the app is in the background, and the ongoing notification itself helps keep the app alive.

Changes:
- `AndroidManifest.xml`: add `POST_PROMOTED_NOTIFICATIONS` permission
- `AetherNotificationController.kt`:
  - New `LiveUpdateChannelId` channel (`aether_live_updates`, `IMPORTANCE_LOW`, no badge)
  - `buildForegroundNotification` uses the Live Update channel + `setRequestPromotedOngoing(true)` while sessions are active, with a live status line (task name + running tool name)
  - Falls back to the normal foreground channel when no task is active
- `AetherForegroundService.kt`: `updateForeground()` refreshes the ongoing notification **in place** (same ID) via `NotificationManagerCompat.notify()` on every status change — this is what makes progress "live"
- `gradle/libs.versions.toml`: bump `androidx.core` (core-ktx) `1.13.1` → `1.17.0` (required for `setRequestPromotedOngoing`)

## Design notes

- Uses `setRequestPromotedOngoing(true)` (maps to `EXTRA_REQUEST_PROMOTED_ONGOING`) — the official compat path for Live Updates. Verified present in androidx.core 1.17.0 (there is **no** `setLiveUpdate` in `NotificationCompat`; that is a platform API 35-only method).
- BigTextStyle + ongoing + `POST_PROMOTED_NOTIFICATIONS` satisfies the promoted-ongoing conditions.

## ⚠️ NOT TESTED — environment cannot compile

This is **an implementation/suggestion only** — I was **unable to compile or run-test** this change. The build host is aarch64 Linux (Alpine/musl), where the Android SDK's official build-tools (`aidl`/`aapt2`) are x86_64-only and cannot execute (tracked in #74).

Please review carefully and run the app on a device (Android 15+) to verify:
1. The notification is promoted while a task is running (app backgrounded)
2. Status text refreshes live
3. Falls back correctly when no task is active

Closes #40
